### PR TITLE
docs: Speculative Messaging on JAM

### DIFF
--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -108,34 +108,13 @@ spec_msg_member: Map<(ParaId, StreamsRoot), MemberEntry {
 
 The settlement check is a single 75 B point read of `spec_msg_member` per `Requires` entry.
 
+When a new root is added, the system drops the oldest tail entry if the queue is full
+(unless a recent duplicate exists), inserts the new root at the head, logs its position,
+and advances the cursor to save the state.
+
 Eviction from the ring is based entirely on position. A root is only pushed out after the parachain adds 64 newer roots.
 If a block sends nothing, nothing is pushed. If a root happens to be repeated, the `MemberEntry` simply shifts to the
 new position while the old queue slot is left behind.
-
-```rust
-fn push(para: ParaId, root: StreamsRoot) {
-  let mut cursor = spec_msg_cursor.get(para);                              // 47 B read
-
-  // Eviction
-  while cursor.head.wrapping_sub(cursor.tail) >= W_MAX {
-    let to_evict = spec_msg_queue.get(&(para, cursor.tail));               // 75 B read
-    spec_msg_queue.remove(&(para, cursor.tail));                           // delete
-
-    let entry = spec_msg_member.get(&(para, to_evict));                    // 75 B read
-    if entry.seq == cursor.tail {
-      // Tail slot is this root's latest occurrence: membership expires.
-      spec_msg_member.remove(&(para, to_evict));                           // delete
-    }
-    // else: root was re-pushed since; the newer slot keeps it alive.
-    cursor.tail = cursor.tail.wrapping_add(1);
-  }
-
-  spec_msg_queue.insert((para, cursor.head), root);                        // 75 B write
-  spec_msg_member.insert((para, root), MemberEntry { seq: cursor.head });  // 75 B write
-  cursor.head = cursor.head.wrapping_add(1);
-  spec_msg_cursor.set(para, cursor);                                       // 47 B write
-}
-```
 
 **Teardown.** When `parachain_set_head` overwrites a live head, or `parachain_clean_up` is
 called, the ring is cleared. The ring is bounded by `W_MAX`, so teardown is bounded too

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -1,51 +1,93 @@
 # Speculative Messaging on JAM
 
- 
 The [Parachain Service](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#3-the-parachain-service) needs a robust messaging system to replace the older HRMP-style payloads, and [Speculative Messaging](https://github.com/paritytech/polkadot-sdk/blob/9d0a0daee40e6e350209aaf4b3e3bdf1fb9a8793/docs/speculative-messaging-design.md) is our primary candidate for JAM.
 
 Here is a breakdown of exactly what needs to change to make Speculative Messaging work smoothly on JAM, ensuring every Polkadot feature has a clear, explicit JAM backport.
 
-## Core Idea
+> For MVP, if a root has already been enacted, B can simply prove the enactment in core.
+> Enactment itself is the commitment that needs no sender host call, no dedicated state, no cell.
 
-> For MVP, if a root has already been enacted by B's anchor, B can simply prove it locally. 
-> The chain never needs to be involved, meaning **no on-chain settlement step is required**.
+The Parachain Service refine context carries the anchor's **accumulation-output-log super-peak**, and the 
+Accumulate output commits the heads that changed per block. Therefore, any root that was enacted
+is provable in-core from any recent anchor without any recency bound on enactment.
 
-B selects a recent JAM block to act as anchor, and includes a Merkle Proof in its PoV. 
-The PoV proof attests that A's cell holds `StreamsRootA`. Validators then verify this in-core.
+```
+anchor super-peak → belt leaf → (PS, heads_root) → Leaf { para_id, head_hash }
+  → header preimage → SPMS digest → StreamsRootA
+```
 
-If the root wasn't enacted at the anchor, it cannot be proven and must be verified on-chain instead.
-Ultimately, the system latency tiers dictate when to use this lightweight in-core proof or
-fallback to the settlement ring.
+In core validation proves the root was enacted, while on chain liveness ensure the history remains valid.
+Every consumer records `(ParaId, Generation)` per source in its digest.
+
+Since old roots prove forever in-core, we need a mechanism to catch rolled back senders (ie the `Generation` field).
+The receiver `B`'s digest records `(ParaId, Generation)` and the Accumulation phase ensures the `Generation` matches
+the latest one from the sender `A`.
+
+The roots not yet enacted enacted (higher specualtion tiers) still need the settlement ring.
+
 
 ## Changes at Accumulation Tier MVP
 
 We are releasing SpecMsg with Accumulation Tier (HRMP parity) from day 0. The changes needed:
 
-1. Digest fields: `spec_msg_provides: Option<StreamsRoot>` on the PS work digest.
+1. Sender header digest: `DigestItem::Consensus(SPMS_ENGINE_ID, enum SpmsDigest)`.
 
-The field is set via `set_provides_root` at most once per `Refine` and needs 33 bytes out of the 48 KiB report budget.
+This payload is the leaf that every enactment proof walk terminates on. To ensure we can change the
+digest layout in the future while having coexisting versions, the `SpmsDigest` is a versioned enum. 
+
+For bundled PoV the Parachain Service commits the head a parachain ended the block with. Therefore, only the
+final inner block's root is ever provable and intermediate roots can never be consumed or settled.
+
+This is the sender's consensus commitment relying only on 41 bytes in its header.
+
+```rust
+/// SCALE-encoded payload of `DigestItem::Consensus(SPMS_ENGINE_ID, ..)`: 41 bytes.
+///
+/// Identical encoding to (layout_version = V0, generation, streams_root). 
+enum SpmsDigest {
+    /// Versioned so we can have coexisting diget formats and coordonate the release schedule.
+    /// Encodes to u8.
+    V0 {
+        /// Sender `generation` same as above.
+        generation: u64,
+        /// The root of the sender's outbound message streams.
+        streams_root: H256
+    },
+}
+```
+
+2. Generations: `ParaInfo.generation: u64` plus a global `next_generation` allocator.
+
+The `ParaInfo` gains a `generation` field that starts at 1, generation 0 acts as a santinel for "unset" and
+ensures we can never pass accidentally the liveness check. 
+
+The `next_generation` is allocated globally per service, and not per-para. This ensures a rollback can't
+re-mint a value the consumer trusted in the past. The value is bumped only when `parachain_set_head`
+overwrote a live head and by a new Coretime `parachain_bump_generation` (this lets Coretime explicitly invalidate
+a para's history).
+
+Decoding optimization: The field is placed ahead of any variable-length fields of the `ParaInfo` so we can keep the
+per request read check cheap.
+
+3. Digest fields: `spec_msg_requires: BoundedVec<(ParaId, Generation), 64>` on the PS work digest
+
+The field is set via `set_requires_root` host call at most once per `Refine`. 
+At 12 bytes each, full fan-in costs is ~770 bytes of the 48 KiB report.
 This must be a digest field and not UpwardMessage, because UMP replays after the head write (so it can't gate enactment).
 
-The same `StreamsRoot` value must be byte-identical to the header digest (`DigestItem::Consensus(SPMS_ENGINE_ID, root)`).
-For bundled PoVs, the call is made once with the final inner block's root. This is valid since MMRs are append-only.
+4. `declare_budget(distinct_sources)` mandatory, once per Refine, before the first spec-msg call
+
+At MVP, the `declare_budget(distinct_sources)` declares upfront how many distinct `(ParaId, Generation)`
+sources it will touch. Then, lets the `Refine` wrapper reserve gas for proof verification before the
+work starts.
 
 
-2. A provides cell: one 32 byte value per parachain keyed at `0x09 ++ para_id`. 
+4. Settlement step 5b `spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>`
 
-The cell is written only by Accumulate on enactment. Since it's 32 bytes it fits directly into a JAM trie leaf,
-so proving it is a pure Merkle path without a preimage, saving ~4KiB of proof per source per block vs a field inside
-`ParaInfo`. The cell's storage footprint is 81 balance units (vs +33 for the in-`ParaInfo` placement). The proof size
-wins over the 48 units.
+This is deferred to Tier 1b (not added until then) and represents the last `W` enacted roots per para keyed at `0x0a ++ para_id`.
 
-Note: Accumulate writes what the digest carries without verifying the MMR extensions. Consumers are protected against
-forged messages, not against a source rolling back its stream.
-
-
-3. Settlement ring: The last `W` enacted roots per para keyed at `0x0a ++ para_id`. This is reserved only and priced from
-day 0, but not written until Tier 1b.
-
-Sized at `W = 48` (derived from `3 elastic cores * (8 slot eviction window + 8 slot pipeline depth)`). This number must be
-fixed before baseline freezes.
+The settlement ring is charged at first write rather then priced from day-0 baseline. An unfunded parachain can consume sources at T0.
+However, it cannot consume them at T1b or above. 
 
 ```rust
 /// Keyed `0x0a ++ SCALE(para_id)`.
@@ -55,21 +97,25 @@ fixed before baseline freezes.
 spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>
 ```
 
-The baseline footprint goes from 69,847 to 71,514 balance units. Every write and delete is balance neutral. All of this has to land before
-the first parachain registers to avoid a live migration.
+Every requires entry's source must exist at the named generation or the candidate is rejected.
+The candidate is rejected silently and the receiver `B` monitors off-chain similar to `parent-head` or 
+`check-code` failures. Otherwise, letting rejected candidates append `AccumulateLogs` would let junk
+candidates push out valuable entries.
 
-> Note: Only the PoV bundle final root reaches the cell and the ring. Intermediate roots stay in headers and can never be settled on chain.
 
-
-Deferred changes:
-- Digest field `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), N>` where `N = 64` consumed changes
-- `set_requires_root` host call to set the `spec_msg_requires`
+> Note: A forced rollback (`ParachainSetHead` from the Coretime chain) isn't applied instantly. Its an upward message,
+replayed at step 7 when the Coretime chain's own package accumulates. Packages accumulate in order within a block,
+so if B's package sits before Coretime's in that order: B's settlement checks A's generation (still current) and B enacts.
+Moments later int the same round, Coretime's replay rolls A back and bumps the generation. B consumed a history that died within the same block.
+Since this represents a tiny window of exposure relying on accumulation ordering and only reachable via Coretime intervention, at MVP
+this is accepted rather than solved (ie draining Coretime's commands before any settlement runs).
 
 ## Speculation Tiers
 
 - **T0 Accumulate / Consume enacted roots (MVP)**: Parity with HRMP
   - 1 or 2 slots from guarantee to accumulate, plus 1 or 2 for anchor lag
-  - no settlement and no requires field, verification happens with merkle proof in PoV and guest code
+  - root verification in-core via the output-log proof; the requires entry carries only
+    `(ParaId, Generation)` and settlement checks generation liveness — the rollback brake
 
 - **T1a Backed / PrefetchHint**: prefetch on backed with zero consensus change.
   - node reads guaranteed but not yet accumulated reports to warm cache
@@ -77,15 +123,14 @@ Deferred changes:
 
 - **T1b Backed / Active**
   - saves 1 or 2 slots
-  - needs a new digest field `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), N>`
-  - settlement ring gets active and settlement step consumes gas (N must be sized for gas limits)
+  - digest v1 widens the requires entry to `(ParaId, Generation, StreamsRoot)`
+  - settlement ring gets active and settlement adds a ring read per entry (sized for gas limits)
   - `A` guaranteed report can die and `B` burns its slot (ie `A` must land first or `B` burns a slot)
-  - Same block `A -> B` is possible since Accumulation happens in order and A's cell write lands before B's settlement runs.
+  - Same block `A -> B` is possible since Accumulation happens in order and A's ring push lands before B's settlement runs.
 
 - **T2 Best Block**
   - saves 2 to 4 slots
   - needs offchain announce protocol, offchain verification and header-digest read path for package boundary roots
-  - Announcing a boundary then rebundling is adversarial resulting in `RequiresUnmet` and burned slot, which needs slashing to solve
   - Recommended: high-fan-in consumption (64 sources like every tier up to here) at the lowest latency; T3 matches
     the latency but caps fan-in at 8. Needs LLv2 ACK/Slashing on JAM
   - Optional `prerequisites` for ordering: B's package declares A's hash. `J = 8` caps prerequisites plus segment
@@ -104,29 +149,34 @@ Deferred changes:
 
 ## Verification
 
-B's PoV carries per consumed source a Merkle proof of the `0x09` cell at the anchor. This is verified in guest code
-(ie `validate_block`) against the anchor's state root which the child PVM reads from `work_package_context()`.
+B's PoV carries per consumed source an `EnactmentProof`:
 
-**State key derivation**
+```rust
+struct EnactmentProof {
+    /// Path from the anchor's super-peak to the enacting block's entry in the
+    /// accumulation-output log.
+    /// 
+    /// TODO-GrayPaper: We need the exact format and hash function.
+    belt_path: Vec<u8>,
 
-The guest computes the cell's 31 byte state key itself. A mismatch results in a silent failure, therefore the construction matters:
+    /// PS's per-block accumulation output for that block.
+    heads_root: Hash,
 
-1. `h = BLAKE2b-256(0xffffffff ++ storage_key)`. The 4 byte domain prefix marks storage values
+    /// keccak path in the changed-heads tree to `Leaf { para_id, head_hash }`.
+    heads_path: Vec<Hash>,
 
-2. Bytes 0-7 of the state key interleave the service id's little-endian bytes with the hash
-(ie `[id0, h0, id1, h1, id2, h2, id3, h3]`), bytes 8-30 are `h[4..27]` taken linearly.
-The interleave covers only the first eight bytes.
+    /// Full header preimage; must hash to `head_hash`.
+    /// The SPMS digest `(generation, streams_root)` is extracted out of it.
+    header: Vec<u8>,
+}
+```
 
-Two inputs the guest must source correctly:
-- The PS service id is read from `work_items_summary()`
-- The storage key is `0x09` followed by the ParaId as a fixed 4 byte little-endian u32, not `Compact`.
+Verification occurs in the Parachain Service Refine wrapper via
+`verify_enacted_root(para_id, proof) -> Option<(StreamsRoot,Generation)>` and not in the guest code.
+Malformed proofs abort Refine with `RefineLog::InvalidEnactmentProof`.
 
-Then the message Lifts verify against the root as on Polkadot. This means that root authenticity is now enforced by
-parachain guest code rather than consensus. A buggy runtime can disable the inbound authentication with no chain evidence.
-The alternative is to introduce the requires field settlement at every tier.
-
-The settlement only replaces the recent root proof, not message verification. Since message verification is done by Lifts
-which verifies against `StreamRoot` by the guest in-core, a buggy guest that skips lift verification is equally broken.
+Then the message Lifts verify against the root as on Polkadot. Settlement (step 5b) replaces only the
+liveness check and never message verification. A guest that skips lift verification is broken either way.
 
 The anchor must be matched against the last 8 JAM blocks at guarantee time. The 6s slots needs roughly 3-4 slots out of the
 8 for state root lag, building, distribution and inclusion. This leaves approximately 4-5 slots to match against. Missing the
@@ -134,12 +184,13 @@ window means the re-anchoring swaps the proof envelope, not the block. Since MMR
 remains local. This needs to take into account AURA authorizer which makes the anchor double as the slot claim, which could 
 shrink the collator window from 8 to its own rotation run.
 
-PoV cost is about 4KiB per touched stream plus ~2KiB per source proof. A case of 128 streams and 64 sources consumes ~640KiB
-out of the ~13MiB budget.
+PoV cost is about 4KiB per touched stream plus, per source, the belt path (log2 of chain length), the heads
+path (<= log2 of core count) and A's full header preimage. For example, 128 streams and 64 sources stays well
+under 1 MiB out of the ~13MiB budget.
 
-> Unknown: The verification gas is unknown. Verification adds ~1700 blake2 calls inside Refine under a 5 * 10^9 ceiling.
-> This needs to be properly measured and the fallback is a blake2b-256 host call for the child PVM.
-
+> Unknown: The verification gas is unknown, and now needs `keccak_256` for the belt and
+> heads paths, BLAKE2b for the lifts. Needs to fit inside the Refine 5 * 10^9.
+> The fallback is hashing host calls for the child PVM, capped by a `MAX_VERIFICATION_HASHES` constant.
 
 ## Transport and Discovery
 
@@ -153,12 +204,11 @@ The actual cost is erasure-coding bandwidth across validators.
 
 **Discovery**
 
-For bootnode discovery, each parachain publishes its bootnodes under a well-known key in the existing KV store.
 The para's runtime maintains its list in the existing KV store (tag `0x08`):
 
 ```rust
-/// Full storage key: 0x08 ++ SCALE((para_id, SPEC_MSG_BOOTNODES_KEY)).
-const SPEC_MSG_BOOTNODES_KEY: &[u8] = b"spec-msg/bootnodes/v1";
+/// Full storage key: 0x08 ++ SCALE((para_id, BOOTNODES_KEY)).
+const BOOTNODES_KEY: &[u8] = b"bootnodes/v1";
 
 struct BootnodeRecord {
     /// bump = publish under .../v2
@@ -174,20 +224,21 @@ struct BootnodeRecord {
 
 Parachain A talks with Parachain B:
 
-1. B's JAM follower watches A's provides cell (`0x09++A`). When it changes to a new `StreamsRootA`, A added new outbound messages.
+1. B's JAM follower watches PS's per-block head commitments (§5.5) for A's leaf. A changed head carries a new
+`StreamsRootA` in A's header digest: A added new outbound messages.
 
-2. B finds A's network via JAM state keys. A published the bootnodes under `0x08 ++ SCALE((A, "spec-msg/bootnodes/v1"))`. 
+2. B finds A's network via JAM state keys. A published the bootnodes under `0x08 ++ SCALE((A, "bootnodes/v1"))`. 
 The record contains up to 8 multiaddresses (managed by parachain itself).
 
 3. B dials bootnodes and discovers A's archive nodes. Messages plus MMR extension proof are fetched from `/spec-msg/exchange` req-resp protocol.
 
-4. Extension is verified against `StreamsRootA` locally and a prefix of the messages is consumed in the next block. The PoV carries the anchor state proof of A's cell.
+4. Extension is verified against `StreamsRootA` locally and a prefix of the messages is consumed in the next block. The PoV carries the enactment proof for A's root.
 
 **Pruning**
 
-A sender may prune payloads below a watermark once the receiver block acknowledges it. Archives serve extension proofs from any block
-boundary within the last 25h, and payloads for every root still in the anchor window at Tier 0, or in the last `W` ring
-entries from Tier 1b (the ring is unwritten before that), or newer.
+A sender may prune payloads below a watermark once the receiver block acknowledges it.
+Archives serve extension proofs from any block boundary within the last 25h. Since any enacted root is provable regardless of age,
+the payload serving horizon is archive policy rather than a protocol window.
 
 ## Forced Recovery
 
@@ -198,46 +249,50 @@ The `parachain_set_head` rolls back enacted history:
     - B delivered before the recovery abandoned that block
     - B's supply is permanently inflated and no layer can undo it.
 
-To mitigate this the `set_head` must delete both cells, which makes recovery observable.
-The Coretime runbook must treat it as "reset all inbound channels". Consumers freeze a channel on a deleted cell
-or a non-extending root (one that does not extend the consumer's inbound frontier), discard prefetched messages
-and resume only on a fresh `open_channel`.
+To mitigate this, generations are bumped on `set_head` calls if and only if it overwrote a live head.
+Every consumer's requires entry names the generation it consumed under, and step 5b
+rejects any candidate still consuming the abandoned history.
+
+The Coretime runbook must treat a bump as "reset all inbound channels". Consumers freeze a channel
+on a generation bump or a non-extending root (one that does not extend the consumer's inbound frontier),
+discard prefetched messages and resume only on a fresh `open_channel`.
 
 The delivered messages stand and the re-delivered overlap after the restart. Before reopening, the recovering chain
 must communicate: what was delivered under the abandoned roots and compensate or it becomes an inflation source
 for the counterparties.
 
-> Note: A stream-generation marker in the leaf preimage could cover recovery (ie `(generation, StreamsRoot)`). 
-The generation id is bumped on every lifetime discontinuity (registration, set_head and re-onboarding).
-Then everything binds to `(paraID, generation)` instead of `paraId`
+> Note: abandoned enactments stay provable forever since the output log is append-only. A dead chain's last messages
+remain drainable at T0 with no state left behind.
 
 ## 4. Execution: End to End
 
 1. **A:** runtime appends outbound messages to per-destination stream MMRs
 
-   - Output: one `StreamsRoot`; the same computation feeds the header digest and `set_provides_root`
-   (guest-asserted identical).
-   
-   - PVF `export()`s payloads and node-side archives them. Wrapper emits
-   `spec_msg_provides: Some(root)` — once per bundle for the final block.
+   - Output: one `StreamsRoot`, committed as `(leaf_version, generation, root)` in A's own header digest.
+   Nothing else — no host call, no work-digest field.
+
+   - PVF `export()`s payloads and node-side archives them.
 
 2. **JAM:** report guaranteed -> available -> accumulated
-    -  step 6 writes `cell[A]` (and from Tier 1b pushes `ring[A]`).
+    - step 6 writes A's head. The output log carries it
+      under every later super-peak (and from Tier 1b, step 6 also pushes `ring[A]`).
 
-3. **B:** node reads `cell[A]` at recent blocks, fetches payloads (p2p exchange preferred for low latency, or DA)
+3. **B:** node follows A's enacted heads, fetches payloads (p2p exchange preferred for low latency, or DA)
 
-   - selects an anchor (best imported block where all consumed roots match, within its
-   authorizer's eligible set)
-   - authors a block consuming stream prefixes, reserving the proof envelope as `proof_size`
-   - in-core (and in the pre-submission self-check) the guest verifies state proofs against `anchor.state_root` and lifts against each source's
-   `StreamsRoot`. Calls into `report_error` with a structured payload on failure. Nothing further on-chain.
+   - selects an anchor (best imported block, within its authorizer's eligible set — any anchor at or after
+   each source's enacting block works)
+   - authors a block consuming stream prefixes, reserving the proof envelope as `proof_size`, and names each
+   source's `(ParaId, Generation)` via `set_requires_root`
+   - in-core the wrapper walks each enactment proof from the anchor's
+   super-peak and the guest verifies lifts against each source's `StreamsRoot`. Failures abort with `RefineLog`.
+   - on-chain, step 5b checks each named generation is still live, then B enacts.
 
 ## 5. Node Stack
 
 **Topology**, in preference order:
 
-(1) **embedded JAM follower with state**: reads the
-cell and generates proofs locally, no third-party liveness in the critical path (MVP
+(1) **embedded JAM follower with state**: follows the output log and PS head commitments,
+generates enactment proofs locally, no third-party liveness in the critical path (MVP
 production target)
 
 (2) **CE 129 `StateRequest`** against a trusted node. Plausible pending
@@ -245,17 +300,17 @@ four confirmations (ask 16): serves non-validators, 64 reads/slot/consumer load,
 anchor − 8 retained, hash-leaf preimages for `BootnodeRecord` (3) RPC / light-follower
 fallback.
 
-**`ProvidesSource`:** reads the cell at imported blocks — **best, not finalized**. Block
-stream, startup tip, sync gate, ring read at a recent hash, pending-provides hint (dormant
-until Tier 1a).
+**`ProvidesSource`:** reads A's enacted heads at imported blocks — **best, not finalized**. Block
+stream, startup tip, sync gate, ring read at a recent hash (dormant until Tier 1b),
+pending-provides hint (dormant until Tier 1a).
 
 ## 6. Trust Model
 
 | Property | Polkadot | JAM |
 |---|---|---|
 | Message authenticity | PVF | PVF — unchanged |
-| Root authenticity | relay consensus check | guest state proof per-parachain enforcement |
-| Provides commitment | UMP signal | digest field - unchanged guarantees |
+| Root authenticity | relay consensus check | wrapper output-log proof in-core and Generation liveness checked by every validator at 5b |
+| Provides commitment | UMP signal | header digest + §5.5 enactment commitment |
 | Stream monotonicity | not enforced | not enforced — self-harm, consumer-visible |
 
 Polkadot capabilities: same-block A -> B deferred to Tier 1b.
@@ -274,39 +329,53 @@ Polkadot capabilities: same-block A -> B deferred to Tier 1b.
 
 ## 10. Open Questions
 
-1. **PVM BLAKE2b throughput + metered gas ceiling** 
-  Verification adds 1.7k blake2 calls in Refine (64 trie paths + lifts). Refine can consume max 5 billion gas.
-  If in guest blake2 doesn't fit, the fallback is a blake2 host call for the child PVM.
+1. **PVM hashing throughput + metered gas ceiling**
+  Verification now spans keccak_256 (belt + heads paths) and blake2 (lifts) in Refine, under a max 5 billion
+  gas ceiling shared with the parachain's own execution. If guest hashing doesn't fit, the fallback is
+  hashing host calls for the child PVM.
 
-2. **`W`** at best-block depth, before the baseline freezes.
-  The ring must be sized for the best block pipeline (announce to enact), not the backed one. Raising W later
-  is another migration. If we increase W to 64 or `Compact(W)` grows a byte the baseline pricing breaks
+2. **`W`** at best-block depth. Tier 1b sizing input.
+
+  The ring is charged at first write, so nothing reads or prices it before Tier 1b. It must still be sized
+  for the best-block pipeline (announce to enact), not the backed one, before the ring turns on.
 
 3. **Silent ready-queue expiry**
   If B declares a prerequisite on A and A never accumulates, B's report is dropped
   after up to an epoch with zero on-chain trace. The node must detect the drop itself and rebuild-and-retry.
 
-4. **ParaId reuse**
-  Coretime doesn't guarantee ParaId uniqueness on JAM. 
-  Fix: a generation number in the stream leaf preimage, bumped on register/set_head/offboard.
+4. **ParaId reuse** Resolved via `Generation` so everything binds to `(ParaId, Generation)`.
 
 5. **Acknowledgement/slashing on JAM**
   Tier 2's security on Polkadot rests on LLv2 ACK slashing. JAM has no equivalent
 
 6. **CE 129**
-  Can a collator without a JAM node ask another node for state? Should be ok for the cell, but breaks for bootnodes.
+  Can a collator without a JAM node ask another node for state? Recent-history reads are fine, but the
+  enactment proof needs output-log peaks and bootnode records need hash-leaf preimages.
 
 7. **Pin the rest** 
   JAM DA retention period is not pinned. For message recovery we'd need a real number. Similar to key derivation.
 
 8. **Settlement gas at worst-case fan-in**
-  For Tier 1B the settlement scans up to N rings per candidate on chain. Running out of gas in Accumulate silently
-  drops later packages.
+  At MVP settlement reads one generation per source (up to 64 per candidate). Then Tier 1b adds a ring read per
+  entry. We don't have JAM gas per read byte estimates. 
+
+  This would also influence how the `Generation` field is read:
+  - reading the full `ParaInfo` (~4 KiB)
+  - partial read with `Generation` field offset inside `ParaInfo`
+  - dedicated entry written on bumps 
+  
+  Running out of gas in Accumulate silently drops later packages, so this design raises PS's required `min_item_gas`.
 
 9. **Authorizer anchor policy**: AURA uses anchor to prove it's our turn.
   The same anchor is also the block all message proofs verify against.
   The current collator cannot freely pick between the 8 recent blocks anymore (only ones in the current rotation). 
   Needs to make the slot claim independent of anchor choice.
+
+10. **Output-log citations (GP)**
+  For the EnactmentProof we need: 
+  - The super-peak in the refine context is validated against recent history at report inclusion.
+  - Accumulation output log have a proof format and hash function
+  - Newest recent history entry carries a usable super-peak or gets it one block late (decides minimum anchor age). 
 
 ## 12. Super Chains
 
@@ -336,7 +405,7 @@ Solving the work package ordering:
   Securing the link between A and B inside the core:
   - in core: We put B's header at a fixed offset. A reads and checks the `R_B` hash from the header digest. 
   - backup: Add a new digest field that carries A's claimed `(sibling, root)` and rely on Accumulate to double check it
-  against `spec_msg_provides` of B.
+  against the SPMS digest in B's new head data.
 
 - **Solution 1: Ordered pair**
   If a single core limit becomes an issue, we can separate them onto two cores but force synchronization by `prerequisites`.

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -230,15 +230,16 @@ is registered new collators and nodes can join by reading the `AddressRecord` un
 
 Parachain A talks with Parachain B:
 
-1. B's JAM follower watches PS's per-block head commitments (§5.5) for A's leaf. A changed head carries a new
-`StreamsRootA` in A's header digest: A added new outbound messages.
+1. `B` node watches enacted heads from `A`.
+  When `A` enacts a new `StreamRootA`, the PS pushes it into `spec_msg_recent_provides[A]`
 
-2. B finds A's network via JAM state keys. A published the bootnodes under `0x08 ++ SCALE((A, "bootnodes/v1"))`. 
-The record contains up to 8 multiaddresses (managed by parachain itself).
+2. B reads A's bootnodes from `0x08 ++ SCALE((A, "bootnodes/v1"))` and connects to an archive node.
 
-3. B dials bootnodes and discovers A's archive nodes. Messages plus MMR extension proof are fetched from `/spec-msg/exchange` req-resp protocol.
+3. B fetches messages with their MMR extension and proofs from `/spec-msg/exchange` req-response.
+  Then it verifies locally the messages against `StreamsRootA`.
 
-4. Extension is verified against `StreamsRootA` locally and a prefix of the messages is consumed in the next block. The PoV carries the enactment proof for A's root.
+4. B consumes a prefix of messages and declares `Requires(A, StreamsRootA)`.
+  During `Accumulate, the PS accepts B only if the root is still in A's ring.
 
 **Pruning**
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -41,67 +41,79 @@ For a bundle, the wrapper carries the last changed root forward even when later 
 Intermediate roots are not settlement entries. A consumer that used an intermediate boundary must lift
 its endpoint to the candidate-boundary root before it can settle.
 
-To ensure post MVP tiers work, we need a sender header digest as well. There can be at most one SPMS digest
-in the header. The PS remains header agnostic and never decodes it:
-
-```rust
-/// SCALE payload is 33 bytes: one enum byte and one hash.
-enum SpmsDigest { V0 { streams_root: H256 }, }
-DigestItem::Consensus(SPMS_ENGINE_ID, SpmsDigest::V0 { streams_root })
-```
-
 ### Producing Receiver `Requires`
 
-Blocks record what they consumed, grouped by source and stream. They do not receive a `StreamsRoot` in
-the messaging inherent and do not emit the `Requires` directly. The record is declared by the collator.
-A false endpoint cannot bind to a valid lift, so lying provides no benefit.
+The validation wrapper verifies the PoV lifts and declares one `(ParaId, StreamsRoot)` per source parachain,
+via `set_requires_root` host call in Refine. PS Refine copies the entries into `spec_msg_requires` and
+ensures all sources are unique and bounded.
 
-By contrast, `Requires` refers to another chain’s committed history and is always derived by PS Refine Wrapper.
-
-After executing a block, the guest reads its `ConsumptionOutbox`, just as it reads `UpwardMessages`,
-and submits the assembled record through one host call:
+If the runtime is buggy or verifications are disabled, PS does not guarantee that the PoV lifts or stitches
+actually result in the provided `Requires`. The system relies on the Accumulation phase to verify that the
+`Requires` are present in the settlement ring.
 
 ```rust
-/// Records the messages consumed by the current block.
-/// May be called at most once per block.
-fn record_consumption(record: ConsumptionRecord) -> ();
+/// Declares the candidate's requires entries, one per consumed source.
+/// One call carries the whole set. May be called at most once per Refine.
+fn set_requires_root(entries: &[(ParaId, StreamsRoot)]) -> ();
 ```
 
-The PoV contains one lift for each touched stream. PS Refine then:
-
-1. Collects block records in bundle order and applies each consumed interval to the receiver MMR state
-3. Stitches consescutive intervals and proves any gaps
-4. Extends each endpoint to a stream root
-5. Derives a `StreamsRoot` via stream tree proof
-6. Checks all streams from a single source derive the same root
-7. Emits `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 64>`
-
-The PoV’s generation is not trusted. Accumulate checks it against current Parachain Service state.
-
-> PS handles only ConsumptionRecord, Interval, and StreamId, which are common messaging types, and
-> never parses a header.
+> PS doesn't enforce the validity of `Requires`. It remains header agnostic (ie, no decoding) and strictly
+> moves opaque 32byte roots.
+>
+> Moving the verification into the PS Refine wrapper doens't change the security guarantees.
+> Instead, PS Refine would simply check the collator provided consumption record against
+> the collator provided PoV lifts.
 
 At 36 bytes each, full fan-in costs ~2.3 KiB of the 48 KiB report.
 
 ## 2. Settlement Ring
 
+> Note: On polkadot missing the settlement check emplies that the lifts are regenerated and candidate
+> is resubmitted. On JAM, the re anchoring changes the package hash and the cotretime slot is burned.
+
+Every `Requires` source must exist and its root must be present in the ring.
+
 The settlement ring represents the last `W` enacted roots per para, keyed at `0x09 ++ para_id`.
 
 ```rust
-/// Keyed `0x09 ++ SCALE(para_id)`. Newest last, slot-ordered by construction.
+/// Keyed by `0x09 ++ SCALE(para_id)`. Appended newest-last, ensuring strict slot-ordering by construction.
 ///
-/// Depth is dynamic: entries older than `D` (depth) slots are evicted, so a para pushing
-/// k roots per slot holds ~ k * D. Ensures elastic scaling adjusts the ring dynamically.
+/// A root is evicted `D` slots after the parachain pushes its *subsequent* root. Until then, 
+/// it remains in the ring buffer. This dynamic retention guarantees that the latest root of an 
+/// idle or on-demand parachain never expires, while allowing elastic scaling to adjust the buffer's size.
+/// 
+/// A block with no new messages pushes nothing.
+/// The `parachain_clean_up` delets the ring as well.
 spec_msg_recent_provides: Map<ParaId, BoundedVec<(StreamsRoot, Slot), W_MAX>>
 
-/// Number of slots between lift retarget and the accumulate phase 
-pub const D: u32 = 20;
-/// A parachain cannot exceed `MAX_CORES` cores. JAM supports max 341.
+/// The upper bound on the number of slots between a lift's retarget (package build) 
+/// and its accumulation.
+///
+/// Represents the sum of:
+///  `C_H` (anchor recency) + Availability timeout (`U`) + consumer pipeline depth +
+///   censorship margin.
+///
+/// Calculation: `D = 8 + 5 + 9 + 8 = 30` (provisional on `U` with 2 margin slots).
+pub const D: u32 = 32;
+/// Assumed ceiling on concurent cores per parachain. This is not enforced. However,
+/// JAM has 341 cores total.
+///
+/// If Coretime allocates more than `MAX_CORES` to a parachain, the ring will hit `W_MAX`
+/// and safely fall back to oldest-first eviction.
 pub const MAX_CORES: u32 = 20;
+
+/// The absolute maximum capacity of the ring buffer for a single parachain.
+///
+/// This size accommodates a parachain pushing one root per core, per slot, for `D` slots.
 pub const W_MAX: u32 = MAX_CORES * D;
 ```
 
-Every `Requires` source must exist and its root must be present in the ring.
+Under stable block production, the size used is roughtly the number of cores the parachain owns.
+Evection doesn't happen after a fixed amount to account for on-demand parachains.
+
+If the buffer contains `[(root A, slot 10)]`, `root A` remains valid indefinitely.
+The eviction only begins when the parachain pushes its next root. When `root B` lands at `slot 50`,
+root A is scheduled for eviction at `slot 50 + D`.
 
 > Note: A forced rollback (`ParachainSetHead` from the Coretime chain) isn't applied instantly. Its an upward message,
 replayed at step 7 when the Coretime chain's own package accumulates. Packages accumulate in order within a block,
@@ -189,10 +201,16 @@ To ensure we are not relying on JAM provided order, PS reorders the blocks's dig
 The solution is to build a depedency graph based on the speculative `Provides` and `Requires`.
 
 If B's `spec_msg_requires` contains `(A, root)` and A's `spec_msg_provides` is `Some(root)`, add an
-edge from `A -> B`. The source `ParaId` selects A and root equality confirms the dependency. Then we
-run topological sort on the edges. Everything unrelated to speculative messaging remains unchanged.
+edge from `A -> B`. The source `ParaId` selects A and root equality confirms the dependency. For a para
+with multiple candidates in the block, also add an implicit edge from each candidate to its successor, such
+that the chain order is a hard constraint of the graph.
+
+The reorder is part of the consensus logic. Therefore, the sort must be terministic. This is done using
+the Khan's algorithm. Between the nodes with in-degree zero, the digest with the smallest index in JAM's original
+core order is picked. Digests not ordered by any edge keep their JAM relative order.
 
 If a cycle is detected, PS continues with the original order from JAM. The ring will reject the candidates naturally.
+Cycles are not expected since that would imply that both sides are consuming from each other at the same time.
 
 3. Parachain Service Buffering
 
@@ -321,8 +339,9 @@ drainability with it.
 
    - verifies fetched messages and their stream proofs against each source's `StreamsRoot`
    - authors a block consuming stream prefixes and records the consumption
-   - in-core the wrapper verifies the PoV-carried lifts, stitches bundle intervals and gap proofs,
-   and synthesizes each source's `(ParaId, StreamsRoot)`. Failures abort with `RefineLog`.
+   - in-core the validation wrapper verifies the PoV-carried lifts, stitches bundle intervals and gap
+   proofs, and synthesizes each source's `(ParaId, StreamsRoot)` via `set_requires_root`. Failures
+   abort with `RefineLog`.
    - on-chain, §5.1 step 6 checks each named root is in its source's ring, then B enacts.
 
 ## 5. Node Stack

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -17,7 +17,7 @@ mechanism handles settlement for all speculation tiers.
 
 We are releasing with the Enacted tier (HRMP parity) from day 0. The changes needed from PS:
 
-## 1. `Provides` and `Requires` fields on the PS work digest
+## 1. `Provides` and `Requires`
 
 The Parachain Service work digest gains two fields:
 
@@ -180,7 +180,7 @@ Moments later in the same round, Coretime's replay rolls A back and clears the r
 Since this represents a tiny window of exposure relying on accumulation ordering and only reachable via Coretime intervention, at MVP
 this is accepted rather than solved (ie draining Coretime's commands before any settlement runs).
 
-## Buffering
+## 3. Buffering
 
 A candidate that passes every check except settlement (ie, `Provides` entry
 is not yet in the ring) is rejected today. The slot is burned and the work must be redone.
@@ -287,80 +287,12 @@ Map<(ParaId, u8 /*position*/, u8 /*fork lane 0/1*/), Held {
 }
 ```
 
-## Speculation Tiers
+### 4. PS Topological Sort
 
-Each tier is named after the sender-side event the consumer trusts:
-**Enacted, then Guaranteed, then Announced, then Imported and Fused**.
-
-> Speculation risk: a race condition between A's ring push and B's requires check against the ring.
-Since both candidates are independent, they have their own travel time through guaranteed, then availability,
-then the accumulate pipeline. And either can stall or get rejected. If B report accumulates first, the
-settlement check reads A's root before the update and B is rejected.
-
-- **Tier 0: Enacted (Safe Baseline MVP)**:
-  - consume enacted roots with HRMP parity. The requires entry carries `(ParaId, StreamsRoot)` and settlement checks the root against the ring
-  - latency: 1 or 2 slots from guarantee to accumulate, plus receiver build and submission time (between 12 and 24+ seconds)
-  - optimization: node-side fetches `StreamsRoot` from guanranteed but not yet accumulated reports
-  - race condition: structurally impossible since `A` is already enacted. The only remaining risk is not matching the `Provides`
-    against the `W` settlement ring size.
-
-- **Tier 1: Guaranteed (A little faster)**
-  - consume guaranteed but not yet enacted roots (acts on optimization from Tier 0)
-  - latency: saves 1 or 2 slots
-  - risk: if settlement fails `B` burns its slot (`A` can die or `A` lands later)
-  - solution for race condition:
-    - 1. Node side timed work package submission
-    - 2. Parachain Service topological sort of dependencies
-    - 3. (Optional): `prerequisites` fields (capped at `J = 8`)
-  - In theory, same block `A -> B` is possible 
-
-- **Tier 2: Announced (High Speed Communication)**
-  - consume best-block roots advertised via `/spec-msg/announce` notification protocol
-  - Announced roots represent fetching hints. Before `Refine`, the package builder must retarget
-  the lifts to the final candidate root. An intermediate announced root must never be writted directly into `Requires`.
-  The `/spec-msg/announce` carries the exact `work_package_hash` and the final `StreamsRoot`.
-
-  - latency: saves 2 or 4 slots
-  - risk: if settlement fails `B` burns its slot (`A` can die or `A` lands later)
-  - relies on llv2 ack / slashing since building block `A` is cheap
-  - solution for race condition:
-    - 1. `prerequisites` fields: work package hash is distributed offchain via `/spec-msg/announce` (capped at `J = 8`)
-    - 2. Parachain Service Buffering 
-
-- **Tier 3: InCore Imported**: delivery via in-core segment import
-  - B's report names A's segment root. JAM parks the report in the ready queue until the segement dependency is resolved
-  - B can't accumulate before A, the ring still guards cases when `A` is rejected
-  - If `A` segments never become available, `B` package isn't refined and the slot isn't burned
-  - Needs to a segment framing to export the speculative messages, which can land at a later time
-  - latency: same as `Tier 2: Announced`
-  - race condition: doesn't apply since `B`'s report has a prerequisite on `A`
-
-- **Tier 4: Fused / SuperChains**
-  - Both candidates are bundled in the same work package, utilizing the same core
-  - Ordering is resolved while creating the work package
-  - Parachain Service must ensure that if multiple candidates are bundled in the same work package
-  the whole group is declined if one of them fails
-  - If candidates are built by different collators, they must negotiate via p2p protocols which one is trusted with the package
-
-**Solutions to reduce the race condition**
-
-1. Node side timed work package submission
-
-The receiver sees A's report in the guarantees extrinsic and reads the work package hash, core and
-`StreamsRoot` from `spec_msg_provides`.
-The payloads are immediately fetched from p2p layer and verified locally. The receiver `B` work package is created but not submitted.
-
-The `B` package is submitted once count assurance bits for A's core are near 2/3. This gives a higher chance for `A`'s report
-to Accumulate within 1-2 slot delay until `B` accumulates.
-
-- If `A` dies before `B` package is submitted, then `B` rebuilds against the latest T0 enacted root without burning the slot
-- If `A` dies after `B` package is submitted, then `B` burns the slot and `B` rebuilds against T0
-- If `B`'s head doesn't advance after its package accumulates, then `B` burns the slot and conservatively rebuilds against T0
-
-2. Parachain Service topological sort of dependencies
-
-Within one JAM block, the PS `Accumulate` processes digests in the provided order from JAM (sorted by core order).
-If sender A and consumer B land in the same block, but B core is first, then B `Requires` check fails.
+Within one JAM block, the PS `Accumulate` processes digests in the order JAM provides (core order for
+newly available reports, plus ready-queue releases). If sender A and consumer B land in the same block
+but B's digest comes first, B's `Requires` check misses the ring and the digest is buffered, costing
+a slot of latency.
 
 To ensure we are not relying on JAM provided order, PS reorders the blocks's digest.
 The solution is to build a depedency graph based on the speculative `Provides` and `Requires`.
@@ -370,38 +302,25 @@ edge from `A -> B`. The source `ParaId` selects A and root equality confirms the
 with multiple candidates in the block, also add an implicit edge from each candidate to its successor, such
 that the chain order is a hard constraint of the graph.
 
-The reorder is part of the consensus logic. Therefore, the sort must be terministic. This is done using
-the Khan's algorithm. Between the nodes with in-degree zero, the digest with the smallest index in JAM's original
-core order is picked. Digests not ordered by any edge keep their JAM relative order.
+The reorder is part of the consensus logic, therefore the sort must be deterministic. This is done using
+Kahn's algorithm. Among the nodes with in-degree zero, the digest with the smallest index in JAM's
+original operand order is picked. This yields the lexicographically smallest topological order:
+deterministic, but not stable. A digest blocked behind a dependency lets later unrelated digests move
+ahead of it. Digests with no incident edges keep their relative order
 
-If a cycle is detected, PS continues with the original order from JAM. The ring will reject the candidates naturally.
-Cycles are not expected since that would imply that both sides are consuming from each other at the same time.
+Cycles need no separate detection pass. When Kahn's zero in-degree set empties with nodes remaining,
+the acyclic part is already emitted in sorted order and the remaining nodes are appended in JAM's original
+order. Only the cyclic digests lose the reorder benefit, while the rest of the block is unaffected.
+The cyclic digests themselves miss settlement, are buffered, deadlock on each other and expire after `K` slots.
 
-3. Parachain Service Buffering
+## 5. Bootnodes Discovery
 
-Instead of rejecting `B`'s candidate when the requires check fails, the PS will buffer the work digest and settles it later
-once A's root is written in the ring. 
-At most one digest is buffered per parachain at any given time to ensure the state can't grow.
-A buffered digest expires after `K = 2` slots (TBD needs real data to size).
+Speculative messaging relies on two mechanisms to fetch messages:
+- request-response `/spec-msg/exchange` protocol (same as v0.5 SpecMsg design)
+- (from Tier 3) PVF exported payloads to DA as framed segments
+  The DA exports are added from `Tier 3` and offers a bootnode agnostic fallback to fetch messages.
 
-The storage digest is charged from B's balance and refunded on settlement or expiry.
-
-Running the retries consume gas:
-- option 1 (depends on gas usage): Retries run in the `always-accumulate` phase, paid by the protocol's gas grant and capped per block.
-  Therefore, can never consume gas registered by the block's own work packages.
-- option 2: B's next package reserves double the gas
-
-## Transport and Discovery
-
-We have 2 delivery paths for messages:
-- Primary offchain req-resp protocol `/spec-msg/exchange` which holds the messages in a node side archive. This outlives the DA window and gives unbounded catch-up.
-- Secondary via PVF exports of payloads to DA as framed segments add from `Tier 3` onward.
-
-The DA exports are added from `Tier 3` and offers a bootnode agnostic fallback to fetch messages.
-64 KiB of messages per block would cost 0.6% of the budget. The actual cost is erasure-coding bandwidth across validators.
-
-**Discovery**
-
+Therefore, the parachain must discover bootnodes before communicating on the p2p layer.
 The para's runtime maintains its list in the existing KV store (tag `0x08`):
 
 ```rust
@@ -438,68 +357,132 @@ is registered new collators and nodes can join by reading the `AddressRecord` un
 
 > Note: KV writes are charged and skipped on **insufficient balance**.
 
-**Flow**
+## Speculation Tiers
 
-Parachain A talks with Parachain B:
+Each tier is named after the sender-side event the consumer trusts:
+**Enacted, then Guaranteed, then Announced, then Imported and Fused**.
 
-1. `B` node watches enacted heads from `A`.
-  When `A` enacts a new `StreamRootA`, the PS pushes it into `spec_msg_recent_provides[A]`
+> Speculation risk: a race condition between A's ring push and B's requires check against the ring.
+Since both candidates are independent, they have their own travel time through guaranteed, then availability,
+then the accumulate pipeline. And either can stall or get rejected. If B report accumulates first, the
+settlement check reads A's root before the update and B is rejected.
 
-2. B reads A's bootnodes from `0x08 ++ SCALE((A, "bootnodes/v1"))` and connects to an archive node.
+- **Tier 0: Enacted (Safe Baseline MVP)**:
+  - consume enacted roots with HRMP parity. The requires entry carries `(ParaId, StreamsRoot)` and settlement checks the root against the ring
+  - latency: 1 or 2 slots from guarantee to accumulate, plus receiver build and submission time (between 12 and 24+ seconds)
+  - optimization: node-side fetches `StreamsRoot` from guanranteed but not yet accumulated reports
+  - race condition: structurally impossible since `A` is already enacted. The only remaining risk is not matching the `Provides`
+    against the `W` settlement ring size.
 
-3. B fetches messages with their MMR extension and proofs from `/spec-msg/exchange` req-response.
-  Then it verifies locally the messages against `StreamsRootA`.
+- **Tier 1: Guaranteed (A little faster)**
+  - consume guaranteed but not yet enacted roots (acts on optimization from Tier 0)
+  - latency: saves 1 or 2 slots
+  - risk: if settlement fails `B` burns its slot (`A` can die or `A` lands later)
+  - solution for race condition:
+    - 1. Node side timed work package submission heuristic
+    - 2. PS topological sort of dependencies
+    - 3. PS Buffering
+    - 4. (Optional): `prerequisites` fields (capped at `J = 8`)
+  - In theory, same block `A -> B` is possible 
 
-4. B consumes a prefix of messages and declares `Requires(A, StreamsRootA)`.
-  During `Accumulate, the PS accepts B only if the root is still in A's ring.
+- **Tier 2: Announced (High Speed Communication)**
+  - consume best-block roots advertised via `/spec-msg/announce` notification protocol
+  - Announced roots represent fetching hints. Before `Refine`, the package builder must retarget
+  the lifts to the final candidate root. An intermediate announced root must never be writted directly into `Requires`.
+  The `/spec-msg/announce` carries the exact `work_package_hash` and the final `StreamsRoot`.
 
-**Pruning**
+  - latency: saves 2 or 4 slots
+  - risk: if settlement fails `B` burns its slot (`A` can die or `A` lands later)
+  - relies on llv2 ack / slashing since building block `A` is cheap
+  - solution for race condition:
+    - 1. `prerequisites` fields: work package hash is distributed offchain via `/spec-msg/announce` (capped at `J = 8`)
+    - 2. PS Buffering 
 
-A sender may prune payloads below a watermark once the receiver block acknowledges it.
-Archives serve extension proofs from any block boundary within the last 25h. The payload serving
-horizon is archive policy, while settlement remains limited to roots still present in the ring.
+- **Tier 3: InCore Imported**: delivery via in-core segment import
+  - B's report names A's segment root. JAM parks the report in the ready queue until the segement dependency is resolved
+  - B can't accumulate before A, the ring still guards cases when `A` is rejected
+  - If `A` segments never become available, `B` package isn't refined and the slot isn't burned
+  - Needs to a segment framing to export the speculative messages, which can land at a later time
+  - latency: same as `Tier 2: Announced`
+  - race condition: doesn't apply since `B`'s report has a prerequisite on `A`
 
-## Forced Recovery
+- **Tier 4: Fused / SuperChains**
+  - Both candidates are bundled in the same work package, utilizing the same core
+  - Ordering is resolved while creating the work package
+  - Parachain Service must ensure that if multiple candidates are bundled in the same work package
+  the whole group is declined if one of them fails
+  - If candidates are built by different collators, they must negotiate via p2p protocols which one is trusted with the package
 
-The `parachain_set_head` rolls back enacted history:
-- each consumer channel desyncs since A's next root won't extend the old one.
-- deliveries from rolled-back blocks are irreversible
-    - A burned tokens and emitted "mint X" and enacted
-    - B delivered before the recovery abandoned that block
-    - B's supply is permanently inflated and no layer can undo it.
+**Node side timed work package submission**
 
-To mitigate this, a `set_head` call that overwrites a live head clears the para's settlement ring.
-Every consumer's requires entry names the root it consumed, and the requires check (§5.1 step 6)
-rejects any candidate still consuming the abandoned history — its roots are no longer in the ring.
-Everything beyond that brake is Coretime's responsibility: forced recovery is a runbook procedure,
-and Coretime ensures an abandoned history is never silently resumed.
+The receiver sees A's report in the guarantees extrinsic and reads the work package hash and core from the
+report and the `StreamsRoot` from `spec_msg_provides`.
+The payloads are immediately fetched from p2p layer and verified locally. The receiver `B` work package is created but not submitted.
 
-The Coretime runbook must treat a forced `set_head` as "reset all inbound channels". Consumers freeze a
-channel on a ring clear or a non-extending root (one that does not extend the consumer's inbound
-frontier), discard prefetched messages and resume only on a fresh `open_channel`.
+The `B` package is submitted once count assurance bits for A's core are near 2/3. This gives a higher chance for `A`'s report
+to Accumulate within 1-2 slot delay until `B` accumulates.
 
-The delivered messages stand and the re-delivered overlap after the restart. Before reopening, the recovering chain
-must communicate: what was delivered under the abandoned roots and compensate or it becomes an inflation source
-for the counterparties.
+- If `A` dies before `B` package is submitted, then `B` rebuilds against the latest T0 enacted root without burning the slot
+- If `A` dies after `B` package is submited, `B` remains buffered. `B`'s buffered digest can never settle
+  and just expires at `buffered_at + K`. Then, `B` forks immediately at T0 tier and rebuilds on the second buffered lane.
+- If `B`'s head doesn't advance after its package accumulates, then `B` burns the slot and conservatively rebuilds against T0
 
-> Note: a dormant chain's ring persists. The dead chain's last messages remain drainable at the
-Enacted tier as long as its ring stands. A `parachain_clean_up` removes the ring and ends
-drainability with it.
+## Bootnodes Discovery
+
+Speculative messaging relies on two mechanisms to fetch messages:
+- request-response `/spec-msg/exchange` protocol (same as v0.5 SpecMsg design)
+- (from Tier 3) PVF exported payloads to DA as framed segments
+  The DA exports are added from `Tier 3` and offers a bootnode agnostic fallback to fetch messages.
+
+Therefore, the parachain must discover bootnodes before communicating on the p2p layer.
+The para's runtime maintains its list in the existing KV store (tag `0x08`):
+
+```rust
+/// Full storage key: 0x08 ++ SCALE((para_id, BOOTNODES_KEY)).
+const BOOTNODES_KEY: &[u8] = b"bootnodes/v1";
+
+/// Ephemeral record of a parachain's active bootnodes.
+struct AddressRecord {
+    /// The timeslot after which this entire record is invalid and should be dropped.
+    expires_at: Timeslot,
+    /// Up to 4 active bootnodes.
+    bootnodes: BoundedVec<Bootnode, 4>,
+}
+
+struct Bootnode {
+    /// The network address (must NOT contain a peer ID).
+    addr: Multiaddr,
+    /// The public key from which the node's peer ID is derived.
+    node_key: Ed25519Public,
+    /// A monotonic sequence number to prevent replay attacks.
+    seq: u64,
+    /// Proof of possession. The node must sign:
+    /// `("bootnode-pop-v1", jam_genesis_hash, para_id from the key, Bootnode::seq, Bootnode::addr)`
+    /// This proves the node owner consents to being a bootnode for this specific broadcast.
+    sig: Ed25519Signature,
+}
+```
+
+The parachain service doesn't verify the `AddressRecord` fields. The admission of a new
+address into the book is part of the Parachain runtime logic.
+
+Initially the chain operator will setup the network via an explicit `--bootnodes` CLI flag. Once the chain
+is registered new collators and nodes can join by reading the `AddressRecord` under the storage key.
+
+> Note: KV writes are charged and skipped on **insufficient balance**.
 
 ## 4. Execution: End to End
 
 1. **A:** runtime appends outbound messages to per-destination stream MMRs
-
-   - Output: one `StreamsRoot`, committed as `SpmsDigest::V0 { streams_root }` in A's own header digest.
-   No host call is needed. PS Refine decodes the header and writes the root to `spec_msg_provides`.
-
-   - PVF `export()`s payloads and node-side archives them.
+   - Output: The runtime writes `StreamsRoot` into the pallet storage (and header digest). During the PS
+   Refine, after PVF execution the `validate_block` wrapper reads the root from the pallet and reports
+   it via `set_provides_root`. PS never decodes the header.
+   - (Tier InCore) PVF `export()`s payloads and node-side archives them.
 
 2. **JAM:** report guaranteed -> available -> accumulated
     - step 6 writes A's head and pushes its `spec_msg_provides` root into `ring[A]`.
 
 3. **B:** node follows A's enacted heads, fetches payloads (p2p exchange preferred for low latency, or DA)
-
    - verifies fetched messages and their stream proofs against each source's `StreamsRoot`
    - authors a block consuming stream prefixes and records the consumption
    - in-core the validation wrapper verifies the PoV-carried lifts, stitches bundle intervals and gap
@@ -507,43 +490,29 @@ drainability with it.
    abort with `RefineLog`.
    - on-chain, §5.1 step 6 checks each named root is in its source's ring, then B enacts.
 
-## 5. Node Stack
+## Forced Recovery
 
-**Topology**, in preference order:
+`parachain_set_head` rolls back A's enacted history causing two side effects:
+- Every consumer channel desyncs. The sender's next root will not extend the roots consumers are already following.
+- Deliveries from rolled-back blocks cannot be undone. If A enacts "burn, then mint X on B" and B delivers it before
+  the rollback, B's supply is permanently inflated. No layer can retract a delivered message.
 
-(1) **embedded JAM follower with state**: follows PS head commitments and settlement rings,
-with no third-party liveness in the critical path (MVP production target)
+A `parachain_set_head` that overwrites a live chan head will clears A's settlement ring.
+If any candidate attempts to consume the abandoned history, it will reference a root that is no longer in the ring.
+Because it cannot settle, it is buffered and simply expires after `K` slots.
 
-(2) **CE 129 `StateRequest`** against a trusted node. Plausible pending four confirmations
-(ask 16): serves non-validators, with capacity and retention requirements still to be confirmed.
+Everything beyond this is handled via off-chain policy. Forced recovery is a runbook procedure, and Coretime ensures
+an abandoned history is never silently resumed. The runbook treats a forced `set_head` as a trigger to reset all inbound channels:
+1. Consumers freeze a channel upon seeing a ring clear or a non-extending root.
+2. Prefetched messages are discarded.
+3. The channel resumes only through an explicit reopen
 
-(3) **RPC / light-follower fallback**.
+Before reopening the channel, the sender must reconcile what was delivered under the abandoned roots and compensate its counterparties.
+Without this, every recovery turns the sender into an inflation source. When operation resumes, re-sent messages may overlap with ones
+already delivered, but previously delivered messages always stand.
 
-**`ProvidesSource`:** reads A's enacted heads at imported blocks — **best, not finalized**. Block
-stream, startup tip, sync gate, ring read at a recent hash,
-pending-provides hint (dormant until Prefetch mode).
-
-## 10. Open Questions
-
-1. **W at the Enacted pipeline**
-  The ring is live and read by settlement from day 0, so `W` must be fixed before launch.
-  It must exceed the maximum number of distinct roots a sender can enact between the receiver
-  selected a root and the accumulation phase (including elastic scaling). A sender using k cores
-  may advance the ring up to k times per JAM block.
-
-  Since we read the read for settlement, we can read up to `(num digests) * (64 candidates) * W * 32 B`.
-  With hundreads of digets per block, that could reach 10+ MiB of reads.
-  Then the Accumulation step might run out of gas and silently drop later packages.
-
-2. **Silent ready-queue expiry**
-  If B declares a prerequisite on A and A never accumulates, B's report is dropped
-  after up to an epoch with zero on-chain trace. The node must detect the drop itself and rebuild-and-retry.
-
-3. **ParaId reuse**
-  The ring is dropped at clean-up and recreated empty on re-registration.
-
-4. **Acknowledgement/slashing on JAM**
-  The Announced tier's security on Polkadot rests on LLv2 ACK slashing. JAM has no equivalent
+> Note: A dormant chain's ring persists, meaning its final messages remain drainable at the Enacted tier.
+The `parachain_clean_up` routine removes the ring, permanently ending drainability.
 
 ## 12. Super Chains
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -134,6 +134,8 @@ const BOOTNODES_KEY: &[u8] = b"bootnodes/v1";
 /// Ephemeral record of a parachain's active bootnodes.
 struct AddressRecord {
     /// The timeslot after which this entire record is invalid and should be dropped.
+    ///
+    /// `expires_at` is the runtime's liveness statement for the whole record.
     expires_at: Timeslot,
     /// Up to 4 active bootnodes.
     bootnodes: BoundedVec<Bootnode, 4>,
@@ -155,6 +157,16 @@ struct Bootnode {
 
 PS does not verify the `AddressRecord` fields and admission into the record is parachain runtime
 logic. KV writes are charged and skipped on insufficient balance.
+
+The parachain runtime handles the rest of the bootnode lifecycle.
+The pallet maintains the active bootnode set in its own storage, indexing entries by `node_key`.
+Modifying this set requires administrative privileges, the `add_bootnode` and `remove_bootnode` extrinsics
+are restricted to `AdminOrigin` (which defaults to governance). The proof of posession ensures the
+node's consent to be listed.
+
+During admission, the runtime verifies the `sig` and requires the `seq` to exceed the stored `seq` for that `node_key`.
+When a change is accepted, the pallet reencodes the full record and emits a new one via `kv_set`.
+The record is refreshed before `expires_at` to ensure it remains valid.
 
 During the initial chain setup, the operator provides an explicit `--bootnodes` CLI flag.
 Once that record is published to the chain, any new collators and nodes can easily join by reading it.
@@ -204,9 +216,10 @@ lift assembly) carries over unchanged.
 **Umbrella 3 — Bootnode discovery**
 
 - [Task 06] Runtime publishing: Maintain the `AddressRecord` under KV tag `0x08`
-  (`bootnodes/v1`): admission logic, `seq` bumping, expiry.
-- [Task 07] Node side: Proof-of-possession signing and verification, record reading to
-  discover a source para's peers, `--bootnodes` CLI flag for initial setup, feeding the peer
+  (`bootnodes/v1`): admission logic, `seq` bumping, expiry. The whole record is republished on every change
+  and is refreshed before `expires_at`.
+- [Task 07] Node side: Proof-of-possession signing and verification, reader side checks (PoP, expiry, highest
+  `seq`), record reading to discover a source para's peers, `--bootnodes` CLI flag for initial setup, feeding the peer
   registry.
 
 **Umbrella 4 — Node adaptations**

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -73,47 +73,74 @@ At 36 bytes each, full fan-in costs ~2.3 KiB of the 48 KiB report.
 
 Every `Requires` source must exist and its root must be present in the ring.
 
+The settlement ring holds the last `W_MAX = 64` enacted roots per para.
+
 The settlement ring represents the last `W` enacted roots per para, keyed at `0x09 ++ para_id`.
 
 ```rust
-/// Keyed by `0x09 ++ SCALE(para_id)`. Appended newest-last, ensuring strict slot-ordering by construction.
+/// Tracks order and capacity.
 ///
-/// A root is evicted `D` slots after the parachain pushes its *subsequent* root. Until then, 
-/// it remains in the ring buffer. This dynamic retention guarantees that the latest root of an 
-/// idle or on-demand parachain never expires, while allowing elastic scaling to adjust the buffer's size.
+/// Key: `0x09 ++ para_id`
+///
+/// Billed: 47 B (never read during settlement)
+spec_msg_cursor: Map<ParaId, Cursor {
+  /// Sequence of next push (wrapping).
+  head: u32,
+  /// Sequence of the oldest entry.
+  tail: u32,
+}>
+
+/// Maps the sequence to the streams root.
 /// 
-/// A block with no new messages pushes nothing.
-/// The `parachain_clean_up` delets the ring as well.
-spec_msg_recent_provides: Map<ParaId, BoundedVec<(StreamsRoot, Slot), W_MAX>>
+/// Key: `0x0b ++ para_id ++ seq`
+///
+/// Billed: 75 B (Read on capacity eviction and lifecycle).
+spec_msg_queue: Map<(ParaId, u32), StreamsRoot>
 
-/// The upper bound on the number of slots between a lift's retarget (package build) 
-/// and its accumulation.
+/// Ensures the `StreamsRoot` is present in the ring.
 ///
-/// Represents the sum of:
-///  `C_H` (anchor recency) + Availability timeout (`U`) + consumer pipeline depth +
-///   censorship margin.
+/// Key: `0x0a ++ para_id ++ root`
 ///
-/// Calculation: `D = 8 + 5 + 9 + 8 = 30` (provisional on `U` with 2 margin slots).
-pub const D: u32 = 32;
-/// Assumed ceiling on concurent cores per parachain. This is not enforced. However,
-/// JAM has 341 cores total.
-///
-/// If Coretime allocates more than `MAX_CORES` to a parachain, the ring will hit `W_MAX`
-/// and safely fall back to oldest-first eviction.
-pub const MAX_CORES: u32 = 20;
-
-/// The absolute maximum capacity of the ring buffer for a single parachain.
-///
-/// This size accommodates a parachain pushing one root per core, per slot, for `D` slots.
-pub const W_MAX: u32 = MAX_CORES * D;
+/// Billed: 75 B (Read only by settlement check).
+spec_msg_member: Map<(ParaId, StreamsRoot), MemberEntry {
+  /// The queue position ensuring duplicate guard and consumer hints about
+  /// live chain sets.
+  seq: u32
+}>
 ```
 
-Under stable block production, the size used is roughtly the number of cores the parachain owns.
-Evection doesn't happen after a fixed amount to account for on-demand parachains.
+The ring capacity is per parachain and strictly position based. A root is only evicted after the parachain pushes `W_MAX (64)`
+new roots. Because eviction requires new messages, a block with no new messages pushes nothing.
+After 64 roots, the ring reaches a maximum capacity of 9747 B.
 
-If the buffer contains `[(root A, slot 10)]`, `root A` remains valid indefinitely.
-The eviction only begins when the parachain pushes its next root. When `root B` lands at `slot 50`,
-root A is scheduled for eviction at `slot 50 + D`.
+**Push Logic**
+
+If a root is repeated, the `MemberEntry` is updated with the new position, leaving the old entry in the
+`spec_msg_queue`.
+
+```rust
+fn push(para: ParaId, root: StreamsRoot) {
+  let mut cursor = spec_msg_cursor.get(para);
+
+  // Eviction
+  while cursor.head.wrapping_sub(cursor.tail) >= W_MAX {
+    let to_evict = spec_msg_queue.get(&(para, cursor.tail));  // 75 B read
+    let entry = spec_msg_member.get(&(para, to_evict));       // 75 B read
+    if entry.seq == cursor.tail {
+      // Head submitted again more recently.
+      spec_msg_member.remove(&(para, to_evict));
+    }
+    spec_msg_queue.remove(&(para, cursor.tail));              // 75 B write
+    spec_msg_member.insert((para, root), MemberEntry { seq: cursor.head}); // 75 B write 
+    cursor.head = cursor.head.wrapping_add(1);
+    spec_msg_cursor.set(para, c); // 47 B write
+  }
+}
+
+When the `parachain_set_head` overwrites a live head, or if `parachain_clean_up` is called, the ring is cleared.
+The teardown process reads the cursor and walks backwards from `head - 1` down to `tail`.
+If the process runs out of gas, the revert leaves the cursor intact. This acts as a sentinel to detect incomplete
+teardown.
 
 > Note: A forced rollback (`ParachainSetHead` from the Coretime chain) isn't applied instantly. Its an upward message,
 replayed at step 7 when the Coretime chain's own package accumulates. Packages accumulate in order within a block,

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -123,8 +123,10 @@ settlement check reads A's root before the update and B is rejected.
 - **Tier 3: InCore Imported**: delivery via in-core segment import
   - B's report names A's segment root. JAM parks the report in the ready queue until the segement dependency is resolved
   - B can't accumulate before A, the ring still guards cases when `A` is rejected
+  - If `A` segments never become available, `B` package isn't refined and the slot isn't burned
   - Needs to a segment framing to export the speculative messages, which can land at a later time
-  - latency: same as Tier 2: Announced
+  - latency: same as `Tier 2: Announced`
+  - race condition: doesn't apply since `B`'s report has a prerequisite on `A`
 
 - **Tier 4: Fused / SuperChains**
   - Both candidates are bundled in the same work package, utilizing the same core
@@ -176,11 +178,10 @@ The storage digest is charged from B's balance and refunded on settlement or exp
 
 We have 2 delivery paths for messages:
 - Primary offchain req-resp protocol `/spec-msg/exchange` which holds the messages in a node side archive. This outlives the DA window and gives unbounded catch-up.
-- Secondary via PVF exports of payloads to DA as framed segments.
+- Secondary via PVF exports of payloads to DA as framed segments add from `Tier 3` onward.
 
-Since segments cannot be exported retroactively, the DA exports are used since day 0. This offers a bootnode agnostic fallback to fetch messages and
-the Imported tier relies on the segments. 64 KiB of messages per block would cost 0.6% of the budget.
-The actual cost is erasure-coding bandwidth across validators.
+The DA exports are added from `Tier 3` and offers a bootnode agnostic fallback to fetch messages.
+64 KiB of messages per block would cost 0.6% of the budget. The actual cost is erasure-coding bandwidth across validators.
 
 **Discovery**
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -312,58 +312,31 @@ pending-provides hint (dormant until Prefetch mode).
 
 ## 10. Open Questions
 
-2. **`W`** at best-block depth
-
+1. **`W`** at best-block depth
   The ring is live and read by settlement from day 0, so `W` must be fixed before launch.
   It must be sized for the Announced (best-block) pipeline — announce to enact — not the Guaranteed one, since
   the higher tiers reuse the same ring without a consensus change.
 
-3. **Silent ready-queue expiry**
+  Since we read the read for settlement, we can read up to 64 candidates * `W` * 32 bytes each.
+  Then if `W` is 128, the Accumulation step might run out of gas and silently drop later packages.
+
+2. **Silent ready-queue expiry**
   If B declares a prerequisite on A and A never accumulates, B's report is dropped
   after up to an epoch with zero on-chain trace. The node must detect the drop itself and rebuild-and-retry.
 
-4. **ParaId reuse** The ring is dropped at clean-up and recreated empty on re-registration, so a
-  reused id's stale roots are never consumable. That a reused `ParaId` is a *different chain* is a
-  Coretime guarantee (registration policy), not a consensus check — consumers must treat channel
-  identity as managed by Coretime.
+3. **ParaId reuse**
+  The ring is dropped at clean-up and recreated empty on re-registration.
 
-5. **Acknowledgement/slashing on JAM**
+4. **Acknowledgement/slashing on JAM**
   The Announced tier's security on Polkadot rests on LLv2 ACK slashing. JAM has no equivalent
-
-6. **CE 129**
-  Can a collator without a JAM node ask another node for state? Recent-history reads are fine, but the
-  enactment proof needs output-log peaks and bootnode records need hash-leaf preimages.
-
-7. **Pin the rest** 
-  JAM DA retention period is not pinned. For message recovery we'd need a real number. Similar to key derivation.
-
-8. **Settlement gas at worst-case fan-in**
-  At MVP settlement reads one ring per source (up to 64 per candidate, `W` × 32 bytes each), and
-  the head write adds a ring push. We don't have JAM gas per read byte estimates. 
-  
-  Running out of gas in Accumulate silently drops later packages, so this design raises PS's required `min_item_gas`.
-
-9. **Authorizer anchor policy**: AURA uses anchor to prove it's our turn.
-  The same anchor is also the block all message proofs verify against.
-  The current collator cannot freely pick between the 8 recent blocks anymore (only ones in the current rotation). 
-  Needs to make the slot claim independent of anchor choice.
-
-10. **Output-log citations (GP)**
-  For the EnactmentProof we need: 
-  - The super-peak in the refine context is validated against recent history at report inclusion.
-  - Accumulation output log have a proof format and hash function
-  - Newest recent history entry carries a usable super-peak or gets it one block late (decides minimum anchor age). 
 
 ## 12. Super Chains
 
 A superchain pair consumes each other's speculative output every step (A consumes B in this block and B consumes an earlier A block).
 Because of how it's designed, this loop works safely on JAM.
 
-Solving the work package ordering:
-
 > Why not mutual JAM `prerequisites`?
 > An honest author cannot even encode the cycle. `P_A` would need `hash(P_B)` which needs `hash(P_A)`
-> 
 > Colluding guarantors *can* put mutually-referencing reports on chain, but those park in the ready queue,
 > never release, and are silently discarded at the epoch boundary.
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -13,97 +13,95 @@ Therefore, we introduce on-chain settlement from the MVP. The sender `StreamsRoo
 the consumer `Requires` field (ie `(ParaId, StreamsRoot)`) is checked against the ring. The same
 mechanism handles settlement for all speculation tiers.
 
-The settlement ring is used for monitoring rollbacks. When a `parachain_set_head` overwrites a live
-head, it will also clear out the parachain's ring. Abandoned roots are no longer consumed and recovery
-(resetting the channels, compensate for delivered messages) is a `Coretime` runbook procedure, not
-a consensus mechanims Speculative Messaging or PS provides.
-
 ## Changes at MVP Tier
 
-We are releasing with the Enacted tier (HRMP parity) from day 0. The changes needed:
+We are releasing with the Enacted tier (HRMP parity) from day 0. The changes needed from PS:
 
-1. Sender header digest: `DigestItem::Consensus(SPMS_ENGINE_ID, enum SpmsDigest)`.
+## 1. `Provides` and `Requires` fields on the PS work digest
 
-For bundled PoV, only the candidate-boundary StreamsRoot is added to the settlement ring.
-Messages from inner blocks can still be consumed, but the receiver PoV must lift the stream state
-to the final root. Inner blocks cannot be settled directly.
-
-To ensure we can change the digest layout in the future while having coexisting versions, the `SpmsDigest` is a versioned enum.
-
-PS Refine decodes the candidate-boundary header. It rejects more than one SPMS digest or an
-unsupported version (PS support for the new version must be released before parachains use it).
+The Parachain Service work digest gains two fields:
 
 ```rust
-/// SCALE-encoded payload of `DigestItem::Consensus(SPMS_ENGINE_ID, ..)`
-/// Aproximately 39 bytes in its header.
-enum SpmsDigest {
-    /// Encodes to u8.
-    V0 {
-        /// The root of the sender's outbound message streams.
-        streams_root: H256
-    },
+struct ParachainWorkDigestOk {
+  /// ...
+  spec_msg_provides: Option<StreamsRoot>,
+  spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 64>,
 }
 ```
 
-2. `Provides` and `Requires` fields on the PS work digest
+### Producing Sender `Provides`
 
-```rust
-spec_msg_provides: Option<StreamsRoot>,
-spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 64>,
-```
+The sender runtime maintains its stream MMR frontiers and the commitment tree. After all inner blocks in
+a candidate have executed, the validation wrapper reports the final changed root through
+`set_provides_root`. It may do so once per `Refine`.
 
-The PS Refine wrapper derives `spec_msg_provides` from the candidate-boundary `SpmsDigest`.
-`Accumulate` consumes this field and never decodes the parachain header.
-
-The `spec_msg_requires` must not be chosen by the parachain block. Otherwise it can state any consumption.
-The block records what is consumed, then the PS Refine wrapper verifies the PoV carried lift,
-stitches bundle intervals and gap proofs, and synthesizes a `(ParaId, StreamsRoot)` per source.
-
-The PS Refine writes both fields after decoding the header and verifying the consumption records and PoV lifts.
-
-To ensure canonical encoding and uniqueness, the PS Refine wrapper produces unique entries sorted by `ParaId`.
-The Refine phase rejects malformed input.
-
-`spec_msg_provides` lets `Accumulate` update the sender's settlement ring and construct the dependency graph.
 It costs 33 bytes when present.
 
-`spec_msg_requires` is a digest field, because UMP signals are replayed after the head write (so it can't gate enactment).
+For a bundle, the wrapper carries the last changed root forward even when later inner blocks send nothing.
+Intermediate roots are not settlement entries. A consumer that used an intermediate boundary must lift
+its endpoint to the candidate-boundary root before it can settle.
+
+To ensure post MVP tiers work, we need a sender header digest as well. There can be at most one SPMS digest
+in the header. The PS remains header agnostic and never decodes it:
+
+```rust
+/// SCALE payload is 33 bytes: one enum byte and one hash.
+enum SpmsDigest { V0 { streams_root: H256 }, }
+DigestItem::Consensus(SPMS_ENGINE_ID, SpmsDigest::V0 { streams_root })
+```
+
+### Producing Receiver `Requires`
+
+Blocks record what they consumed, grouped by source and stream. They do not receive a `StreamsRoot` in
+the messaging inherent and do not emit the `Requires` directly. The record is declared by the collator.
+A false endpoint cannot bind to a valid lift, so lying provides no benefit.
+
+By contrast, `Requires` refers to another chain’s committed history and is always derived by PS Refine Wrapper.
+
+After executing a block, the guest reads its `ConsumptionOutbox`, just as it reads `UpwardMessages`,
+and submits the assembled record through one host call:
+
+```rust
+/// Records the messages consumed by the current block.
+/// May be called at most once per block.
+fn record_consumption(record: ConsumptionRecord) -> ();
+```
+
+The PoV contains one lift for each touched stream. PS Refine then:
+
+1. Collects block records in bundle order and applies each consumed interval to the receiver MMR state
+3. Stitches consescutive intervals and proves any gaps
+4. Extends each endpoint to a stream root
+5. Derives a `StreamsRoot` via stream tree proof
+6. Checks all streams from a single source derive the same root
+7. Emits `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 64>`
+
+The PoV’s generation is not trusted. Accumulate checks it against current Parachain Service state.
+
+> PS handles only ConsumptionRecord, Interval, and StreamId, which are common messaging types, and
+> never parses a header.
+
 At 36 bytes each, full fan-in costs ~2.3 KiB of the 48 KiB report.
 
-3. Settlement: ring `spec_msg_recent_provides` and `Requires` check
+## 2. Settlement Ring
 
 The settlement ring represents the last `W` enacted roots per para, keyed at `0x09 ++ para_id`.
 
-The check and ring are delivered by the MVP implementation. When a work digest enacts, its
-`spec_msg_provides` root is pushed into the sender's ring only if present and different from the
-newest entry. The ring evicts the oldest entry beyond `W`.
-
-> `W` is no longer extra pipeline headroom. It is the window against which `Requires` must match.
-If a package `Requires` is not in the ring, that slot is lost. On polkadot, a stale candidate
-can retry for free. On JAM, each retry costs another slot.
-
-A forced `parachain_set_head` that overwrites a live head will also clear the ring.
-For a parachain with an existing head, a byte-identical `parachain_set_head` is a no op.
-While `is_deregistering`, the parachain cannot submit work but remains a valid Requires source.
-Its ring is removed only when clean-up completes and ParaInfo is dropped.
-
 ```rust
-/// Keyed `0x09 ++ SCALE(para_id)`.
-/// 
-/// Step 6 pushes `spec_msg_provides` at the head write iff present and != newest entry, evicts oldest.
-/// Cleared when a forced `parachain_set_head` overwrites a live head.
-/// Read by settlement, never proved.
-spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>
+/// Keyed `0x09 ++ SCALE(para_id)`. Newest last, slot-ordered by construction.
+///
+/// Depth is dynamic: entries older than `D` (depth) slots are evicted, so a para pushing
+/// k roots per slot holds ~ k * D. Ensures elastic scaling adjusts the ring dynamically.
+spec_msg_recent_provides: Map<ParaId, BoundedVec<(StreamsRoot, Slot), W_MAX>>
+
+/// Number of slots between lift retarget and the accumulate phase 
+pub const D: u32 = 20;
+/// A parachain cannot exceed `MAX_CORES` cores. JAM supports max 341.
+pub const MAX_CORES: u32 = 20;
+pub const W_MAX: u32 = MAX_CORES * D;
 ```
 
-The ring reads are charged to the parachain. Every `Requires` source must exist and its root must be present in the ring.
-On the first missing entry, PS rejects the candidate and emits one bounded `AccumulateLog::RequiresUnmet { source, root }`
-allowing the receiver to identify a settlement miss and rebuild. Otherwise, the block builder cannot distinguish
-between a missing root from gas exhaustion, or queue expiry or parent-head failure. Logging only the first
-miss is bounded and the candidate has already passed authorization checks.
-
-Before processing a digest, PS charges its worst-case ring-read cost against that item’s declared accumulation gas. The
-`W` should be reasonable bounded and the scan reads the newest entries first stopping on the first match.
+Every `Requires` source must exist and its root must be present in the ring.
 
 > Note: A forced rollback (`ParachainSetHead` from the Coretime chain) isn't applied instantly. Its an upward message,
 replayed at step 7 when the Coretime chain's own package accumulates. Packages accumulate in order within a block,

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -25,27 +25,38 @@ The Parachain Service work digest gains two fields:
 struct ParachainWorkDigestOk {
   /// ...
   spec_msg_provides: Option<StreamsRoot>,
-  spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 64>,
+  spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 32>,
 }
 ```
 
 ### Producing Sender `Provides`
 
-The sender runtime maintains its stream MMR frontiers and the commitment tree. After all inner blocks in
-a candidate have executed, the validation wrapper reports the final changed root through
-`set_provides_root`. It may do so once per `Refine`.
+The sender runtime maintains its stream MMR frontiers and the commitment tree.
+When producing a block, the runtime writes the `Provides` root directly into pallet storage and the header digest.
+
+During the PS Refine phase, guarantors execute the PVF. Once execution completes, the `validate_block` wrapper
+reads the root from pallet storage and reports it via the `set_provides_root` host call.
+
+For bundled PoVs, the wrapper carries the last produced `Provides` forward to the call, even when later inner blocks send nothing.
+Intermediate roots are not settlement entries. A consumer that used an intermediate boundary must lift its endpoint
+to the candidate boundary root before it can settle.
+
+During Accumulate, the candidate's head is written for enactment. If a `Provides` root is present, it is pushed into
+the sender's settlement ring (`ring[A]`).
 
 It costs 33 bytes when present.
 
-For a bundle, the wrapper carries the last changed root forward even when later inner blocks send nothing.
-Intermediate roots are not settlement entries. A consumer that used an intermediate boundary must lift
-its endpoint to the candidate-boundary root before it can settle.
-
 ### Producing Receiver `Requires`
 
-The validation wrapper verifies the PoV lifts and declares one `(ParaId, StreamsRoot)` per source parachain,
-via `set_requires_root` host call in Refine. PS Refine copies the entries into `spec_msg_requires` and
-ensures all sources are unique and bounded.
+The collator node picks the target `Provides` depending on the speculation tier and
+consumes a prefix of messages. The runtime consumes the messages and records a `ConsumptionRecord`.
+The collator then generate the Lift proofs and packages them into the PoV.
+
+In the PS Refine, the guarantoors execute the PVF. Then, the `validate_block` wrapper reads the
+`ConsumptionRecords` from the pallet storage with the Lifts from the PoV. It stitches consumption gaps
+to produce a final `Requires` that is set via `set_requires_root`.
+
+PS Refine then enforces that all source parachains in the `Requires` set are unique and bounded to 32 entries.
 
 If the runtime is buggy or verifications are disabled, PS does not guarantee that the PoV lifts or stitches
 actually result in the provided `Requires`. The system relies on the Accumulation phase to verify that the
@@ -57,14 +68,16 @@ actually result in the provided `Requires`. The system relies on the Accumulatio
 fn set_requires_root(entries: &[(ParaId, StreamsRoot)]) -> ();
 ```
 
+During Accumulate, the system checks the settlement ring. It verifies that each declared `(ParaId, StreamsRoot)` is actually
+present in the source's ring (`ring[ParaID]`). The block is enacted only if this check passes.
+
 > PS doesn't enforce the validity of `Requires`. It remains header agnostic (ie, no decoding) and strictly
 > moves opaque 32byte roots.
->
 > Moving the verification into the PS Refine wrapper doens't change the security guarantees.
 > Instead, PS Refine would simply check the collator provided consumption record against
 > the collator provided PoV lifts.
 
-At 36 bytes each, full fan-in costs ~2.3 KiB of the 48 KiB report.
+At 36 bytes each, full fan-in (32 entries) costs ~1.1 KiB of the 48 KiB report.
 
 ## 2. Settlement Ring
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -267,7 +267,7 @@ must communicate: what was delivered under the abandoned roots and compensate or
 for the counterparties.
 
 > Note: abandoned enactments stay provable forever since the output log is append-only, and a dormant
-chain's ring persists — so a dead chain's last messages remain drainable at the Enacted tier as long
+chain's ring persists. The dead chain's last messages remain drainable at the Enacted tier as long
 as its ring stands. A `parachain_clean_up` removes the ring and ends drainability with it.
 
 ## 4. Execution: End to End
@@ -310,40 +310,12 @@ fallback.
 stream, startup tip, sync gate, ring read at a recent hash,
 pending-provides hint (dormant until Prefetch mode).
 
-## 6. Trust Model
-
-| Property | Polkadot | JAM |
-|---|---|---|
-| Message authenticity | PVF | PVF — unchanged |
-| Root authenticity | relay consensus check | wrapper output-log proof in-core; ring root check at §5.1 step 6 |
-| Provides commitment | UMP signal | header digest + §5.5 enactment commitment |
-| Stream monotonicity | not enforced | not enforced — self-harm, consumer-visible |
-
-Polkadot capabilities: same-block A -> B deferred to the Guaranteed tier.
-
-> **Why not JAM's `prerequisites`?**
->
-> (1) Wrong granularity: a package hash orders, a StreamsRoot is content. The root must be carried regardless.
->
-> (2) Report is not enactment: steps 3/5 can decline after accumulation, so compare-and-reject survives anyway.
-> 
-> (3) `J = 8` is too small and shared with the Imported tier's segment lookups; fan-in targets 64.
->
-> (4) The 8-block reporting gate makes it strictly worse than proving enacted state.
->
-> **Right solution at the Imported tier: segment roots are content-addressed.**
-
 ## 10. Open Questions
 
-1. **PVM hashing throughput + metered gas ceiling**
-  Verification now spans keccak_256 (belt + heads paths) and blake2 (lifts) in Refine, under a max 5 billion
-  gas ceiling shared with the parachain's own execution. If guest hashing doesn't fit, the fallback is
-  hashing host calls for the child PVM.
+2. **`W`** at best-block depth
 
-2. **`W`** at best-block depth. Now a day-0 sizing input.
-
-  The ring is live and read by settlement from day 0, so `W` must be fixed before launch. It must be
-  sized for the Announced (best-block) pipeline — announce to enact — not the Guaranteed one, since
+  The ring is live and read by settlement from day 0, so `W` must be fixed before launch.
+  It must be sized for the Announced (best-block) pipeline — announce to enact — not the Guaranteed one, since
   the higher tiers reuse the same ring without a consensus change.
 
 3. **Silent ready-queue expiry**

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -42,7 +42,7 @@ Intermediate roots are not settlement entries. A consumer that used an intermedi
 to the candidate boundary root before it can settle.
 
 During Accumulate, the candidate's head is written for enactment. If a `Provides` root is present, it is pushed into
-the sender's settlement ring (`ring[A]`).
+the sender's settlement ring (`ring[A]`). Therefore, a root enters the ring only for a candidate that enacted.
 
 It costs 33 bytes when present.
 
@@ -52,9 +52,12 @@ The collator node picks the target `Provides` depending on the speculation tier 
 consumes a prefix of messages. The runtime consumes the messages and records a `ConsumptionRecord`.
 The collator then generate the Lift proofs and packages them into the PoV.
 
-In the PS Refine, the guarantoors execute the PVF. Then, the `validate_block` wrapper reads the
+In the PS Refine, the guarantors execute the PVF. Then, the `validate_block` wrapper reads the
 `ConsumptionRecords` from the pallet storage with the Lifts from the PoV. It stitches consumption gaps
 to produce a final `Requires` that is set via `set_requires_root`.
+
+For a bundle, the wrapper unions the per-block consumption records into one entry per source,
+keeping the latest root per source.
 
 PS Refine then enforces that all source parachains in the `Requires` set are unique and bounded to 32 entries.
 
@@ -73,11 +76,17 @@ present in the source's ring (`ring[ParaID]`). The block is enacted only if this
 
 > PS doesn't enforce the validity of `Requires`. It remains header agnostic (ie, no decoding) and strictly
 > moves opaque 32byte roots.
-> Moving the verification into the PS Refine wrapper doens't change the security guarantees.
+> Moving the verification into the PS Refine wrapper doesn't change the security guarantees.
 > Instead, PS Refine would simply check the collator provided consumption record against
 > the collator provided PoV lifts.
 
 At 36 bytes each, full fan-in (32 entries) costs ~1.1 KiB of the 48 KiB report.
+
+```rust
+/// Declares the candidate's provides root
+/// May be called at most once per Refine. Omitted when the candidate sent nothing.
+fn set_provides_root(root: StreamsRoot) -> ();
+```
 
 ## 2. Settlement Ring
 
@@ -401,8 +410,6 @@ const BOOTNODES_KEY: &[u8] = b"bootnodes/v1";
 
 /// Ephemeral record of a parachain's active bootnodes.
 struct AddressRecord {
-    /// The para ID this record belongs to.
-    para_id: u32,
     /// The timeslot after which this entire record is invalid and should be dropped.
     expires_at: Timeslot,
     /// Up to 4 active bootnodes.
@@ -417,7 +424,7 @@ struct Bootnode {
     /// A monotonic sequence number to prevent replay attacks.
     seq: u64,
     /// Proof of possession. The node must sign:
-    /// `("bootnode-pop-v1", jam_genesis_hash, AddressRecord::para_id, Bootnode::seq, Bootnode::addr)`
+    /// `("bootnode-pop-v1", jam_genesis_hash, para_id from the key, Bootnode::seq, Bootnode::addr)`
     /// This proves the node owner consents to being a bootnode for this specific broadcast.
     sig: Ed25519Signature,
 }

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -13,6 +13,19 @@ Therefore, we introduce on-chain settlement from the MVP. The sender `StreamsRoo
 the consumer `Requires` field (ie `(ParaId, StreamsRoot)`) is checked against the ring. The same
 mechanism handles settlement for all speculation tiers.
 
+## Contents
+
+1. [`Provides` and `Requires`](#1-provides-and-requires)
+2. [Settlement Ring](#2-settlement-ring)
+3. [Buffering](#3-buffering)
+4. [PS Topological Sort](#4-ps-topological-sort)
+5. [Bootnodes Discovery via Para-Owned KV](#5-bootnodes-discovery-via-para-owned-kv)
+6. [Speculation Tiers](#6-speculation-tiers)
+7. [Execution: End to End](#7-execution-end-to-end)
+8. [Forced Recovery](#8-forced-recovery)
+9. [Super Chains](#9-super-chains)
+- [Appendix](#appendix)
+
 ## Changes at MVP Tier
 
 We are releasing with the Enacted tier (HRMP parity) from day 0. The changes needed from PS:
@@ -287,7 +300,7 @@ Map<(ParaId, u8 /*position*/, u8 /*fork lane 0/1*/), Held {
 }
 ```
 
-### 4. PS Topological Sort
+## 4. PS Topological Sort
 
 Within one JAM block, the PS `Accumulate` processes digests in the order JAM provides (core order for
 newly available reports, plus ready-queue releases). If sender A and consumer B land in the same block
@@ -313,7 +326,7 @@ the acyclic part is already emitted in sorted order and the remaining nodes are 
 order. Only the cyclic digests lose the reorder benefit, while the rest of the block is unaffected.
 The cyclic digests themselves miss settlement, are buffered, deadlock on each other and expire after `K` slots.
 
-## 5. Bootnodes Discovery
+## 5. Bootnodes Discovery via Para-Owned KV
 
 Speculative messaging relies on two mechanisms to fetch messages:
 - request-response `/spec-msg/exchange` protocol (same as v0.5 SpecMsg design)
@@ -357,7 +370,7 @@ is registered new collators and nodes can join by reading the `AddressRecord` un
 
 > Note: KV writes are charged and skipped on **insufficient balance**.
 
-## Speculation Tiers
+## 6. Speculation Tiers
 
 Each tier is named after the sender-side event the consumer trusts:
 **Enacted, then Guaranteed, then Announced, then Imported and Fused**.
@@ -390,7 +403,6 @@ settlement check reads A's root before the update and B is rejected.
   - Announced roots represent fetching hints. Before `Refine`, the package builder must retarget
   the lifts to the final candidate root. An intermediate announced root must never be writted directly into `Requires`.
   The `/spec-msg/announce` carries the exact `work_package_hash` and the final `StreamsRoot`.
-
   - latency: saves 2 or 4 slots
   - risk: if settlement fails `B` burns its slot (`A` can die or `A` lands later)
   - relies on llv2 ack / slashing since building block `A` is cheap
@@ -398,12 +410,14 @@ settlement check reads A's root before the update and B is rejected.
     - 1. `prerequisites` fields: work package hash is distributed offchain via `/spec-msg/announce` (capped at `J = 8`)
     - 2. PS Buffering 
 
-- **Tier 3: InCore Imported**: delivery via in-core segment import
+**Tiers with lower implementation priority**
+
+- **Tier 3: InCore Imported/DA Layer**: delivery via in-core segment import
   - B's report names A's segment root. JAM parks the report in the ready queue until the segement dependency is resolved
   - B can't accumulate before A, the ring still guards cases when `A` is rejected
   - If `A` segments never become available, `B` package isn't refined and the slot isn't burned
   - Needs to a segment framing to export the speculative messages, which can land at a later time
-  - latency: same as `Tier 2: Announced`
+  - latency: **Same as T0/T1**
   - race condition: doesn't apply since `B`'s report has a prerequisite on `A`
 
 - **Tier 4: Fused / SuperChains**
@@ -427,51 +441,7 @@ to Accumulate within 1-2 slot delay until `B` accumulates.
   and just expires at `buffered_at + K`. Then, `B` forks immediately at T0 tier and rebuilds on the second buffered lane.
 - If `B`'s head doesn't advance after its package accumulates, then `B` burns the slot and conservatively rebuilds against T0
 
-## Bootnodes Discovery
-
-Speculative messaging relies on two mechanisms to fetch messages:
-- request-response `/spec-msg/exchange` protocol (same as v0.5 SpecMsg design)
-- (from Tier 3) PVF exported payloads to DA as framed segments
-  The DA exports are added from `Tier 3` and offers a bootnode agnostic fallback to fetch messages.
-
-Therefore, the parachain must discover bootnodes before communicating on the p2p layer.
-The para's runtime maintains its list in the existing KV store (tag `0x08`):
-
-```rust
-/// Full storage key: 0x08 ++ SCALE((para_id, BOOTNODES_KEY)).
-const BOOTNODES_KEY: &[u8] = b"bootnodes/v1";
-
-/// Ephemeral record of a parachain's active bootnodes.
-struct AddressRecord {
-    /// The timeslot after which this entire record is invalid and should be dropped.
-    expires_at: Timeslot,
-    /// Up to 4 active bootnodes.
-    bootnodes: BoundedVec<Bootnode, 4>,
-}
-
-struct Bootnode {
-    /// The network address (must NOT contain a peer ID).
-    addr: Multiaddr,
-    /// The public key from which the node's peer ID is derived.
-    node_key: Ed25519Public,
-    /// A monotonic sequence number to prevent replay attacks.
-    seq: u64,
-    /// Proof of possession. The node must sign:
-    /// `("bootnode-pop-v1", jam_genesis_hash, para_id from the key, Bootnode::seq, Bootnode::addr)`
-    /// This proves the node owner consents to being a bootnode for this specific broadcast.
-    sig: Ed25519Signature,
-}
-```
-
-The parachain service doesn't verify the `AddressRecord` fields. The admission of a new
-address into the book is part of the Parachain runtime logic.
-
-Initially the chain operator will setup the network via an explicit `--bootnodes` CLI flag. Once the chain
-is registered new collators and nodes can join by reading the `AddressRecord` under the storage key.
-
-> Note: KV writes are charged and skipped on **insufficient balance**.
-
-## 4. Execution: End to End
+## 7. Execution: End to End
 
 1. **A:** runtime appends outbound messages to per-destination stream MMRs
    - Output: The runtime writes `StreamsRoot` into the pallet storage (and header digest). During the PS
@@ -488,9 +458,9 @@ is registered new collators and nodes can join by reading the `AddressRecord` un
    - in-core the validation wrapper verifies the PoV-carried lifts, stitches bundle intervals and gap
    proofs, and synthesizes each source's `(ParaId, StreamsRoot)` via `set_requires_root`. Failures
    abort with `RefineLog`.
-   - on-chain, §5.1 step 6 checks each named root is in its source's ring, then B enacts.
+   - on-chain, the settlement check (§2) verifies each named root is in its source's ring, then B enacts.
 
-## Forced Recovery
+## 8. Forced Recovery
 
 `parachain_set_head` rolls back A's enacted history causing two side effects:
 - Every consumer channel desyncs. The sender's next root will not extend the roots consumers are already following.
@@ -514,7 +484,7 @@ already delivered, but previously delivered messages always stand.
 > Note: A dormant chain's ring persists, meaning its final messages remain drainable at the Enacted tier.
 The `parachain_clean_up` routine removes the ring, permanently ending drainability.
 
-## 12. Super Chains
+## 9. Super Chains
 
 A superchain pair consumes each other's speculative output every step (A consumes B in this block and B consumes an earlier A block).
 Because of how it's designed, this loop works safely on JAM.

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -122,6 +122,113 @@ Moments later in the same round, Coretime's replay rolls A back and clears the r
 Since this represents a tiny window of exposure relying on accumulation ordering and only reachable via Coretime intervention, at MVP
 this is accepted rather than solved (ie draining Coretime's commands before any settlement runs).
 
+## Buffering
+
+A candidate that passes every check except settlement (ie, `Provides` entry
+is not yet in the ring) is rejected today. The slot is burned and the work must be redone.
+Buffering stores the work digest and applies it later, once the root arrives.
+
+The first buffered entry must target the parachain's enacted head and all other
+entries must form a valid chain. We allow a maximum of two fork lanes. If a collator wants to abandon a branch,
+they can offer a competing one immediately without waiting for the first to expire.
+These forks can either process different messages (different `Requires`) or build a different head from the
+exact same messages (same `Requires`).
+
+Whichever fork settles first (evaluated FIFO by lane) invalidates the other. Forks are designed to be an edge case,
+not the standard operating model.
+
+Before any work items are applied, the buffered chain is walked from the front. The root parent
+must still be the enacted head and the front entry must not be expired (either failure will drop the chain).
+Then each entry's Accumulate is rerun against the current state. An entry that settles is applied and removed.
+An entry still missing its root stays buffered and ends the walk. Any other failure drops the chain.
+
+A chain front entry that is older than `buffered_at + K slots` is dropped when the next work item
+is accumulated. Buffered bytes are billed to the para's balance and are capped at `MAX_BUFFERED_BYTES` per parachain.
+An entry is never replaced or refreshed.
+
+Buffering never holds up the canonical chain. An entry is never replaced or refreshed.
+
+**Gas Model**
+
+The buffer walk happens before the new work item that brought the gas, but it can only spend the leftover
+gas that the item doesn't need for itself. Collators need to pad the work item to cover this walk.
+Because the buffer is in consensus state, they can read the exact cost at their anchor and fund it perfectly.
+If the gas only covers part of the buffer, the walk settles what i can and pauses. Nothing is destroyed,
+and the remainder waits for the next item.
+After the walk, the new item is processed. It is either applied directly if it sits on the enacted head, or
+buffered as a chain extension if it builds on the tip.
+Ultimately, an under gassed item will never cause the buffer to be dropped, and the buffer walk will never starve the item that paid for it.
+
+Parachains can also push the buffer forward without submitting a new candidate. A settlement-only package carries
+no work digest and no parent head. Because it has no parent head, it can't fail the parent-head check,
+guaranteeing it reaches the walk phase and delivers gas.
+
+Like normal work items, they are autorizer-gated produced by active collators . They require a core slot, refine gas and the
+walk's declared gas (which is cheeper than rebuilding).
+
+```rust
+/// Refine output handled to Accumulate.
+enum RefineOutput {
+    /// Full work digest.
+    Candidate(ParachainWorkDigest),
+    /// Settlement only to run the buffer walk with this item's declared gas.
+    SettleOnly,
+}
+
+/// Depth of buffered chain (per fork lane).
+pub const MAX_CHAIN_SIZE: u8 = 16;
+/// Maximum number of fork lanes.
+///
+/// This supports two forks which are common on polkadot
+/// with elastic scaling where 1 chain doesn't get finalized
+/// and a collator starts building a different chain:
+///
+/// ```ignore
+///  A -> B -> C -> D
+///    -> B' -> D'
+/// ```
+///
+/// However it doesn't support more compeating forks.
+pub const MAX_FORKS: u8 = 2;
+/// Total buffered amount per para (includes everything buffering related).
+pub const MAX_BUFFERED_BYTES: u32 = TBD;
+
+Map<ParaId, Cursor {
+    /// The start positon.
+    start: u8,
+    /// Number of elements buffered.
+    /// Supports two lane of forks.
+    len: [u8; 2],
+    /// Position where the chain diverge.
+    /// The position is <= `Cursor::len[0]`. The lane 1
+    /// exists only in `[fork_at, len[1])`
+    fork_at: u8,
+    /// Head hash of last entry. Ensures next buffered
+    /// digest forms a valid chain.
+    tip_head: [H256; 2],
+    /// If the last work digest carries a code upgrade signal
+    /// this must be last entry in the buffered chain. Every buffered
+    /// entry carry a code_hash gainst which it was validated. Any
+    /// successor would be validated against the old code.
+    tip_terminal: [bool; 2],
+    /// The parent the first entry(s), neede for making sure the buffered
+    /// element is still based on the canonical chain.
+    root_parent: H256,
+}
+Map<(ParaId, u8 /*position*/, u8 /*fork lane 0/1*/), Held {
+    /// The stored work digest.
+    digest: ParachainWorkDigest,
+    /// Validation code this entry was refined against.
+    code_hash: H256,
+    /// The head of the entry. Ensures a valid link is formed.
+    head_hash: H256,
+    /// The slot in which this buffered entry was added.
+    /// The full fork dies when the front entry expires
+    /// at `buffered_at + K`.
+    buffered_at: TimeSlot,
+}
+```
+
 ## Speculation Tiers
 
 Each tier is named after the sender-side event the consumer trusts:

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -17,16 +17,16 @@ anchor super-peak → belt leaf → (PS, heads_root) → Leaf { para_id, head_ha
 ```
 
 In-core validation proves the root was enacted; on-chain settlement then re-checks every consumed root
-against the sender's ring of recently enacted roots and checks the history is still live. Every consumer
-records `(ParaId, Generation, StreamsRoot)` per source in its digest.
-
-Since old roots prove forever in-core, we need a mechanism to catch rolled back senders (ie the `Generation` field).
-The receiver `B`'s digest records the generation and the Accumulation phase ensures it matches
-the latest one from the sender `A`.
+against the sender's ring of recently enacted roots. Every consumer records `(ParaId, StreamsRoot)` per
+source in its digest.
 
 The settlement ring is live from day 0: every enacted SPMS root is pushed into the sender's ring at the
 head write, and settlement requires each consumed root to be present in its source's ring. The same
 machinery settles the higher speculation tiers later with no further consensus change.
+
+The ring is also the rollback brake: a forced `parachain_set_head` that overwrites a live head clears
+the para's ring, so abandoned roots stop being consumable immediately. Recovery beyond that (resetting
+channels, compensating deliveries) is a Coretime runbook procedure, not a consensus mechanism.
 
 
 ## Changes at Accumulation Tier MVP
@@ -41,62 +41,47 @@ digest layout in the future while having coexisting versions, the `SpmsDigest` i
 For bundled PoV the Parachain Service commits the head a parachain ended the block with. Therefore, only the
 final inner block's root is ever provable and intermediate roots can never be consumed or settled.
 
-This is the sender's consensus commitment relying only on 41 bytes in its header.
+This is the sender's consensus commitment relying only on 33 bytes in its header.
 
 ```rust
-/// SCALE-encoded payload of `DigestItem::Consensus(SPMS_ENGINE_ID, ..)`: 41 bytes.
-///
-/// Identical encoding to (layout_version = V0, generation, streams_root). 
+/// SCALE-encoded payload of `DigestItem::Consensus(SPMS_ENGINE_ID, ..)`: 33 bytes.
 enum SpmsDigest {
     /// Versioned so we can have coexisting diget formats and coordonate the release schedule.
     /// Encodes to u8.
     V0 {
-        /// Sender `generation` same as above.
-        generation: u64,
         /// The root of the sender's outbound message streams.
         streams_root: H256
     },
 }
 ```
 
-2. Generations: `ParaInfo.generation: u64` plus a global `next_generation` allocator.
-
-The `ParaInfo` gains a `generation` field that starts at 1, generation 0 acts as a santinel for "unset" and
-ensures we can never pass accidentally the liveness check. 
-
-The `next_generation` is allocated globally per service, and not per-para. This ensures a rollback can't
-re-mint a value the consumer trusted in the past. The value is bumped only when `parachain_set_head`
-overwrote a live head and by a new Coretime `parachain_bump_generation` (this lets Coretime explicitly invalidate
-a para's history).
-
-Decoding optimization: The field is placed ahead of any variable-length fields of the `ParaInfo` so we can keep the
-per request read check cheap.
-
-3. Digest fields: `spec_msg_requires: BoundedVec<(ParaId, Generation, StreamsRoot), 64>` on the PS work digest
+2. Digest fields: `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 64>` on the PS work digest
 
 The field is set via `set_requires_root` host call at most once per `Refine`. Each entry names the
 consumed root itself, so settlement can re-check it against the source's ring from day 0.
-At 44 bytes each, full fan-in costs ~2.8 KiB of the 48 KiB report.
+At 36 bytes each, full fan-in costs ~2.3 KiB of the 48 KiB report.
 This must be a digest field and not UpwardMessage, because UMP replays after the head write (so it can't gate enactment).
 
-4. `declare_budget(distinct_sources)` mandatory, once per Refine, before the first spec-msg call
+3. `declare_budget(distinct_sources)` mandatory, once per Refine, before the first spec-msg call
 
-At MVP, the `declare_budget(distinct_sources)` declares upfront how many distinct `(ParaId, Generation)`
+At MVP, the `declare_budget(distinct_sources)` declares upfront how many distinct `ParaId`
 sources it will touch. Then, lets the `Refine` wrapper reserve gas for proof verification before the
 work starts.
 
 
-5. Settlement: the requires check runs at §5.1 step 6, against the day-0 ring `spec_msg_recent_provides`
+4. Settlement: the requires check runs at §5.1 step 6, against the day-0 ring `spec_msg_recent_provides`
 
-The settlement ring represents the last `W` enacted roots per para, keyed at `0x0a ++ para_id` (`0x09`
-holds `next_generation`). It is live from day 0: at the head write (§5.1 step 6), if the enacted head
-carries an SPMS digest, its root is pushed into the sender's ring — iff different from the newest entry,
-evicting the oldest beyond `W`. Paras that never emit SPMS digests never write.
+The settlement ring represents the last `W` enacted roots per para, keyed at `0x09 ++ para_id`. It is
+live from day 0: at the head write (§5.1 step 6), if the enacted head carries an SPMS digest, its root
+is pushed into the sender's ring — iff different from the newest entry, evicting the oldest beyond `W`.
+Paras that never emit SPMS digests never write. A forced `parachain_set_head` that overwrites a live
+head clears the ring instead.
 
 ```rust
-/// Keyed `0x0a ++ SCALE(para_id)`.
+/// Keyed `0x09 ++ SCALE(para_id)`.
 /// 
 /// §5.1 step 6 pushes the enacted root at the head write iff != newest entry, evicts oldest.
+/// Cleared when a forced `parachain_set_head` overwrites a live head.
 /// Read by settlement, never proved.
 spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>
 ```
@@ -107,8 +92,7 @@ cannot act as a source at any tier until funded.
 
 The requires check itself sits at the head of §5.1 step 6 — the last gate, so passing implies enacting,
 and before the head write, so a rejected `B` never publishes a root of its own. Every requires entry's
-source must exist at the named generation, **and** the named root must be present in the source's ring,
-or the candidate is rejected.
+source must exist and the named root must be present in the source's ring, or the candidate is rejected.
 The candidate is rejected silently and the receiver `B` monitors off-chain similar to `parent-head` or 
 `check-code` failures. Otherwise, letting rejected candidates append `AccumulateLogs` would let junk
 candidates push out valuable entries.
@@ -121,8 +105,8 @@ against a recent root.
 
 > Note: A forced rollback (`ParachainSetHead` from the Coretime chain) isn't applied instantly. Its an upward message,
 replayed at step 7 when the Coretime chain's own package accumulates. Packages accumulate in order within a block,
-so if B's package sits before Coretime's in that order: B's settlement checks A's generation (still current) and B enacts.
-Moments later int the same round, Coretime's replay rolls A back and bumps the generation. B consumed a history that died within the same block.
+so if B's package sits before Coretime's in that order: B's settlement finds A's root still in the ring and B enacts.
+Moments later in the same round, Coretime's replay rolls A back and clears the ring. B consumed a history that died within the same block.
 Since this represents a tiny window of exposure relying on accumulation ordering and only reachable via Coretime intervention, at MVP
 this is accepted rather than solved (ie draining Coretime's commands before any settlement runs).
 
@@ -131,8 +115,8 @@ this is accepted rather than solved (ie draining Coretime's commands before any 
 - **T0 Accumulate / Consume enacted roots (MVP)**: Parity with HRMP
   - 1 or 2 slots from guarantee to accumulate, plus 1 or 2 for anchor lag
   - root verification in-core via the output-log proof; the requires entry carries
-    `(ParaId, Generation, StreamsRoot)` and settlement checks generation liveness — the rollback
-    brake — plus the root against the source's ring
+    `(ParaId, StreamsRoot)` and settlement checks the root against the source's ring — the
+    rollback brake, since a forced rollback clears the ring
 
 - **T1a Backed / PrefetchHint**: prefetch on backed with zero consensus change.
   - node reads guaranteed but not yet accumulated reports to warm cache
@@ -184,17 +168,17 @@ struct EnactmentProof {
     heads_path: Vec<Hash>,
 
     /// Full header preimage; must hash to `head_hash`.
-    /// The SPMS digest `(generation, streams_root)` is extracted out of it.
+    /// The SPMS digest `streams_root` is extracted out of it.
     header: Vec<u8>,
 }
 ```
 
 Verification occurs in the Parachain Service Refine wrapper via
-`verify_enacted_root(para_id, proof) -> Option<(StreamsRoot,Generation)>` and not in the guest code.
+`verify_enacted_root(para_id, proof) -> Option<StreamsRoot>` and not in the guest code.
 Malformed proofs abort Refine with `RefineLog::InvalidEnactmentProof`.
 
 Then the message Lifts verify against the root as on Polkadot. Settlement (§5.1 step 6) re-checks the
-named root against the source's ring and checks generation liveness — never message verification, which
+named root against the source's ring — never message verification, which
 is inherently guest-side. A guest that skips lift verification is broken either way.
 
 The anchor must be matched against the last 8 JAM blocks at guarantee time. The 6s slots needs roughly 3-4 slots out of the
@@ -268,26 +252,29 @@ The `parachain_set_head` rolls back enacted history:
     - B delivered before the recovery abandoned that block
     - B's supply is permanently inflated and no layer can undo it.
 
-To mitigate this, generations are bumped on `set_head` calls if and only if it overwrote a live head.
-Every consumer's requires entry names the generation it consumed under, and the requires check (§5.1
-step 6) rejects any candidate still consuming the abandoned history.
+To mitigate this, a `set_head` call that overwrites a live head clears the para's settlement ring.
+Every consumer's requires entry names the root it consumed, and the requires check (§5.1 step 6)
+rejects any candidate still consuming the abandoned history — its roots are no longer in the ring.
+Everything beyond that brake is Coretime's responsibility: forced recovery is a runbook procedure,
+and Coretime ensures an abandoned history is never silently resumed.
 
-The Coretime runbook must treat a bump as "reset all inbound channels". Consumers freeze a channel
-on a generation bump or a non-extending root (one that does not extend the consumer's inbound frontier),
-discard prefetched messages and resume only on a fresh `open_channel`.
+The Coretime runbook must treat a forced `set_head` as "reset all inbound channels". Consumers freeze a
+channel on a ring clear or a non-extending root (one that does not extend the consumer's inbound
+frontier), discard prefetched messages and resume only on a fresh `open_channel`.
 
 The delivered messages stand and the re-delivered overlap after the restart. Before reopening, the recovering chain
 must communicate: what was delivered under the abandoned roots and compensate or it becomes an inflation source
 for the counterparties.
 
-> Note: abandoned enactments stay provable forever since the output log is append-only. A dead chain's last messages
-remain drainable at T0 with no state left behind.
+> Note: abandoned enactments stay provable forever since the output log is append-only, and a dormant
+chain's ring persists — so a dead chain's last messages remain drainable at T0 as long as its ring
+stands. A `parachain_clean_up` removes the ring and ends drainability with it.
 
 ## 4. Execution: End to End
 
 1. **A:** runtime appends outbound messages to per-destination stream MMRs
 
-   - Output: one `StreamsRoot`, committed as `(leaf_version, generation, root)` in A's own header digest.
+   - Output: one `StreamsRoot`, committed as `SpmsDigest::V0 { streams_root }` in A's own header digest.
    Nothing else — no host call, no work-digest field.
 
    - PVF `export()`s payloads and node-side archives them.
@@ -301,11 +288,10 @@ remain drainable at T0 with no state left behind.
    - selects an anchor (best imported block, within its authorizer's eligible set — any anchor at or after
    each source's enacting block works)
    - authors a block consuming stream prefixes, reserving the proof envelope as `proof_size`, and names each
-   source's `(ParaId, Generation, StreamsRoot)` via `set_requires_root`
+   source's `(ParaId, StreamsRoot)` via `set_requires_root`
    - in-core the wrapper walks each enactment proof from the anchor's
    super-peak and the guest verifies lifts against each source's `StreamsRoot`. Failures abort with `RefineLog`.
-   - on-chain, §5.1 step 6 checks each named generation is still live and each named root is in its
-     source's ring, then B enacts.
+   - on-chain, §5.1 step 6 checks each named root is in its source's ring, then B enacts.
 
 ## 5. Node Stack
 
@@ -329,7 +315,7 @@ pending-provides hint (dormant until Tier 1a).
 | Property | Polkadot | JAM |
 |---|---|---|
 | Message authenticity | PVF | PVF — unchanged |
-| Root authenticity | relay consensus check | wrapper output-log proof in-core; ring root check and Generation liveness at §5.1 step 6 |
+| Root authenticity | relay consensus check | wrapper output-log proof in-core; ring root check at §5.1 step 6 |
 | Provides commitment | UMP signal | header digest + §5.5 enactment commitment |
 | Stream monotonicity | not enforced | not enforced — self-harm, consumer-visible |
 
@@ -364,7 +350,10 @@ Polkadot capabilities: same-block A -> B deferred to Tier 1b.
   If B declares a prerequisite on A and A never accumulates, B's report is dropped
   after up to an epoch with zero on-chain trace. The node must detect the drop itself and rebuild-and-retry.
 
-4. **ParaId reuse** Resolved via `Generation` so everything binds to `(ParaId, Generation)`.
+4. **ParaId reuse** The ring is dropped at clean-up and recreated empty on re-registration, so a
+  reused id's stale roots are never consumable. That a reused `ParaId` is a *different chain* is a
+  Coretime guarantee (registration policy), not a consensus check — consumers must treat channel
+  identity as managed by Coretime.
 
 5. **Acknowledgement/slashing on JAM**
   Tier 2's security on Polkadot rests on LLv2 ACK slashing. JAM has no equivalent
@@ -377,13 +366,8 @@ Polkadot capabilities: same-block A -> B deferred to Tier 1b.
   JAM DA retention period is not pinned. For message recovery we'd need a real number. Similar to key derivation.
 
 8. **Settlement gas at worst-case fan-in**
-  At MVP settlement reads one generation plus one ring per source (up to 64 of each per candidate), and
+  At MVP settlement reads one ring per source (up to 64 per candidate, `W` × 32 bytes each), and
   the head write adds a ring push. We don't have JAM gas per read byte estimates. 
-
-  This would also influence how the `Generation` field is read:
-  - reading the full `ParaInfo` (~4 KiB)
-  - partial read with `Generation` field offset inside `ParaInfo`
-  - dedicated entry written on bumps 
   
   Running out of gas in Accumulate silently drops later packages, so this design raises PS's required `min_item_gas`.
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -4,7 +4,7 @@ The [Parachain Service](https://github.com/paritytech/polkadot-sdk/blob/afe236db
 
 Here is a breakdown of exactly what needs to change to make Speculative Messaging work smoothly on JAM, ensuring every Polkadot feature has a clear, explicit JAM backport.
 
-> For MVP, chains speculate at `Enactment` tier. Sender parachain `A` writes its `Provides/StreamsRoot` entry
+> For MVP, chains speculate at the `Enacted` tier. Sender parachain `A` writes its `Provides/StreamsRoot` entry
 > inside a `recent_provides` settlement ring (bounded vector). Receiver `B` monitors the ring, fetches messages from `A` and targets its
 > `Requires` field agains the latest `recent_provides` entry. In the `Accumulate` phase, the PS ensures that
 > all `Requires` are matched against their respective `recent_provides` entries.
@@ -20,7 +20,7 @@ a consensus mechanims Speculative Messaging or PS provides.
 
 ## Changes at MVP Tier
 
-We are releasing SpecMsg with Accumulation Tier (HRMP parity) from day 0. The changes needed:
+We are releasing with the Enacted tier (HRMP parity) from day 0. The changes needed:
 
 1. Sender header digest: `DigestItem::Consensus(SPMS_ENGINE_ID, enum SpmsDigest)`.
 
@@ -86,40 +86,91 @@ this is accepted rather than solved (ie draining Coretime's commands before any 
 
 ## Speculation Tiers
 
-- **T0 Accumulate / Consume enacted roots (MVP)**: Parity with HRMP
-  - 1 or 2 slots from guarantee to accumulate, plus 1 or 2 for anchor lag
-  - root verification in-core via the output-log proof; the requires entry carries
-    `(ParaId, StreamsRoot)` and settlement checks the root against the source's ring — the
-    rollback brake, since a forced rollback clears the ring
+Each tier is named after the sender-side event the consumer trusts:
+**Enacted, then Guaranteed, then Announced, then Imported and Fused**.
 
-- **T1a Backed / PrefetchHint**: prefetch on backed with zero consensus change.
-  - node reads guaranteed but not yet accumulated reports to warm cache
-  - still consumes T0 enacted roots
+> Speculation risk: a race condition between A's ring push and B's requires check against the ring.
+Since both candidates are independent, they have their own travel time through guaranteed, then availability,
+then the accumulate pipeline. And either can stall or get rejected. If B report accumulates first, the
+settlement check reads A's root before the update and B is rejected.
 
-- **T1b Backed / Active**
-  - saves 1 or 2 slots
-  - needs no consensus change
-  - `A` guaranteed report can die and `B` burns its slot (ie `A` must land first or `B` burns a slot)
-  - Same block `A -> B` is possible since Accumulation happens in order and A's ring push lands before B's settlement runs.
+- **Tier 0: Enacted (Safe Baseline MVP)**:
+  - consume enacted roots with HRMP parity. The requires entry carries `(ParaId, StreamsRoot)` and settlement checks the root against the ring
+  - latency: 1 or 2 slots from guarantee to accumulate, plus 1 or 2 for anchor lag (between 12 and 24+ seconds)
+  - optimization: node-side fetches `StreamsRoot` from guanranteed but not yet accumulated reports
+  - race condition: structurally impossible since `A` is already enacted. The only remaining risk is not matching the `Provides`
+    against the `W` settlement ring size.
 
-- **T2 Best Block**
-  - saves 2 to 4 slots
-  - needs offchain announce protocol, offchain verification and header-digest read path for package boundary roots
-  - Recommended: high-fan-in consumption (64 sources like every tier up to here) at the lowest latency; T3 matches
-    the latency but caps fan-in at 8. Needs LLv2 ACK/Slashing on JAM
-  - Optional `prerequisites` for ordering: B's package declares A's hash. `J = 8` caps prerequisites plus segment
-    lookups per report, not consumed sources, so fan-in stays at 64. The 64 to 8 drop only happens at Tier 3.
-  - Work package hash is distributed via `/spec-msg/announce` notification protocol.
+- **Tier 1: Guaranteed (A little faster)**
+  - consume guaranteed but not yet enacted roots (acts on optimization from Tier 0)
+  - latency: saves 1 or 2 slots
+  - risk: if settlement fails `B` burns its slot (`A` can die or `A` lands later)
+  - solution for race condition:
+    - 1. Node side timed work package submission
+    - 2. Parachain Service topological sort of dependencies
+    - 3. (Optional): `prerequisites` fields (capped at `J = 8`)
+  - In theory, same block `A -> B` is possible 
 
-- **T3 InCore Tier**
-  - B imports A's exported segment
-  - delivery becomes in-core and deterministic with `import_segments()`
-  - we drop the maximum communication sources from 64 to 8 (`J` constant), but keep the same latency as *T2 Best Block*
-  - Recommended: low-fan-in (8 consumed sources), latency critical (parity with T2) and segment import is straightforward without LLv2 ACK/Slashing
+- **Tier 2: Announced (High Speed Communication)**
+  - consume best-block roots advertised via `/spec-msg/announce` notification protocol
+  - latency: saves 2 or 4 slots
+  - risk: if settlement fails `B` burns its slot (`A` can die or `A` lands later)
+  - relies on llv2 ack / slashing since building block `A` is cheap
+  - solution for race condition:
+    - 1. `prerequisites` fields: work package hash is distributed offchain via `/spec-msg/announce` (capped at `J = 8`)
+    - 2. Parachain Service Buffering 
 
-- **T4 SuperChains**
-  - Both A and B candidates are bundled in the same package
-  - Needs a PS service rule that if any member fails the whole group is declined.
+- **Tier 3: InCore Imported**: delivery via in-core segment import
+  - B's report names A's segment root. JAM parks the report in the ready queue until the segement dependency is resolved
+  - B can't accumulate before A, the ring still guards cases when `A` is rejected
+  - Needs to a segment framing to export the speculative messages, which can land at a later time
+  - latency: same as Tier 2: Announced
+
+- **Tier 4: Fused / SuperChains**
+  - Both candidates are bundled in the same work package, utilizing the same core
+  - Ordering is resolved while creating the work package
+  - Parachain Service must ensure that if multiple candidates are bundled in the same work package
+  the whole group is declined if one of them fails
+  - If candidates are built by different collators, they must negotiate via p2p protocols which one is trusted with the package
+
+**Solutions to reduce the race condition**
+
+1. Node side timed work package submission
+
+The receiver sees A's reportin the guarantees extrinsic and fetch the work package hash, core and `StreamsRoot` from the header digest.
+The payloads are immediately fetched from p2p layer and verified locally. The receiver `B` work package is created but not submitted.
+
+The `B` package is submitted once count assurance bits for A's core are near 2/3. This gives a higher chance for `A`'s report
+to Accumulate within 1-2 slot delay until `B` accumulates.
+
+- If `A` dies before `B` package is submitted, then `B` reanchors against T0 latest enacted root without burning the slot
+- If `A` dies after `B` package is submitted, then `B` burns the slot and `B` rebuilds against T0
+- If `B`'s head doesn't advance after its package accumulates, then `B` burns the slot and conservatively rebuilds against T0
+
+2. Parachain Service topological sort of dependencies
+
+Within one JAM block, the PS `Accumulate` processes digests in the provided order from JAM (sorted by core order).
+If sender A and consumer B land in the same block, but B core is first, then B `Requires` check fails.
+
+To ensure we are not relying on JAM provided order, PS reorders the blocks's digest.
+The solution is to build a depedency graph based on the speculative `Provides` and `Requires`.
+
+If B digest contains `spec_msg_requires` towards `A` and `A` has the same `StreamsRoot` as B's `Requires`, the we have
+an edge from `A -> B`. Edges are created by `ParaID` only. Then we run topological sort on the edges. Everything
+unrelated to speculative messaging remains unchanged.
+
+If a cycle is detected, PS continues with the original order from JAM. The ring will reject the candidates naturally.
+
+3. Parachain Service Buffering
+
+Instead of rejecting `B`'s candidate when the requires check fails, the PS will buffer the work digest and settles it later
+once A's root is written in the ring. 
+At most one digest is buffered per parachain at any given time to ensure the state can't grow.
+A buffered digest expires after `K = 2` slots (TBD needs real data to size).
+Retries run in the `always-accumulate` phase, paid by the protocol's gas grant and capped per block.
+Therefore, can never consume gas registered by the block's own work packages.
+The storage digest is charged from B's balance and refunded on settlement or expiry.
+
 
 ## Transport and Discovery
 
@@ -128,7 +179,7 @@ We have 2 delivery paths for messages:
 - Secondary via PVF exports of payloads to DA as framed segments.
 
 Since segments cannot be exported retroactively, the DA exports are used since day 0. This offers a bootnode agnostic fallback to fetch messages and
-Tier 3 (in-core tier) relies on the segments. 64 KiB of messages per block would cost 0.6% of the budget.
+the Imported tier relies on the segments. 64 KiB of messages per block would cost 0.6% of the budget.
 The actual cost is erasure-coding bandwidth across validators.
 
 **Discovery**
@@ -215,8 +266,8 @@ must communicate: what was delivered under the abandoned roots and compensate or
 for the counterparties.
 
 > Note: abandoned enactments stay provable forever since the output log is append-only, and a dormant
-chain's ring persists — so a dead chain's last messages remain drainable at T0 as long as its ring
-stands. A `parachain_clean_up` removes the ring and ends drainability with it.
+chain's ring persists — so a dead chain's last messages remain drainable at the Enacted tier as long
+as its ring stands. A `parachain_clean_up` removes the ring and ends drainability with it.
 
 ## 4. Execution: End to End
 
@@ -256,7 +307,7 @@ fallback.
 
 **`ProvidesSource`:** reads A's enacted heads at imported blocks — **best, not finalized**. Block
 stream, startup tip, sync gate, ring read at a recent hash,
-pending-provides hint (dormant until Tier 1a).
+pending-provides hint (dormant until Prefetch mode).
 
 ## 6. Trust Model
 
@@ -267,7 +318,7 @@ pending-provides hint (dormant until Tier 1a).
 | Provides commitment | UMP signal | header digest + §5.5 enactment commitment |
 | Stream monotonicity | not enforced | not enforced — self-harm, consumer-visible |
 
-Polkadot capabilities: same-block A -> B deferred to Tier 1b.
+Polkadot capabilities: same-block A -> B deferred to the Guaranteed tier.
 
 > **Why not JAM's `prerequisites`?**
 >
@@ -275,11 +326,11 @@ Polkadot capabilities: same-block A -> B deferred to Tier 1b.
 >
 > (2) Report is not enactment: steps 3/5 can decline after accumulation, so compare-and-reject survives anyway.
 > 
-> (3) `J = 8` is too small and shared with Tier 3's segment lookups; fan-in targets 64.
+> (3) `J = 8` is too small and shared with the Imported tier's segment lookups; fan-in targets 64.
 >
 > (4) The 8-block reporting gate makes it strictly worse than proving enacted state.
 >
-> **Right solution at Tier 3: segment roots are content-addressed.**
+> **Right solution at the Imported tier: segment roots are content-addressed.**
 
 ## 10. Open Questions
 
@@ -291,8 +342,8 @@ Polkadot capabilities: same-block A -> B deferred to Tier 1b.
 2. **`W`** at best-block depth. Now a day-0 sizing input.
 
   The ring is live and read by settlement from day 0, so `W` must be fixed before launch. It must be
-  sized for the best-block pipeline (announce to enact), not the backed one, since the higher tiers
-  reuse the same ring without a consensus change.
+  sized for the Announced (best-block) pipeline — announce to enact — not the Guaranteed one, since
+  the higher tiers reuse the same ring without a consensus change.
 
 3. **Silent ready-queue expiry**
   If B declares a prerequisite on A and A never accumulates, B's report is dropped
@@ -304,7 +355,7 @@ Polkadot capabilities: same-block A -> B deferred to Tier 1b.
   identity as managed by Coretime.
 
 5. **Acknowledgement/slashing on JAM**
-  Tier 2's security on Polkadot rests on LLv2 ACK slashing. JAM has no equivalent
+  The Announced tier's security on Polkadot rests on LLv2 ACK slashing. JAM has no equivalent
 
 6. **CE 129**
   Can a collator without a JAM node ask another node for state? Recent-history reads are fine, but the
@@ -376,7 +427,7 @@ Solving the work package ordering:
 ## Apendix
 
 This sections highlights an alternative to the onchain ring settlement that is valid only
-for the MVP tier (Enactment).
+for the Enacted tier (MVP).
 
 ### Alternative Verification
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -169,10 +169,13 @@ Instead of rejecting `B`'s candidate when the requires check fails, the PS will 
 once A's root is written in the ring. 
 At most one digest is buffered per parachain at any given time to ensure the state can't grow.
 A buffered digest expires after `K = 2` slots (TBD needs real data to size).
-Retries run in the `always-accumulate` phase, paid by the protocol's gas grant and capped per block.
-Therefore, can never consume gas registered by the block's own work packages.
+
 The storage digest is charged from B's balance and refunded on settlement or expiry.
 
+Running the retries consume gas:
+- option 1 (depends on gas usage): Retries run in the `always-accumulate` phase, paid by the protocol's gas grant and capped per block.
+  Therefore, can never consume gas registered by the block's own work packages.
+- option 2: B's next package reserves double the gas
 
 ## Transport and Discovery
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -559,28 +559,192 @@ to the Enacted tier and is not part of the MVP or the design above.
 
 ### Alternative Verification
 
-The RefineContext carries the anchor's accumulation-output-log super peak. The verification
-can happen in-core of the receiver parachain. Since speculation happens at enactment, the
-super peak contains the sender parachain header hash. The receiver node passes in its PoV
-an enactment proof which walks the super peak to the sender header hash, plus the full sender header.
-The receiver then extracts from the SPMS digest the `StreamsRoot` and compares against its `Provides`.
+The RefineContext carries the anchor's accumulation-output-log super peak, authenticated by JAM.
+Verification happens in-core, in the receiver parachain's Refine. Since speculation happens at
+enactment, the super peak commits to what PS accumulated at the sender's enacting block.
+
+During Accumulate, at the same point where a `Provides` root is pushed into the sender's ring,
+PS also emits `Leaf { para_id, streams_root }` into a per-block provides tree. Its root is
+committed next to the changed-heads root in PS's accumulation output:
+
+```
+output = keccak("ps-out-v1" ++ heads_root ++ provides_root)
+```
+
+A provides leaf exists only for a candidate that enacted, and it carries exactly the value the
+sender reported via `set_provides_root`: the same value ring settlement checks. No header is
+involved anywhere.
+
+The changed-heads *tree* stays byte identical, but the output commitment changes shape: every
+existing belt consumer (light clients, bridges) that walked `belt leaf → heads_root` directly
+must be upgraded to supply the `provides_root` sibling and the version tag. This is a
+coordinated format migration, not a drop-in change.
+
+**Tree construction (consensus rules).** The provides tree is a binary keccak tree with
+mandatory domain separation:
+
+- leaf: `keccak(0x00 ++ para_id ++ streams_root)`
+- interior node: `keccak(0x01 ++ left ++ right)`
+
+Leaves are sorted by `para_id`; a para enacting multiple candidates in one block contributes
+multiple leaves, ordered by accumulation order. A single-leaf tree's root is the leaf hash. A
+block in which no para provides commits the constant
+`EMPTY_PROVIDES_ROOT = keccak("ps-provides-empty-v1")`, so the output shape never varies and a
+heads-only commitment can never be reinterpreted. The in-block `(service, output)` pairs tree
+uses the same leaf/interior tags. The tags are not optional: without them a 64-byte leaf
+encoding is byte identical to an interior preimage and interior-as-leaf forgeries open up.
+Sorted leaves also make non-membership provable ("para A provided nothing at this block"),
+usable for the §8 channel-freeze policy.
 
 Walking the super-peak:
 
 ```
-anchor super-peak → belt leaf → (PS, heads_root) → Leaf { para_id, head_hash }
-  → header preimage → SPMS digest → StreamsRootA
+anchor super-peak → belt leaf → (PS, output) pair → provides_root → Leaf { para_id, streams_root }
 ```
 
+### Proof Format
+
+Every path carries its position; side bits at each level derive from the index, so hashing is
+never commutative and every leaf is position bound.
+
 ```rust
+/// Depth caps, enforced before any hashing. An oversize or malformed proof
+/// aborts Refine with `RefineLog`; no panics, checked index arithmetic only.
+const MAX_BELT_DEPTH: usize = 64;     // u64 leaf index bounds the MMR
+const MAX_PAIRS_DEPTH: usize = 16;    // services accumulating per block
+const MAX_PROVIDES_DEPTH: usize = 16; // provides leaves per block
+
 struct EnactmentProof {
-    /// Path from the anchor's super-peak to the enacting block's entry.
-    belt_path: Vec<u8>,
-    /// PS's per-block accumulation output for that block.
+    /// Position of the enacting block's belt leaf in the accumulation-output log.
+    belt_leaf_index: u64,
+    /// Intra-peak siblings, `<= MAX_BELT_DEPTH`.
+    belt_peak_path: Vec<Hash>,
+    /// Remaining peak bag, folded per `belt_leaf_index`, `<= MAX_BELT_DEPTH`.
+    belt_peaks: Vec<Hash>,
+    /// Position of the `(PS, output)` pair in the block's pairs tree.
+    pairs_index: u16,
+    /// Siblings in the pairs tree, `<= MAX_PAIRS_DEPTH`.
+    pairs_path: Vec<Hash>,
+    /// PS's changed-heads root for that block, the sibling of `provides_root`
+    /// in the output commitment.
     heads_root: Hash,
-    /// keccak path in the changed-heads tree to `Leaf { para_id, head_hash }`.
-    heads_path: Vec<Hash>,
-    /// Full header preimage that must match to `head_hash`.
-    header: Vec<u8>,
+    /// Position of the provides leaf.
+    provides_index: u16,
+    /// Siblings in the provides tree, `<= MAX_PROVIDES_DEPTH`.
+    provides_path: Vec<Hash>,
 }
 ```
+
+Verification, in the receiver's Refine:
+
+1. Enforce the depth caps and decode; failure aborts with `RefineLog` before any hashing.
+2. Recompute `leaf = keccak(0x00 ++ para_id ++ streams_root)` from the verifier's own
+   `Requires` target. Nothing semantic is ever extracted from the proof.
+3. Walk `provides_path` (sides from `provides_index`) up to `provides_root`.
+4. Recombine `output = keccak("ps-out-v1" ++ heads_root ++ provides_root)`.
+5. Recompute the pair leaf from the verifier's own PS service id constant and `output`, walk
+   `pairs_path` (sides from `pairs_index`) up to the block's belt leaf.
+6. Walk `belt_peak_path` and fold `belt_peaks` per `belt_leaf_index` up to the anchor super
+   peak; compare against the RefineContext value.
+
+Every step is a hash membership check on values the receiver already holds; a proof cannot
+settle any root other than the one being asked about.
+
+**Service id binding is the security of the scheme.** Every service fully controls its own
+output bytes, so any attacker can register a service and emit
+`keccak("ps-out-v1" ++ x ++ fake_provides_root)` where the fake tree contains
+`Leaf { victim_para, evil_root }`. The only thing separating that from a universal forgery is
+step 5: the pair leaf is recomputed from the PS service id the verifier already knows, never
+read from the proof.
+
+**Replay.** Settlement (ring or proof) only ever answers "was this root enacted". Which
+messages get consumed is guarded solely by the receiver's consumption frontier, enforced by
+its registered PVF: stream positions are append-only, and a `parachain_set_head` reverts the
+frontier and the consumption effects atomically, so double delivery is impossible while both
+endpoint histories are continuous. The discontinuous cases are Known Limitations below.
+
+### Costs
+
+Proofs ride in the work item payload next to the Lift proofs, are consumed in Refine and
+discarded. Only the resulting `(ParaId, StreamsRoot)` entries (~36 B each) reach the digest;
+Accumulate performs zero settlement reads. The bytes are paid in package size, DA erasure
+coding and audit re-execution, not in the 48 KiB report.
+
+Path length grows with chain age, not activity. At ~2^26 belt leaves (about a decade of 6 s
+blocks) a proof is ~2.5 KiB per consumed source; the depth caps bound it at ~5.2 KiB. Naive
+full fan-in (32 sources, §1) is ~80 KiB, ~165 KiB at the caps (~1.2% of the package budget).
+Sources enacted in the same block share `belt_*`, `pairs_*` and `heads_root`, so the wire
+format groups proofs by enacting block: each co-enacted source adds only its provides path
+(~450 B), bringing full fan-in to ~16 KiB in the common case. Verify gas is at most ~161
+keccaks of 64 B per source.
+
+Proofs verify against the anchor super peak, so they are anchor specific: a resubmission that
+re-anchors (§2 note) needs freshly generated proofs. Collator tooling must not cache them
+across anchors.
+
+### Trust Model
+
+Ring settlement trusts an Accumulate state read. Here the load-bearing check runs in Refine,
+so the trust root moves to ELVES-audited in-core execution. The verification must live in
+PS's own Refine logic, not in the §1 wrapper checks that are explicitly collator-vs-collator.
+The digest carries a PS-attested flag marking entries as proof-settled, and Accumulate skips
+the ring read exactly for those: while both mechanisms coexist, every `Requires` entry is
+settled by exactly one of them, never neither.
+
+### Why not walk to the header
+
+An earlier form of this proof walked `belt leaf → heads_root → Leaf { para_id, head_hash }
+→ header preimage → SPMS digest → StreamsRoot`, carrying the full sender header in the PoV.
+It had provable defects:
+
+- **Unbound root.** The ring is fed from `set_provides_root` (pallet storage); the SPMS header
+  digest is written separately by the sender runtime. PS is header agnostic and never checks
+  they agree, so a buggy or malicious runtime can settle one root on-chain while its header
+  proves a different one in-core. The two settlement paths diverge silently and consumers can
+  be made to settle a root that never entered the settlement system.
+- **Bundles break the walk.** For bundled PoVs the wrapper carries the last produced `Provides`
+  forward when later inner blocks send nothing. Only the candidate-boundary head enters the
+  changed-heads tree, so the enacted header's digest need not contain the settled root at all.
+  For such candidates the proof simply has no path to the root: verification fails on honest
+  history.
+- **Opaque preimage.** `head_hash` commits to opaque head-data bytes. Decoding them as a header
+  with a known digest layout is a format assumption PS nowhere enforces, and every proof hauls
+  up to 4 KiB of header into the PoV just to read 32 bytes out of it.
+
+Pushing the root as its own PS-authored leaf removes all three: the leaf is created by PS
+itself, at enactment, from the host-call value, for the effective candidate-boundary root.
+
+### Known Limitations
+
+**1. Canonicality.** The accumulation-output log is append-only, so this proof shows a root
+*was* enacted, permanently and with unbounded reach (no `W_MAX` window). It cannot show the
+enacting history is still canonical: `parachain_set_head` (§8) clears the ring precisely so
+abandoned roots stop settling, and no rollback can retract a belt leaf. As a full replacement
+for ring settlement this scheme must be paired with a per-para generation key: the receiver's
+Accumulate checks the sender's current generation at settlement, and the generation bumps on
+every `parachain_set_head` that overwrites a live head, on `parachain_clean_up`, and on para
+id (re)registration. Bumping is coarse: it also invalidates proofs for the still-canonical
+prefix. That matches ring semantics, since a ring clear drops prefix roots too, and §8's
+runbook already freezes and explicitly reopens every channel after recovery. Alone, without
+the generation key, this scheme is only safe for histories Forced Recovery has never touched.
+
+**2. Generation TOCTOU.** The proof verifies in Refine against an anchor up to `C_H = 8`
+slots stale; the generation is checked at Accumulate. A recovery landing in that window makes
+a candidate fail on-chain after passing in-core: the slot is burned and, unlike ring
+settlement, §3 buffering cannot rescue it, because the verification is already fixed at
+Refine. Same acceptance class as the Coretime-ordering window noted in §2.
+
+**3. Para id reuse.** `parachain_clean_up` removes the ring and permanently ends drainability
+(§8); a belt leaf can never be removed. Without the generation bump on cleanup and
+re-registration above, a para id re-registered to a new chain inherits provable
+`Leaf { para_id, root }` history from its predecessor, and receivers can be made to consume
+the dead chain's messages as the new one's.
+
+**4. Enacted tier only, no buffering.** A root missing at Refine fails the candidate in-core:
+there is nothing for §3 buffering to wait on, and §4's sort cannot help. The scheme cannot
+serve Tiers 1-2, which settle at Accumulate time by construction. "Full replacement" is only
+meaningful if those tiers keep the ring or are dropped.
+
+**5. Proof-data liveness.** The ring needed only current state; generating a proof for an old
+root requires reconstructing that block's provides tree from chain history. Unless an indexer
+retains them, old roots stay theoretically provable but practically unsettleable.

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -27,8 +27,9 @@ We are releasing with the Enacted tier (HRMP parity) from day 0. The changes nee
 This payload is the leaf that every enactment proof walk terminates on. To ensure we can change the
 digest layout in the future while having coexisting versions, the `SpmsDigest` is a versioned enum. 
 
-For bundled PoV the Parachain Service commits the head a parachain ended the block with. Therefore, only the
-final inner block's root is ever provable and intermediate roots can never be consumed or settled.
+For bundled PoV, only the candidate-boundary StreamsRoot is added to the settlement ring.
+Messages from inner blocks can still be consumed, but the receiver PoV must lift the stream state
+to the final root. Inner blocks cannot be settled directly.
 
 This is the sender's consensus commitment relying only on 33 bytes in its header.
 
@@ -123,6 +124,10 @@ settlement check reads A's root before the update and B is rejected.
 
 - **Tier 2: Announced (High Speed Communication)**
   - consume best-block roots advertised via `/spec-msg/announce` notification protocol
+  - Announced roots represent fetching hints. Before `Refine`, the package builder must retarget
+  the lifts to the final candidate root. An intermediate announced root must never be writted directly into `Requires`.
+  The `/spec-msg/announce` carries the exact `work_package_hash` and the final `StreamsRoot`.
+
   - latency: saves 2 or 4 slots
   - risk: if settlement fails `B` burns its slot (`A` can die or `A` lands later)
   - relies on llv2 ack / slashing since building block `A` is cheap

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -45,12 +45,17 @@ enum SpmsDigest {
 
 2. Digest fields: `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 64>` on the PS work digest
 
-The field is set via `set_requires_root` host call at most once per `Refine`. Each entry names the
-consumed root itself, so settlement can check it against the source's ring.
+The `spec_msg_requires` must not be chosen by the parachain block. Otherwise it can state any consumption.
+The block records what is consumed, then the PS Refine wrapper verifies the PoV carried lift,
+stitches bundle intervals and gap proofs, and synthesizes a `(ParaId, StreamsRoot)` per source.
 
+The PS Refine should write `spec_msg_requires` directly after verifying the consumption records and PoV lifts.
+
+To ensure canonical encoding and uniqueness, the PS Refine wrapper produces unique entries sorted by `ParaId`.
+The Refine phase rejects malformed input.
+
+`spec_msg_requires` is a digest field, because UMP signals are replayed after the head write (so it can't gate enactment).
 At 36 bytes each, full fan-in costs ~2.3 KiB of the 48 KiB report.
-
-This must be a digest field and not UpwardMessage, because UMP replays after the head write (so it can't gate enactment).
 
 3. Settlement: ring `spec_msg_recent_provides` and `Requires` check
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -191,15 +191,37 @@ The para's runtime maintains its list in the existing KV store (tag `0x08`):
 /// Full storage key: 0x08 ++ SCALE((para_id, BOOTNODES_KEY)).
 const BOOTNODES_KEY: &[u8] = b"bootnodes/v1";
 
-struct BootnodeRecord {
-    /// bump = publish under .../v2
-    version: u8,  
-    /// Reachable bootnodes into the para's network, not the authoring node.
-    addrs: BoundedVec<Multiaddr /* <=128 B */, ConstU32<8>>,
+/// Ephemeral record of a parachain's active bootnodes.
+struct AddressRecord {
+    /// The para ID this record belongs to.
+    para_id: u32,
+    /// The timeslot after which this entire record is invalid and should be dropped.
+    expires_at: Timeslot,
+    /// Up to 4 active bootnodes.
+    bootnodes: BoundedVec<Bootnode, 4>,
+}
+
+struct Bootnode {
+    /// The network address (must NOT contain a peer ID).
+    addr: Multiaddr,
+    /// The public key from which the node's peer ID is derived.
+    node_key: Ed25519Public,
+    /// A monotonic sequence number to prevent replay attacks.
+    seq: u64,
+    /// Proof of possession. The node must sign:
+    /// `("bootnode-pop-v1", jam_genesis_hash, AddressRecord::para_id, Bootnode::seq, Bootnode::addr)`
+    /// This proves the node owner consents to being a bootnode for this specific broadcast.
+    sig: Ed25519Signature,
 }
 ```
 
-> Note: KV writes are charged and skipped on **insufficient balance**. This is accepted since we have DA as independent path to fetch messages.
+The parachain service doesn't verify the `AddressRecord` fields. The admission of a new
+address into the book is part of the Parachain runtime logic.
+
+Initially the chain operator will setup the network via an explicit `--bootnodes` CLI flag. Once the chain
+is registered new collators and nodes can join by reading the `AddressRecord` under the storage key.
+
+> Note: KV writes are charged and skipped on **insufficient balance**.
 
 **Flow**
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -136,6 +136,15 @@ fn push(para: ParaId, root: StreamsRoot) {
     spec_msg_cursor.set(para, c); // 47 B write
   }
 }
+```
+
+| per para                | one-item ring (W = 64)          | this layout (point reads)          |
+|-------------------------|---------------------------------|------------------------------------|
+| settle, per `Requires`  | 2,345 B read                    | 75 B read                          |
+| push                    | 2,345 B read + 2,345 B write    | 197 B read + 197 B write, 2 dels   |
+| teardown                | 1 delete                        | 65 reads (~4.85 KB) + 129 deletes  |
+| resident footprint      | 2,345 B, self-pruning           | 9,647 B, ratchets until teardown   |
+
 
 When the `parachain_set_head` overwrites a live head, or if `parachain_clean_up` is called, the ring is cleared.
 The teardown process reads the cursor and walks backwards from `head - 1` down to `tail`.

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -60,6 +60,11 @@ It is check and ring is delivered by the MVP implementation. If the enacted head
 its root is pushed into the senders ring only if different from the newest entry. The ring evicts the
 oldest entry beyond `W`.
 
+> `W` is no longer extra pipeline headroom. It is the window against which `Requires` must match.
+If a package `Requires` is not in the ring, that slot is lost. On polkadot, a stale candidate
+can retry for free. On JAM, each retry costs another slot.
+
+
 A forced `parachain_set_head` that overwrites a live head will also clear the ring.
 
 ```rust

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -1,226 +1,569 @@
 # Speculative Messaging on JAM
 
-The [Parachain Service](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#3-the-parachain-service) needs a robust messaging system to replace the older HRMP-style payloads, and [Speculative Messaging](https://github.com/paritytech/polkadot-sdk/blob/9d0a0daee40e6e350209aaf4b3e3bdf1fb9a8793/docs/speculative-messaging-design.md) is our primary candidate for JAM.
+The [Parachain Service](../designs/parachain-service-on-jam/parachain-service-on-jam.md#3-the-parachain-service)
+needs a messaging system to replace HRMP-style payloads;
+[Speculative Messaging](https://github.com/paritytech/polkadot-sdk/blob/9d0a0daee40e6e350209aaf4b3e3bdf1fb9a8793/docs/speculative-messaging-design.md)
+is the candidate. This document is the protocol spec: consensus delta, verification,
+transport, tiers, asks.
 
-Here is a breakdown of exactly what needs to change to make Speculative Messaging work smoothly on JAM, ensuring every Polkadot feature has a clear, explicit JAM backport.
+**Normativity:** the PS design is normative for the service delta (digest fields, tags,
+accumulate steps, host functions); this document for the protocol. One home per constant.
+
+Pinned against PolkaJAM `84f86225a704` (GP 0.7.x): `W_B = 13,791,360`, report budget 48 KiB,
+`H = 8`, `U = 5`, `E = 600`, `max_refine_gas = 5×10⁹`, `max_exports = 3,072`, segment
+4,104 B. Open: DA retention period (ask 17), GP equation refs.
+
+## 0. Design Summary
+
+> **If a root was already enacted by B's anchor, B just proves it and the chain never hears
+> about it.** (ie no settlement needed)
+>
+> B picks a recent JAM block as its anchor and ships a Merkle proof in its PoV:
+> "in the state *after* this block executed, A's cell holds `StreamsRootA`." 
+> Validators check that in-core. A root not yet enacted at the anchor cannot be
+> proven this way and has to be checked on-chain instead.
+>
+> The latency tiers decide when to use the in-core cell proof or the settlement ring.
+
+This is safe because JAM only accepts B's report if the anchor is an ancestor of the block that
+accumulates it (it must be in `β`), and enacted state never un-happens along a fork. So, whatever B
+proved at the anchor is still true when B lands.
+
+Two exceptions: forced recovery (§1.6) and co-packaged sibling roots (§12). And when a root *does* have to
+be checked on-chain (Tier 1b+), Accumulate needs something on-chain to check it against (settlement ring).
+
+MVP delta: `set_provides_root` + digest field (33 B), provides cell (81 balance units),
+ring slot reserved-not-written (1,586). **No settlement step, no requires field, no
+`yield`.** Baseline bumped: 69,847 → **71,514**.
 
 ## 1. Consensus and State Changes
 
-### 1.1 Digest Fields Replace UMP Signals
+### 1.1 The Provides Digest Field
 
-On Polkadot, `Provides` and `Requires` travel as [UMP signals](https://github.com/paritytech/polkadot-sdk/blob/436cd3373a71f1c2251ce3976ee04220cf2646be/polkadot/primitives/src/v9/mod.rs#L2740-L2760).
-
-In JAM, the consensus output per candidate is `ParachainWorkDigest::Ok`, which is assembled by the refine wrapper.
-
-We need to add two new digest fields (optionally present and at most once per child PVM via `set_provides_root` and `set_requires`).
-If a duplicate call is made, Refine fails. At 64 sources, this takes up about 2.3 KiB, which is a comfortable 5% of our 48 KiB work-report budget.
+Only **provides** reaches consensus at MVP:
 
 ```rust
-const MAX_REQUIRES_SOURCES: u32 = 64;
-
-struct SpecMessagingDigest {
-    provides: Option<StreamsRoot>,
-    requires: BoundedVec<(ParaId, StreamsRoot), MAX_REQUIRES_SOURCES>,
-}
-
 enum ParachainWorkDigest {
     Ok {
-        para_id: ParaId,
-        // .. existing variants
-        spec_messaging: SpecMessagingDigest,
+        // .. existing fields
+        /// Set via `set_provides_root`. `None` = root unchanged.
+        spec_msg_provides: Option<StreamsRoot>,
     }
 }
 ```
 
-### 1.2 The `RecentProvides` Service State
+- `set_provides_root(root)`: optional host call, at-most-once per Refine, wrapper-enforced. Second
+  call fails with `RefineLog::DuplicateProvidesDeclaration`.
+- **Bundled PoVs:** called once per bundle, with the **final** inner block's root (the
+  guest aggregates). Sound because stream MMRs are append-only and the final root commits to
+  every inner block's messages.
+- **Normative rule:** the `set_provides_root` value and the final inner block's header
+  digest (`DigestItem::Consensus(SPMS_ENGINE_ID, root)`) are one computation,
+  byte-identical. This is guest-asserted by aborting Refine on mismatch. A wrong but internally
+  consistent root is unenforceable self harm.
+- 33 B against the 48 KiB report budget; PS §4.1 step 8's size check must include it.
+- `ParachainWorkDigest` field, not an `UpwardMessage` since UMP replays after the step-6 head write, so it
+  cannot gate enactment.
 
-To perform the settlement check during the `Accumulate` phase, the Parachain Service needs to maintain a ring of [RecentProvides](https://github.com/paritytech/polkadot-sdk/blob/436cd3373a71f1c2251ce3976ee04220cf2646be/polkadot/runtime/parachains/src/spec_msg.rs#L55-L70) roots for every source parachain.
-
-This is a new service [state item](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#61-state-balance-accounting) (keyed under tag 0x08) that is written exclusively by `Accumulate` upon enactment. It has a fixed worst-case footprint of 4,649 bytes, which is folded directly into the per-para [baseline footprint](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#sizing-the-baseline-footprint).
-
-> **Important**: The [parachain_clean_up](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#side-effect-host-functions) must additionally drop the ring entry when a parachain is offboarded. Otherwise a reused `ParaId` inherits the prior stale roots.
+### 1.2 The Provides Cell
 
 ```rust
-pub const RECENT_PROVIDES_WINDOW: u32 = 128;
-pub struct RecentRoots(BoundedVec<StreamsRoot, ConstU32<RECENT_PROVIDES_WINDOW>>);
-
-// Keyed under tag 0x08. Written only by Accumulate.
-recent_provides: Map<ParaId, RecentRoots>
+/// Keyed `0x09 ++ SCALE(para_id)`.
+/// - ParaId as fixed 4-byte LE u32, NOT Compact.
+/// - Absent means never sent or force-recovered or not re-enacted or offboarded (OQ 4).
+/// Written only by Accumulate, on enactment (PS §5.1 step 6).
+spec_msg_provides: Map<ParaId, StreamsRoot>
 ```
 
-### 1.3 Settlement in Accumulate
+Step 6 runs after the registration/parent-head/code checks and a rejected candidate never
+moves the cell. `parachain_clean_up` drops it.
 
-Polkadot handles settlement by dropping [candidates pre-inclusion](https://github.com/paritytech/polkadot-sdk/blob/436cd3373a71f1c2251ce3976ee04220cf2646be/polkadot/runtime/parachains/src/paras_inherent/mod.rs#L1043-L1058) if Requires doesn't match Provides. Because JAM lacks a pre-inclusion hook, this check shifts into the Accumulate phase (specifically between the validation-code check and the head-data update).
+- **Why a bare 32-byte value:** values <= 32 bytes are placed in the JAM trie leaf, so the proof is a
+  pure Merkle path, no preimage.
+  Costs 81 units vs +33 in `ParaInfo`, but saves ~4 KiB of proof per source per block.
 
-Every required root in the digest must match the source's recent_provides state. If there's a miss, the candidate is rejected, the receiver burns B's core slot (a difference from Polkadot), and it logs an `AccumulateLog::RequiresUnmet` error. The collator then simply drops the package, rebuilds, and retries.
+- Accumulate writes whatever the digest carries, JAM will not verify MMR extension. This means
+  that consumers are protected against forged messages, **not against a source rolling back its own stream**.
+
+
+### 1.3 The Settlement Ring — reserved at MVP, written from Tier 1b
 
 ```rust
-5. Validation code check: ..
-6. Speculative Messaging Settlement
-7. Head-data update: ..
+/// Keyed `0x0a ++ SCALE(para_id)`.
+/// 
+/// From Tier 1b: step 6 pushes the enacted root iff != newest entry, evicts oldest.
+/// Read only by settlement (§7.2). NEVER Merkle-proved — so width costs nothing in proof size.
+spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>
 ```
 
-[AccumulateLog](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#31-service-state-layout) is adjusted to reflect the new settlement check:
+| | Cell (`0x09`) | Ring (`0x0a`) |
+|---|---|---|
+| Consumer | in-core verifier (guest) | Accumulate settlement |
+| Access | Merkle proof in PoV | Direct state read |
+| Size | <= 32 B hard | unconstrained |
+| Live at | every tier | Tier 1b+ |
+
+**Sizing:** `W = max_elastic_cores * (eviction_window + pipeline_depth)`.
+The core rate multiplies the whole exposure span. For 3 cores, 3 * (8 + 8) = **48**. Choose at *best-block*
+depth before the baseline freezes.
+
+`Compact(W)` is 1 byte only for W <= 63.
+
+### 1.4 Baseline Footprint
+
+PS §6.1 prices an entry at `44 + |value| + |key|` — **balance units, not bytes**:
+cell = 44 + 32 + 5 = **81**; ring at W = 48 = 44 + 1,537 + 5 = **1,586**;
+baseline bumps 69,847 to **71,514**.
+
+Both are baseline-covered: writes take no balance check ("the write cannot fail"), 
+and **deletions refund nothing**, unlike `kv_remove`, the deletes in `parachain_clean_up`
+and `parachain_set_head` must not touch `used_state_balance`, or PS §6.4's exact-equality check bricks every deregistration.
+
+**Land before the first parachain registers (ask 7) — plan of record.** Any later `BASELINE_FOOTPRINT` change is a live migration.
+
+### 1.5 Bundling and Granularity
+
+Provides is per block semantically, per work package in consensus. A bundle declares the
+**final** root and intermediates stay in their headers. Consequences:
+
+- Event streams coarsen to the bundle (serving obligation, §3.3).
+- A bundling receiver merges per-block requires into one set.
+- **Bundle-intermediate roots are unsettleable at every tier**: only the digest root
+  reaches cell and ring. Tier 1b is immune (binds to bundle-final digests by construction);
+  Tier 2 must bind only to declared package-boundary roots (§7.3).
+
+Cycles: never between blocks (SpecMsg's invariant), never at Tier 0 (only enacted roots
+consumable).
+
+From Tier 1b, mutual requires between co-arriving candidates are handled by co-packaging or
+enactment groups (and not by mutual **prerequisites** (§12)). This means that no 
+viratual window is needed. The Accumulate processes packages in order and step 6 writes before
+the next package's setlement runs. Therefore, we can achive same-block A->B communication and
+ordering (one-directional prerequisite as Tier 2).
+
+### 1.6 Forced Recovery
+
+`parachain_set_head` (PS §6.3) **rolls back enacted history**. Two costs:
+
+1. **Channel desync (liveness):** A's next root won't extend the old one; every consumer
+   stalls.
+2. **Economic divergence (safety):** deliveries from rolled-back enacted blocks are
+   irreversible. A burns X, emits "mint X", enacts, B delivers, recovery abandons the
+   block: re-executed txs double-mint, non-re-executed leave an unbacked mint. **B's supply
+   is permanently inflated**; no messaging-layer mechanism can undo it.
+
+Handling:
+
+- **Service:** `parachain_set_head` also deletes `0x09`/`0x0a` (balance-neutral) and recovery
+  becomes observable via the absent cell.
+  Consequence: **any mid-life `set_head` is channel-severing by construction**.
+  Coretime runbooks must treat it as "reset all inbound channels" (ask 19). No-op at registration-time use.
+
+- **Consumer:** on cell deletion or non-extending root will freeze the channel, discard
+  prefetched material. Resume **only** on a fresh `open_channel`, resetting the inbound
+  frontier to the new stream state. The re-delivered overlap is genuinely new messages
+  (Cost 2's residue), not a dedup bug. Delivered messages stand.
+
+- **Sender (reconciliation gate, ask 19):** before reopening, enumerate messages delivered
+  under abandoned roots (archive/DA) and compensate — suppress re-emission or account the
+  drift. Skipping this makes the para an inflation source for its counterparties.
+
+**In-flight tail, accepted and bounded:** packages anchored pre-deletion still deliver
+abandoned-branch messages for up to 8 slots + accumulation lag.
+
+At Tier 1b+ in-flight settlements naming the deleted ring burn those consumers' slots.
+Robust form: a stream-generation marker in the leaf preimage (OQ 4) covers recovery,
+offboarding and ParaId reuse in one mechanism.
+
+## 2. In-Core Verification of Requires
+
+### 2.1 State Proofs Against the Anchor
+
+B's PoV carries, per consumed source A with root `StreamsRootA`, a Merkle proof that
+`0x09 ++ SCALE(A) = StreamsRootA` at B's anchor which is verified in-core against
+`RefineContext.anchor.state_root` (fetched by the child PVM via
+`work_package_context()`, no wrapper involvement).
+Then Lifts are verified against `StreamsRootA` as on Polkadot. Nothing reaches Accumulate.
+
+**State-key derivation** (a mismatch is a silent, total failure, §8):
+
+1. `h = BLAKE2b-256( 0xffffffff ++ storage_key )`.
+2. 31-byte key: bytes 0–7 interleave service-id LE bytes with the hash
+   `[id₀,h₀,id₁,h₁,id₂,h₂,id₃,h₃]`; bytes 8–30 = `h[4..27]`.
+
+The guest reads the service id from `work_items_summary()`, never hardcoded. The anchor
+state-root is part of the package — deterministic for every guarantor. `RefineContext` has
+**no anchor timeslot**, so no in-core freshness policy is expressible.
+
+### 2.2 The Anchor Budget
+
+The anchor must be within the last **8** JAM blocks (`H`) at guarantee inclusion.
+
+- **Anchor on the best imported block, not finalized.** A dropped fork fails closed
+  (rebuild) — the exposure every work package has. Finality gates delivery confidence and
+  pruning instead (§3.3).
+- Budget at 6 s slots: state-root lag 1 (headers carry the *prior* root — freshest anchor
+  is **tip − 1**), build < 1, distribution 1–2, inclusion 1 → **3–4 of 8 used**, 4–5
+  reserve.
+- **The anchor is double-booked (ask 18).** PS §7.1's AURA authorizer makes the anchor the
+  slot claim, shrinking a collator's eligible anchors from 8 to its own rotation run —
+  degrading the reserve, the envelope cache, and re-anchoring locality.
+  
+  Either authorizers for message-consuming paras claim slots without binding anchor choice (OQ 9), or this
+  budget is re-derived at the constrained count. The unstated interaction is the only
+  unacceptable outcome.
+
+### 2.3 Re-anchoring
+
+Missing the window is cheap:
+- 1. Re-anchoring swaps the ~KiB proof envelope, never the block
+- 2. MMR peaks are prefetched continuously, so regenerating lifts is local
+- 3. keep a small cache of envelopes against recent eligible anchors.
+
+From Tier 1b the ring lets B name an older root against a newer anchor, ending forced lift regeneration.
+
+### 2.4 Verification Lives in Guest Code
+
+The proof rides the PoV in the `ParachainBlockData` framing and is verified
+via `validate_block` in cumulus guest code — **the framing needs a slot for the anchor
+proof** (V4 or a V3 field, same code for both targets, ask 14).
+
+The wrapper's requires-related delta is **zero**. All hashing is BLAKE2b-256 (state trie and message
+trees); the existing `sp_io`-on-PVM shim covers it — subject to §2.6.
+
+This implies a trust cost: root authenticity moves from a relay-consensus check to per-parachain guest code.
+A buggy runtime can disable inbound authentication with no on-chain evidence. The alternative is a
+requires field with a settlement at every tier.
+
+### 2.5 Budgets and PoV Reservation
+
+The bound is on **touched streams**, not sources (~4 KiB per touched stream worst case
++ ~2 KiB per read-context gap; one source = many streams). Reserve in the STF as
+`proof_size`:
+
+```
+pov_reserve = Σ_touched_streams (4 KiB + gaps × 2 KiB)   # lifts
+            + Σ_consumed_sources (2 KiB)                 # state proofs (additive)
+```
+
+Aproximation: 128 streams + 64 sources = 640 KiB, well inside `W_B` ~13.15 MiB.
+A single-key proof is `32 * depth + 64` ~ 0.7–1 KiB; 2 KiB is conservative.
+Depth tracks *total* JAM state. Encode the 64 paths as a **multiproof** (~20% saving).
+
+`MAX_REQUIRES_SOURCES = 64` and `MAX_TOUCHED_STREAMS` are **guest-side, advisory at
+Tier 0** (requires is off-chain and nothing checks them).
+
+From Tier 1b the speculative subset is wrapper-bounded by `N` (§7.2).
+On-chain cost of requires at Tier 0: **zero bytes**.
+
+### 2.6 Gas — the highest-risk unknown
+
+Refine gas is a hard consensus limit. The design adds ~1,700 BLAKE2b invocations (64 paths
+× 20–30 compressions) plus lift verification, on an unmeasured transpilation baseline.
+
+Three gates: throughput (informs core time), **metered ceiling (go/no-go, before spec
+freeze**, denominator `max_refine_gas = 5×10⁹`), and accumulate settlement gas (before
+Tier 1b, §7.2).
+
+**Fallback: a BLAKE2b-256 host call for the child PVM (ask 10)**.
+
+## 3. Transport and Discovery
+
+### 3.1 Transport — dual, DA default-on
+
+- **Primary:** `/spec-msg/exchange` request-response for low latency. The payloads are retained in the sender's
+  node-side archive per §3.3 (outlives DA windows with unbounded catch-up).
+
+- **DA export, default-on:** the PVF `export()`s outbound payloads as framed segments.
+  Segments **cannot be retro-exported**, so deferring DA is irreversible for every block
+  produced meanwhile. Enabling unneeded DA is cheap. Also the zero-discovery fallback and
+  the cold-start path (signal leaves + register events in segment framing means no pre-existing
+  channel needed). Tier 3 requires it outright.
+
+- Cost: a 64 KiB/block para uses 17 segments ~ 0.6% of the export budget; the real cost is
+  erasure-coding bandwidth across the validator set (needs double checking before we decide to go with p2p only).
+
+### 3.2 Discovery — parachain-managed KV bootnodes
+
+JAM state keys are hashed and non-enumerable, so the key must be well-known. The para's
+runtime maintains its list in the existing KV store (tag `0x07`):
 
 ```rust
-enum AccumulateLog {
-    // .. existing variants
-    RequiresUnmet { src: ParaId, root: StreamsRoot },
+/// Full storage key: 0x07 ++ SCALE((para_id, SPEC_MSG_BOOTNODES_KEY)).
+const SPEC_MSG_BOOTNODES_KEY: &[u8] = b"spec-msg/bootnodes/v1";
+
+struct BootnodeRecord {
+    /// bump = publish under .../v2
+    version: u8,  
+    /// Reachable bootnodes into the para's network, not the authoring node.
+    addrs: BoundedVec<Multiaddr /* <=128 B */, ConstU32<8>>,
 }
 ```
 
-## 2. Transport And Discovery
+Requires no changes for Parachain Service. The parachain must handle rotation and anti-spam policies.
+Note: KV writes are charged and skipped on **insufficient balance**. This is accepted since we
+have DA as independent path to fetch messsages.
 
-### 2.1 Transport Payload
+Note: discovery may be self-attested (KV), but Provides must be consensus written.
 
-For the MVP, parachains will exchange messages strictly offchain via peer-to-peer (P2P) using a `/spec-msg/exchange` request-response protocol. The payloads remain in the sender's [node side archive](https://github.com/paritytech/polkadot-sdk/blob/436cd3373a71f1c2251ce3976ee04220cf2646be/cumulus/client/spec-msg/src/archive.rs#L18-L57) until the receiver acknowledges them.
+### 3.3 Irreversibility, Pruning, Serving
 
-Future Extension: if P2P isn't available, the JAM-native fallback will be exporting payloads into the Data Availability (DA) lake, allowing receivers to fetch them directly from DA segments.
+| SM trust row | Polkadot | JAM |
+|---|---|---|
+| Different trust domain | relay inclusion | **enacted in Accumulate** (Tier 0), sanctioned exceptions per §0 |
+| Same trust domain | Low-Latency v2 ack slashing | **no equivalent** — gates Tier 2 (§7.3, OQ 5) |
+| Same super-chain | co-authored super-block | **co-packaged work package** or enactment group (§12) |
 
-### 2.2 The Discovery Mechanism
+Prune payloads below watermark `W` once the receiver block asserting `W` is irreversible
+per the row above (at MVP **enacted**).
 
-JAM doesn't have a DHT, meaning we lose Polkadot's "Bootnodes on DHT" feature. To allow parachains to find each other and fetch messages, the parachain service introduces an authorship-derived bootnode ring.
+Material for §1.6-frozen channels is retained until reconciliation (it's the evidence).
+Serving oblication by the archive node side:
+- extension proofs from any block boundary in the last **25 h**
+- payloads for every stream under any root in the last `W` ring entries
+- anchor window at Tier 0
 
-Collators will attach a publicly reachable `Multiaddr` to their work items. The refine wrapper forwards this to Accumulate, which rotates it into a `recent_collator_addr`s` map for accepted candidates. The receiving parachain uses this ring to bootstrap the DHT and fetch payloads directly.
+## 4. Execution: End to End
 
-```rust
-pub const MAX_COLLATOR_ADDR_RING: u32 = 20;
-struct CollatorAddrRing(
-    BoundedVec<(Timeslot, CollatorKeyHash, Multiaddr), MAX_COLLATOR_ADDR_RING>
-);
+1. **A:** runtime appends outbound messages to per-destination stream MMRs
 
-/// Discovery anchor, keyed under tag 0x09.
-recent_collator_addrs: Map<ParaId, CollatorAddrRing>
-```
+   - Output: one `StreamsRoot`; the same computation feeds the header digest and `set_provides_root`
+   (guest-asserted identical).
+   
+   - PVF `export()`s payloads and node-side archives them. Wrapper emits
+   `spec_msg_provides: Some(root)` — once per bundle for the final block.
 
-**Extrinsic Payload**
+2. **JAM:** report guaranteed -> available -> accumulated
+    -  step 6 writes `cell[A]` (and from Tier 1b pushes `ring[A]`).
 
-The [work item](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#32-work-items) is naturally extended to carry the collator provided multiaddress:
+3. **B:** node reads `cell[A]` at recent blocks, fetches payloads (p2p exchange preffered for low latency, or DA)
 
-```rust
- struct WorkItemExtrinsics {
-        // { validation_code_hash, pov }
-        candidate: ParachainCandidate,
-        /// The serving endpoint shouldn't be the authoring node's IP,
-        /// but a bootnode into the DHT of the parachain.
-        recent_collator_addr: Option<Multiaddr>,
-  }
-```
+   - selects an anchor (best imported block where all consumed roots match, within its
+   authorizer's eligible set)
+   - authors a block consuming stream prefixes, reserving the proof envelope as `proof_size`
+   - in-core (and in the pre-submission self-check) the guest verifies state proofs against `anchor.state_root` and lifts against each source's
+   `StreamsRoot`. Calls into `report_error` with a structured payload on failure. Nothing further on-chain.
 
-During the refine step, this address is forwarded directly to the Accumulate phase via the `SpecMessagingDigest` (see 1).
+Handshakes (`open_channel`/`accept_open_channel`) and flow control port unchanged 
+(in-band, stream-ordered, parachain-side). **PS §8.2's open point answered: no host functions
+needed for channel management.**
 
-```rust
-struct SpecMessagingDigest {
-    provides: Option<StreamsRoot>,
-    requires: BoundedVec<(ParaId, StreamsRoot), MAX_REQUIRES_SOURCES>,
+## 5. Node Stack
 
-    /// Newly added collator address, forwarded exactly by the refine step.
-    collator_addr: Option<Multiaddr>,
-}
-```
+**Topology**, in preference order:
 
-**Service State Authoring ring**
+(1) **embedded JAM follower with state**: reads the
+cell and generates proofs locally, no third-party liveness in the critical path (MVP
+production target)
 
-To maintain recent discovery addresses, the service state implements an LRU-based authoring ring (stored as a map under discovery anchor tag `0x09`).
-- Bounded Capacity: Limited to a maximum of 20 entries per parachain (similar to DHT bootnode limits).
-- Anti-Spam: Entries are keyed by `CollatorKeyHash`. This ensures a malicious collator can only occupy a single slot in the ring.
-- Temporal Decay: Entries are timestamped. The consumer-side enforces a soft limit, ignoring addresses older than 2 hours.
-- Performance: Uses an LRU eviction policy (requiring a mem-move of a few KiB to shift the vector).
+(2) **CE 129 `StateRequest`** against a trusted node. Plausible pending
+four confirmations (ask 16): serves non-validators, 64 reads/slot/consumer load, state at
+anchor − 8 retained, hash-leaf preimages for `BootnodeRecord` (3) RPC / light-follower
+fallback.
 
+**`ProvidesSource`:** reads the cell at imported blocks — **best, not finalized**. Block
+stream, startup tip, sync gate, ring read at a recent hash, pending-provides hint (dormant
+until Tier 1a).
 
-**State Transition**
+## 6. Trust Model
 
-```rust
-// ..
-// 6. Speculative Messaging Settlement
-// 7. Head-data update: ..
-// (new) 8. Update collator ring address.
+| Property | Polkadot | JAM |
+|---|---|---|
+| Message authenticity | PVF | PVF — unchanged |
+| Root authenticity | relay consensus check | guest state proof — per-parachain enforcement (§2.4) |
+| Provides commitment | UMP signal | digest field — unchanged guarantees |
+| Stream monotonicity | not enforced | not enforced — self-harm, consumer-visible |
+| Sender-history irreversibility | governance-grade exception | Coretime-grade (§1.6) — more routine, hence reconciliation-gated |
 
-    if let Some(addr) = digest.collator_addr {
-        let author = collator_key_from_authorizer_trace(&report)
-                .unwrap_or(CollatorKeyHash::LATEST_AUTHOR);
-        recent_collator_addrs[para_id].touch(timeslot, author, addr);
-    }
-```
-
-> **Important**: The [parachain_clean_up](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#side-effect-host-functions) needs to clean up the ring.
-
-**Node side contract**
-- Addresses outside the 2-hour window are strictly ignored.
-- Address deduplication is handled defensively at dial time.
-- The consumer node is responsible for protecting itself against invalid or malicious dials.
+Polkadot capabilities: same-block A→B **deferred to Tier 1b** (free via in-order
+accumulation); atomic enactment groups, candidate cycles and super chains — **service-level
+/ handled at authoring**, see §12.
 
 
-**Storage overhead**
-- The `Multiaddr` is capped to 128B.
-- Worst-case footprint for `recent_collator_addrs` is `3360 B` at 128-B addresses
-- This gets folded into the per-parachain baseline_footprint, increasing it from `74,474` bytes to `77,834` bytes (including the provides ring).
+> **Why not JAM's `prerequisites`?**
+>
+> (1) Wrong granularity: a package hash orders, a StreamsRoot is content. The root must be carried regardless.
+>
+> (2) Report is not enactment: steps 3/5 can decline after accumulation, so compare-and-reject survives anyway.
+> 
+> (3) `J = 8` is too small and shared with Tier 3's segment lookups; fan-in targets 64.
+> 
+> (4) The 8-block reporting gate makes it strictly worse than proving enacted state.
+> Compact form:**available exactly where they buy nothing (Tier 0), unusable exactly where they'd help
+> (mutual dependencies never clear the ready queue, §7.3).
+> 
+> **Right solution at Tier 3: segment roots *are* content-addressed.**
 
+## 7. Latency Tiers
 
-## 3. Execution and Verification
+Cumulative — each tier carries everything below it.
 
-### 3.1 Receiver Verification
+| | Consumes | Requires settles | Ring | New GP deps |
+|---|---|---|---|---|
+| **T0** Accumulate | enacted roots | in-core | reserved, unwritten | none |
+| **T1a** Backed (hint) | enacted roots | in-core | reserved, unwritten | none |
+| **T1b** Backed (active) | guaranteed roots | **on-chain** | **written + read** | none |
+| **T2** Best block | announced roots | on-chain | written + read, deeper | optional prerequisites |
+| **T3** In-core import | exported segments | on-chain | written + read | **`J = 8` binds** |
 
-The child PVM has no crypto host calls, and the BLAKE2b-256 hash function runs in guest code. The `sp_io`-on-PVM guest shim provides hashing, crypto, and allocators in-guest via a target-generic `replace_implementation` mechanism.
+### T0 — Accumulate (MVP)
 
-1. The receiver fetches payload bytes and verifies them.
-2. The PVF recomputes the hash tree using BLAKE2b-256 inside the guest code.
-3. The wrapper synthesizes the `Requires` field.
-4. Accumulate matches these roots against the `RecentProvides` ring.
+HRMP latency parity (guarantee->accumulate 1–2 slots + 1–2 anchor lag).
 
-### 3.2 Lifts in PoV & Handshakes
+Implementation Delta:
+- digest field
+- host fn + `DuplicateProvidesDeclaration` 
+- step-8 budget check
+- cell `0x09` + reserved ring `0x0a`, baseline 71,514, all writes/deletes balance-neutral
+- step-6 cell write, no settlement; clean-up and recovery drop both tags
+- guest = trie path per source + lifts + digest/header assertion + structured `report_error`
+- PoV = proofs + lifts in the `proof_size` reservation, multiproof-encoded; framing slot for the anchor proof
+- node = cell reads at best blocks, embedded follower preferred, exchange + DA, KV bootnodes, telemetry from day zero. 
 
-**Lifts**
+Contingency: BLAKE2b host call (ask 10).
 
-The PoV carries lifts using the [ParachainBlockData::V3](https://github.com/paritytech/polkadot-sdk/blob/436cd3373a71f1c2251ce3976ee04220cf2646be/cumulus/primitives/core/src/parachain_block_data.rs#L88-L102) framing. Lifts are bounded at ~512 KiB worst case (64 sources * a pessimistic 8 KiB of proof material), against ~13 MB of PoV headroom on JAM.
+### T1a — Backed, prefetch hint. Zero consensus delta.
 
-The relay shaped `scheduling_proof` field rides along in V3 and is pinned `None` in the JAM.
+`pending_provides()` reads guaranteed-not-accumulated reports (needs block-body visibility,
+ask 13). Prefetch payloads, warm MMR peaks — still consume only enacted roots. Ship first,
+measure.
 
-Only 36 B per source (the digest's `(ParaId, StreamsRoot)` pair is within JAM's on-chain budget of the 48 KiB per work report). The lift proofs stay in the PoV, which is consumed in-core and never lands on-chain.
+### T1b — Backed, active
 
-**Handshake**
+**Gate: guarantee->accumulate survival >= 99% in a 2-slot window, read chain-weighted.**
 
-Channel handshakes (`open_channel` / `accept_open_channel`) port over perfectly.
+A guaranteed report can still die (availability timeout `U = 5`, step-3/5 decline).
 
-The JAM parachain service doesn't need host functions for this. It's handled entirely on the parachains side.
+- Digest: `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), N>`, **N = 16
+  provisional**, speculative subset only, unique by ParaId, wrapper-enforced via
+  `set_requires_speculative` (at-most-once). Enacted-at-anchor roots stay in-core at zero
+  cost. `N` is sized by settlement **gas**, not digest bytes — fix before the digest
+  freezes (ask 11).
+- Ring `0x0a` written at step 6 + read by the **new settlement step at the 5/6 seam**:
+  every `(src, streams_root)` must be in `ring[src]`, newest-first. Miss = reject like a parent-head
+  mismatch, log `RequiresUnmet { src, root }`, no state change. Same-block A->B needs
+  nothing (in-order processing); ordering misses just retry.
+- Guest split: enacted-at-anchor -> prove in-core; speculative -> emit to digest.
+- Node: rebuild-and-retry on `RequiresUnmet`.
 
-The same holds for flow control: registers, credit windows, all in-band and stream-ordered, riding the same streams as the data.
+**Settlement gas is the tier's real gate:** up to `N` rings × 1,537 B, newest-first, inside
+`min_item_gas` — and reports are **not replayed** after out-of-gas, so under-sizing
+silently drops *later* packages in the block (innocent paras lose slots). Size at
+worst-case fan-in; let gas bound `N` (ask 12).
 
-## 4. Node Stack
+**Economics:** a settlement miss burns B's slot *and* withholds B's own provides, so misses
+cascade — a 5-deep chain at 99% survival clears ≈ 95%. Read the gate at the depth actually
+built; consume speculatively from sources, not from speculative consumers of sources.
+Bundling immunity: 1b binds to bundle-final digests, so §1.5's intermediate hazard cannot
+occur here. Bonus: the ring ends forced lift regeneration on re-anchor (§2.3).
 
-The node side requires a new `ProvidesSource` trait to interface with the messaging pipeline. This trait must expose the following capabilities: block stream, startup tip, sync gate, ring read at a recent block hash, pending-provides hint for the guaranteed tier. 
+A must land first or B burns a slot.
 
-A newly introduced JAM `ProvidesSource` will be responsible for extracting the latest provides. It accomplishes this by reading the tag derived key `0x08 ++ SCALE(para_id)` at imported JAM blocks.
+### T2 — Best block
 
-## 5. Latency Tiers
+Consensus surface unchanged from 1b. New, node-side: `/spec-msg/announce`; off-chain block
+verification (header lineage, valid collator — needs its own definition once PS §7.1 is
+repaired, ask 9); the **header-digest read path**, correct only for **declared
+package-boundary roots** — announce carries A's intended boundary and B binds speculative
+requires only to boundary roots (§1.5); ready-queue expiry detection (OQ 3). Ring needs the
+deeper best-block `pipeline_depth` — already sized in from Tier 0, **no second migration**.
 
-The messaging architecture is designed around progressive latency tiers, establishing a robust baseline at launch while paving the way for highly optimized pipelines post MVP.
+- **Boundary violation is adversarial:** announcing a boundary then re-bundling inflicts
+  `RequiresUnmet` + a burned slot on every bound consumer, free and repeatable. Interim:
+  per-source backoff (violations are publicly observable). Systemic: the slashing design
+  (OQ 5).
+- **Optional prerequisites for ordering:** B's package declares A's hash; JAM orders A
+  first, same-block included. Caveats: report ≠ enactment (compare-and-reject stays); the
+  **8-block reporting gate binds at every stage** (never name a package reported > 8 blocks
+  ago — the report becomes unreportable; ξ's epoch depth is duplicate-rejection, not
+  eligibility); **silent expiry** (dropped from the ready queue after ≤ 1 epoch, no
+  on-chain trace — node detection, OQ 3); **no mutual prerequisites** — honest packages
+  can't encode them (the field hashes under the package hash) and fabricated reports never
+  clear the ready queue; super chains use co-packaging or one-directional prerequisites
+  (§12).
+- **The unfunded dependency:** SM's speculative tier is backed by acknowledgement slashing;
+  no JAM equivalent exists. Tier 2 cannot ship on its stated security basis until one does
+  (OQ 5) — the gating item, on no other list.
 
-**MVP**
-- Accumulate Tier: The root becomes visible in recent_provides immediately after the Accumulate step. This is functionally equivalent to the inclusion tier on Polkadot.
-- From launch, message latency will maintain parity with Polkadot's existing HRMP performance.
+### T3 — In-core import
 
-**Post MVP**
-- JAM Backed Tier: Work reports become available approximately 1–2 timeslots before the Accumulate step.
-  - Initially deployed as a prefetch hint. Once Accumulate survival rates exceed 99% within a 2-slot window, it can be shifted into active use.
+B imports A's exported segments; delivery becomes in-core and deterministic. No new
+consensus (settlement and ring still required); `import_segments()` exists; PoV shrinks;
+tight coupling to A's export timing and the DA window. **`J = 8` binds** — fan-in drops
+from 64 to 8. The only tier with a genuine `J`-bump motive; still wait for measured demand.
 
-- WIP In-Core Import Tier: Parachain B's work package explicitly declares Parachain A's exported payload segments as imports. This creates a tight coupling between B's block production and A's segment export timing and Data Availability (DA) window.
+### Decide before the baseline freezes
 
-- BestBlock Tier: Parachain B acts proactively on Parachain A's announced "best block" before any data lands on-chain (mirroring current Polkadot behavior). This tier may require the future implementation of a dedicated `/spec-msg/announce` protocol or similar.
+1. `W` at best-block depth (§1.3). 2. Ring slot reserved at Tier 0 — **yes**. 3. Land
+before first registration (ask 7). 4. Super-chain parked reserve: **opt-in delta-charged,
+never baseline** (§12).
 
+## 9. Asks on the Parachain Service
 
-## 6. Primitives
+| # | Ask | Tier | Acceptance |
+|---|---|---|---|
+| 1 | `spec_msg_provides` digest field | T0 | 33 B counted in the 48 KiB budget |
+| 2 | `set_provides_root(root)` host fn | T0 | optional, at-most-once, wrapper-enforced |
+| 3 | `RefineLog::DuplicateProvidesDeclaration` | T0 | second call fails Refine |
+| 4 | Output-size check includes the field | T0 | `RefineOutputTooLarge` accounts for it |
+| 5 | Tag `0x09` + step-6 write | T0 | written only after steps 1/3/5; balance-neutral |
+| 6 | Tag `0x0a`, reserved unwritten | T0 | baseline-charged at W = 48 |
+| 7 | Baseline 69,847 → 71,514 | T0 | **lands pre-first-registration**; fallback priced (§1.4), never preferred |
+| 8 | `parachain_clean_up` drops `0x09`/`0x0a` | T0 | reused ParaId inherits nothing; deletions refund nothing |
+| 9 | `RefineContext` doc fix | T0 | records `beefy_root`; removes fields GP lacks; flags §7.1's slot claim; constrained by ask 18 |
+| 10 | BLAKE2b-256 host call for the child PVM *(contingent)* | T0 | only if §2.6's gas gate fails |
+| 11 | `spec_msg_requires` + `set_requires_speculative` + log variant | T1b | speculative subset, unique by ParaId; `N` fixed pre-freeze, sized by gas |
+| 12 | Ring write + settlement step + `RequiresUnmet` | T1b | push iff ≠ newest, balance-neutral; check after earlier same-block step 6; gas sized at worst-case fan-in in `min_item_gas` |
+| 13 | Guarantees-extrinsic visibility (node) | T1a | `ProvidesSource` reads guaranteed-not-accumulated reports |
+| 14 | `ParachainBlockData` anchor-proof slot (ours) | T0 | V4 or V3 field; both targets; guest digest/host-call assertion, fixture-backed |
+| 15 | `parachain_set_head` deletes `0x09`/`0x0a` | T0 | recovery observable; balance-neutral; no-op at registration |
+| 16 | Confirm CE 129 serving envelope (node) | T0 | non-validator peers; load; state at anchor − 8; hash-leaf preimages |
+| 17 | Pin the DA retention period | T0 | §3.3's backstop and cold-start have a number |
+| 18 | Anchor-freedom constraint on the §7.1 repair | T0 | slot claims don't bind anchor choice (OQ 9), or §2.2 re-derived |
+| 19 | Recovery runbook: reconciliation-gated re-open | T0 | `set_head` = "resets all inbound channels"; reconcile before re-opening; consumers resume only on fresh `open_channel` |
 
-- One single crate under `cumulus/primitives/spec-messaging` (StreamId, MMR, tree, lifts, wire, fixtures) compiles for `riscv64emac-unknown-none-polkavm` in CI from the moment JAM work starts.
-- Pallets are ported directly via [cumulus on JAM plan](https://github.com/paritytech/polkadot-sdk/blob/mku-cumulus-on-jam-doc/designs/cumulus-on-jam/cumulus-on-jam.md).
+## 10. Open Questions
 
-**Migration**
+1. **PVM BLAKE2b throughput + metered gas ceiling** (§2.6) — go/no-go, fallback ask 10.
+   Highest-risk item.
+2. **`W`** at best-block depth, before the baseline freezes. Worked 48; `Compact` boundary
+   at 63.
+3. **Silent ready-queue expiry** — node-side detection + rebuild-and-retry (also covers
+   §12's S1.5). Liveness, not soundness.
+4. **ParaId reuse** — re-run SM's threat assessment against Coretime-on-JAM's id policy; a
+   stream-generation marker in the leaf preimage covers reuse, offboarding *and* recovery
+   in one mechanism and makes §1.6's re-open gate structural.
+5. **Acknowledgement/slashing on JAM** — Tier 2's trust row is empty; owner needed; the
+   §7.3 grief vector is required input.
+6. **CE 129's four confirmations** (ask 16), esp. hash-leaf preimage retrieval.
+7. **Pin the rest:** DA retention (ask 17), GP equation refs for key derivation and report
+   checks.
+8. **Settlement gas at worst-case fan-in** — sizes `min_item_gas` and `N` (asks 11, 12);
+   before Tier 1b.
+9. **Authorizer anchor policy** (ask 18) — resolve with, not after, ask 9's §7.1 repair.
 
-- No migration to tackle on JAM, implementation lands from day zero. The XCM router is simply `SpecMsgRouter` without HRMP part.
+## 12. Super Chains
 
-### Open Questions
-- PVM blake2b throughput needs benchmarks. Fallback is coordinated via leaf version
-- DA segment for messages vs P2P only for recovering messages for MVP
-- `MAX_REQUIRES_SOURCES` bounded at 64, needs more data for a bump
-- Exposed JAM `ProvidesSource` unverified
+A superchain pair consumes each other's speculative output every step (A consumes B
+same-step; B consumes an earlier A block), all lifts valid by construction.
 
+The validated ladder:
+
+- **S0 — Fusion** *(the plan)*: both candidates as work items of one package on one core —
+  one report, one invocation, availability atomic. Needs one service-level group-enactment
+  rule (any member fails means decline all). Zero JAM changes.
+  
+  This is §0's second sanctioned exception.
+
+- **S1.5 — Ordered pair**: two cores; B declares a one-directional prerequisite on A, A
+  imports B's exports via a `Direct` segment root.
+  
+  Zero changes; only "A enacted, B missing" remains.
+
+- **S1 — Asymmetric parking**: closes that residual service-side (opt-in delta-charged
+  record, never baseline). Zero JAM changes.
+- **S2 — GP package groups**: format-breaking; gated on measured demand (fusion overflow ∧
+  parking pain ∧ burn cost).
+
+The fixpoint dies at authoring (fixed intra-superstep order); mutual same-step consumption
+is a two-phase-collation STF profile, not an impossibility.

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -113,7 +113,7 @@ settlement check reads A's root before the update and B is rejected.
 
 - **Tier 0: Enacted (Safe Baseline MVP)**:
   - consume enacted roots with HRMP parity. The requires entry carries `(ParaId, StreamsRoot)` and settlement checks the root against the ring
-  - latency: 1 or 2 slots from guarantee to accumulate, plus 1 or 2 for anchor lag (between 12 and 24+ seconds)
+  - latency: 1 or 2 slots from guarantee to accumulate, plus receiver build and submission time (between 12 and 24+ seconds)
   - optimization: node-side fetches `StreamsRoot` from guanranteed but not yet accumulated reports
   - race condition: structurally impossible since `A` is already enacted. The only remaining risk is not matching the `Provides`
     against the `W` settlement ring size.
@@ -166,7 +166,7 @@ The payloads are immediately fetched from p2p layer and verified locally. The re
 The `B` package is submitted once count assurance bits for A's core are near 2/3. This gives a higher chance for `A`'s report
 to Accumulate within 1-2 slot delay until `B` accumulates.
 
-- If `A` dies before `B` package is submitted, then `B` reanchors against T0 latest enacted root without burning the slot
+- If `A` dies before `B` package is submitted, then `B` rebuilds against the latest T0 enacted root without burning the slot
 - If `A` dies after `B` package is submitted, then `B` burns the slot and `B` rebuilds against T0
 - If `B`'s head doesn't advance after its package accumulates, then `B` burns the slot and conservatively rebuilds against T0
 
@@ -265,8 +265,8 @@ Parachain A talks with Parachain B:
 **Pruning**
 
 A sender may prune payloads below a watermark once the receiver block acknowledges it.
-Archives serve extension proofs from any block boundary within the last 25h. Since any enacted root is provable regardless of age,
-the payload serving horizon is archive policy rather than a protocol window.
+Archives serve extension proofs from any block boundary within the last 25h. The payload serving
+horizon is archive policy, while settlement remains limited to roots still present in the ring.
 
 ## Forced Recovery
 
@@ -291,9 +291,9 @@ The delivered messages stand and the re-delivered overlap after the restart. Bef
 must communicate: what was delivered under the abandoned roots and compensate or it becomes an inflation source
 for the counterparties.
 
-> Note: abandoned enactments stay provable forever since the output log is append-only, and a dormant
-chain's ring persists. The dead chain's last messages remain drainable at the Enacted tier as long
-as its ring stands. A `parachain_clean_up` removes the ring and ends drainability with it.
+> Note: a dormant chain's ring persists. The dead chain's last messages remain drainable at the
+Enacted tier as long as its ring stands. A `parachain_clean_up` removes the ring and ends
+drainability with it.
 
 ## 4. Execution: End to End
 
@@ -305,31 +305,27 @@ as its ring stands. A `parachain_clean_up` removes the ring and ends drainabilit
    - PVF `export()`s payloads and node-side archives them.
 
 2. **JAM:** report guaranteed -> available -> accumulated
-    - step 6 writes A's head and pushes the enacted root into `ring[A]`. The output log carries the
-      head under every later super-peak.
+    - step 6 writes A's head and pushes the enacted root into `ring[A]`.
 
 3. **B:** node follows A's enacted heads, fetches payloads (p2p exchange preferred for low latency, or DA)
 
-   - selects an anchor (best imported block, within its authorizer's eligible set — any anchor at or after
-   each source's enacting block works)
-   - authors a block consuming stream prefixes, reserving the proof envelope as `proof_size`, and names each
-   source's `(ParaId, StreamsRoot)` via `set_requires_root`
-   - in-core the wrapper walks each enactment proof from the anchor's
-   super-peak and the guest verifies lifts against each source's `StreamsRoot`. Failures abort with `RefineLog`.
+   - verifies fetched messages and their stream proofs against each source's `StreamsRoot`
+   - authors a block consuming stream prefixes and records the consumption
+   - in-core the wrapper verifies the PoV-carried lifts, stitches bundle intervals and gap proofs,
+   and synthesizes each source's `(ParaId, StreamsRoot)`. Failures abort with `RefineLog`.
    - on-chain, §5.1 step 6 checks each named root is in its source's ring, then B enacts.
 
 ## 5. Node Stack
 
 **Topology**, in preference order:
 
-(1) **embedded JAM follower with state**: follows the output log and PS head commitments,
-generates enactment proofs locally, no third-party liveness in the critical path (MVP
-production target)
+(1) **embedded JAM follower with state**: follows PS head commitments and settlement rings,
+with no third-party liveness in the critical path (MVP production target)
 
-(2) **CE 129 `StateRequest`** against a trusted node. Plausible pending
-four confirmations (ask 16): serves non-validators, 64 reads/slot/consumer load, state at
-anchor − 8 retained, hash-leaf preimages for `BootnodeRecord` (3) RPC / light-follower
-fallback.
+(2) **CE 129 `StateRequest`** against a trusted node. Plausible pending four confirmations
+(ask 16): serves non-validators, with capacity and retention requirements still to be confirmed.
+
+(3) **RPC / light-follower fallback**.
 
 **`ProvidesSource`:** reads A's enacted heads at imported blocks — **best, not finalized**. Block
 stream, startup tip, sync gate, ring read at a recent hash,
@@ -397,10 +393,10 @@ Because of how it's designed, this loop works safely on JAM.
   If A is enacted, but B fails to enact, the system won't enact A until B can enact.
   A is parked for a timeout and if B takes too long or never arrives, A is dropped as well.
 
-## Apendix
+## Appendix
 
-This sections highlights an alternative to the onchain ring settlement that is valid only
-for the Enacted tier (MVP).
+This appendix records an unscoped alternative to on-chain ring settlement. It applies only
+to the Enacted tier and is not part of the MVP or the design above.
 
 ### Alternative Verification
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -199,6 +199,12 @@ A candidate that passes every check except settlement (ie, `Provides` entry
 is not yet in the ring) is rejected today. The slot is burned and the work must be redone.
 Buffering stores the work digest and applies it later, once the root arrives.
 
+> Note: #11883 §5.1's rejection path mentiones that "a candidate rejected at any
+> step changes nothing at all". A candidate that fails only settlement will be buffered.
+> The exposure is bounded by `MAX_BUFFERED_BYTES` and billed to the para balance at §6.1 rates.
+> A digest carries up to 4 KiB `head_data` plus the 40 KiB upward-message budget,
+> so `MAX_CHAIN_SIZE (16) * MAX_FORKS (2)` digests would be ~1.4 MiB per parachain.
+
 The first buffered entry must target the parachain's enacted head and all other
 entries must form a valid chain. We allow a maximum of two fork lanes. If a collator wants to abandon a branch,
 they can offer a competing one immediately without waiting for the first to expire.
@@ -217,28 +223,45 @@ A chain front entry that is older than `buffered_at + K slots` is dropped when t
 is accumulated. Buffered bytes are billed to the para's balance and are capped at `MAX_BUFFERED_BYTES` per parachain.
 An entry is never replaced or refreshed.
 
-Buffering never holds up the canonical chain. An entry is never replaced or refreshed.
+Buffering never holds up the canonical chain.
 
 **Gas Model**
 
 The buffer walk happens before the new work item that brought the gas, but it can only spend the leftover
 gas that the item doesn't need for itself. Collators need to pad the work item to cover this walk.
-Because the buffer is in consensus state, they can read the exact cost at their anchor and fund it perfectly.
-If the gas only covers part of the buffer, the walk settles what i can and pauses. Nothing is destroyed,
+
+> Note: JAM combines all the Accumulate gas for a service's work items into one total
+> for the block. To charge this walk to a single item, we need a way to track individual
+> gas usage inside that total pool. This is the same attribution problem flagged in #11883 §5.1
+> for deferred `TransferOut` gas. The walk has to stay within the limit set by the item paying
+> for it, so it will depend on how we solve attribution there.
+
+Because the buffer is in consensus state, collators can read the walk's cost at their anchor.
+The anchor is up to `C_H = 8` slots stale and the buffer can move in between, so this is an
+estimate to over-provision against, not an exact figure.
+
+If the gas only covers part of the buffer, the walk settles what it can and pauses. Nothing is destroyed,
 and the remainder waits for the next item.
 After the walk, the new item is processed. It is either applied directly if it sits on the enacted head, or
 buffered as a chain extension if it builds on the tip.
 Ultimately, an under gassed item will never cause the buffer to be dropped, and the buffer walk will never starve the item that paid for it.
 
 Parachains can also push the buffer forward without submitting a new candidate. A settlement-only package carries
-no work digest and no parent head. Because it has no parent head, it can't fail the parent-head check,
+no work digest and no parent head, so no check tied to a candidate can reject it,
 guaranteeing it reaches the walk phase and delivers gas.
 
-Like normal work items, they are autorizer-gated produced by active collators . They require a core slot, refine gas and the
-walk's declared gas (which is cheeper than rebuilding).
+`SettleOnly` is a new kind of payload that doesn't include a candidate body. Refine skips the PVF completely,
+forgets about head declarations, and just hands back `RefineOutput::SettleOnly`. Once it hits Accumulate,
+the system sees what it is and sends it straight to the buffer walk. It bypasses all the usual candidate checks.
+
+> Note: #11883 needs adjusting around:
+> - §4.1 runs the PVF no matter what, so Refine needs that early exit.
+> - §4.2 insists on set_parent_head_hash and set_head every single time.
+> - §3.2 assumes every work item is a full parachain candidate.
+
 
 ```rust
-/// Refine output handled to Accumulate.
+/// Refine output handed to Accumulate.
 enum RefineOutput {
     /// Full work digest.
     Candidate(ParachainWorkDigest),
@@ -307,8 +330,8 @@ newly available reports, plus ready-queue releases). If sender A and consumer B 
 but B's digest comes first, B's `Requires` check misses the ring and the digest is buffered, costing
 a slot of latency.
 
-To ensure we are not relying on JAM provided order, PS reorders the blocks's digest.
-The solution is to build a depedency graph based on the speculative `Provides` and `Requires`.
+To ensure we are not relying on JAM provided order, PS reorders the block's digests.
+The solution is to build a dependency graph based on the speculative `Provides` and `Requires`.
 
 If B's `spec_msg_requires` contains `(A, root)` and A's `spec_msg_provides` is `Some(root)`, add an
 edge from `A -> B`. The source `ParaId` selects A and root equality confirms the dependency. For a para

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -70,7 +70,6 @@ oldest entry beyond `W`.
 If a package `Requires` is not in the ring, that slot is lost. On polkadot, a stale candidate
 can retry for free. On JAM, each retry costs another slot.
 
-
 A forced `parachain_set_head` that overwrites a live head will also clear the ring.
 
 ```rust
@@ -87,6 +86,9 @@ the candidate will enact. Every requires entry source must exist and the named r
 The candidate is rejected silently and the receiver `B` monitors offchain this behaviour, similar to
 `parent-head` or `check-code` failures. Otherwise, letting rejected candidates append `AccumulateLogs` would let junk
 candidates push out valuable entries.
+
+ Before processing a digest, PS charges its worst-case ring-read cost against that item’s declared accumulation gas. The
+ `W` should be reasonable bounded and the scan reads the newest entries first stopping on the first match.
 
 > Note: A forced rollback (`ParachainSetHead` from the Coretime chain) isn't applied instantly. Its an upward message,
 replayed at step 7 when the Coretime chain's own package accumulates. Packages accumulate in order within a block,
@@ -331,13 +333,15 @@ pending-provides hint (dormant until Prefetch mode).
 
 ## 10. Open Questions
 
-1. **`W`** at best-block depth
+1. **W at the Enacted pipeline**
   The ring is live and read by settlement from day 0, so `W` must be fixed before launch.
-  It must be sized for the Announced (best-block) pipeline — announce to enact — not the Guaranteed one, since
-  the higher tiers reuse the same ring without a consensus change.
+  It must exceed the maximum number of distinct roots a sender can enact between the receiver
+  selected a root and the accumulation phase (including elastic scaling). A sender using k cores
+  may advance the ring up to k times per JAM block.
 
-  Since we read the read for settlement, we can read up to 64 candidates * `W` * 32 bytes each.
-  Then if `W` is 128, the Accumulation step might run out of gas and silently drop later packages.
+  Since we read the read for settlement, we can read up to `(num digests) * (64 candidates) * W * 32 B`.
+  With hundreads of digets per block, that could reach 10+ MiB of reads.
+  Then the Accumulation step might run out of gas and silently drop later packages.
 
 2. **Silent ready-queue expiry**
   If B declares a prerequisite on A and A never accumulates, B's report is dropped

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -1,295 +1,163 @@
 # Speculative Messaging on JAM
 
-The [Parachain Service](../designs/parachain-service-on-jam/parachain-service-on-jam.md#3-the-parachain-service)
-needs a messaging system to replace HRMP-style payloads;
-[Speculative Messaging](https://github.com/paritytech/polkadot-sdk/blob/9d0a0daee40e6e350209aaf4b3e3bdf1fb9a8793/docs/speculative-messaging-design.md)
-is the candidate. This document is the protocol spec: consensus delta, verification,
-transport, tiers, asks.
+ 
+The [Parachain Service](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#3-the-parachain-service) needs a robust messaging system to replace the older HRMP-style payloads, and [Speculative Messaging](https://github.com/paritytech/polkadot-sdk/blob/9d0a0daee40e6e350209aaf4b3e3bdf1fb9a8793/docs/speculative-messaging-design.md) is our primary candidate for JAM.
 
-**Normativity:** the PS design is normative for the service delta (digest fields, tags,
-accumulate steps, host functions); this document for the protocol. One home per constant.
+Here is a breakdown of exactly what needs to change to make Speculative Messaging work smoothly on JAM, ensuring every Polkadot feature has a clear, explicit JAM backport.
 
-Pinned against PolkaJAM `84f86225a704` (GP 0.7.x): `W_B = 13,791,360`, report budget 48 KiB,
-`H = 8`, `U = 5`, `E = 600`, `max_refine_gas = 5×10⁹`, `max_exports = 3,072`, segment
-4,104 B. Open: DA retention period (ask 17), GP equation refs.
+## Core Idea
 
-## 0. Design Summary
+> For MVP, if a root has already been enacted by B's anchor, B can simply prove it locally. 
+> The chain never needs to be involved, meaning **no on-chain settlement step is required**.
 
-> **If a root was already enacted by B's anchor, B just proves it and the chain never hears
-> about it.** (ie no settlement needed)
->
-> B picks a recent JAM block as its anchor and ships a Merkle proof in its PoV:
-> "in the state *after* this block executed, A's cell holds `StreamsRootA`." 
-> Validators check that in-core. A root not yet enacted at the anchor cannot be
-> proven this way and has to be checked on-chain instead.
->
-> The latency tiers decide when to use the in-core cell proof or the settlement ring.
+B selects a recent JAM block to act as anchor, and includes a Merkle Proof in its PoV. 
+The PoV proof attests that A's cell holds `StreamsRootA`. Validators then verify this in-core.
 
-This is safe because JAM only accepts B's report if the anchor is an ancestor of the block that
-accumulates it (it must be in `β`), and enacted state never un-happens along a fork. So, whatever B
-proved at the anchor is still true when B lands.
+If the root wasn't enacted at the anchor, it cannot be proven and must be verified on-chain instead.
+Ultimately, the system latency tiers dictate when to use this lightweight in-core proof or
+fallback to the settlement ring.
 
-Two exceptions: forced recovery (§1.6) and co-packaged sibling roots (§12). And when a root *does* have to
-be checked on-chain (Tier 1b+), Accumulate needs something on-chain to check it against (settlement ring).
+## Changes at Accumulation Tier MVP
 
-MVP delta: `set_provides_root` + digest field (33 B), provides cell (81 balance units),
-ring slot reserved-not-written (1,586). **No settlement step, no requires field, no
-`yield`.** Baseline bumped: 69,847 → **71,514**.
+We are releasing SpecMsg with Accumulation Tier (HRMP parity) from day 0. The changes needed:
 
-## 1. Consensus and State Changes
+1. Digest fields: `spec_msg_provides: Option<StreamsRoot>` on the PS work digest.
 
-### 1.1 The Provides Digest Field
+The field is set via `set_provides_root` at most once per `Refine` and needs 33 bytes out of the 48 KiB report budget.
+This must be a digest field and not UpwardMessage, because UMP replays after the head write (so it can't gate enactment).
 
-Only **provides** reaches consensus at MVP:
-
-```rust
-enum ParachainWorkDigest {
-    Ok {
-        // .. existing fields
-        /// Set via `set_provides_root`. `None` = root unchanged.
-        spec_msg_provides: Option<StreamsRoot>,
-    }
-}
-```
-
-- `set_provides_root(root)`: optional host call, at-most-once per Refine, wrapper-enforced. Second
-  call fails with `RefineLog::DuplicateProvidesDeclaration`.
-- **Bundled PoVs:** called once per bundle, with the **final** inner block's root (the
-  guest aggregates). Sound because stream MMRs are append-only and the final root commits to
-  every inner block's messages.
-- **Normative rule:** the `set_provides_root` value and the final inner block's header
-  digest (`DigestItem::Consensus(SPMS_ENGINE_ID, root)`) are one computation,
-  byte-identical. This is guest-asserted by aborting Refine on mismatch. A wrong but internally
-  consistent root is unenforceable self harm.
-- 33 B against the 48 KiB report budget; PS §4.1 step 8's size check must include it.
-- `ParachainWorkDigest` field, not an `UpwardMessage` since UMP replays after the step-6 head write, so it
-  cannot gate enactment.
-
-### 1.2 The Provides Cell
-
-```rust
-/// Keyed `0x09 ++ SCALE(para_id)`.
-/// - ParaId as fixed 4-byte LE u32, NOT Compact.
-/// - Absent means never sent or force-recovered or not re-enacted or offboarded (OQ 4).
-/// Written only by Accumulate, on enactment (PS §5.1 step 6).
-spec_msg_provides: Map<ParaId, StreamsRoot>
-```
-
-Step 6 runs after the registration/parent-head/code checks and a rejected candidate never
-moves the cell. `parachain_clean_up` drops it.
-
-- **Why a bare 32-byte value:** values <= 32 bytes are placed in the JAM trie leaf, so the proof is a
-  pure Merkle path, no preimage.
-  Costs 81 units vs +33 in `ParaInfo`, but saves ~4 KiB of proof per source per block.
-
-- Accumulate writes whatever the digest carries, JAM will not verify MMR extension. This means
-  that consumers are protected against forged messages, **not against a source rolling back its own stream**.
+The same `StreamsRoot` value must be byte-identical to the header digest (`DigestItem::Consensus(SPMS_ENGINE_ID, root)`).
+For bundled PoVs, the call is made once with the final inner block's root. This is valid since MMRs are append-only.
 
 
-### 1.3 The Settlement Ring — reserved at MVP, written from Tier 1b
+2. A provides cell: one 32 byte value per parachain keyed at `0x09 ++ para_id`. 
+
+The cell is written only by Accumulate on enactment. Since it's 32 bytes it fits directly into a JAM trie leaf,
+so proving it is a pure Merkle path without a preimage, saving ~4KiB of proof per source per block vs a field inside
+`ParaInfo`. The cell's storage footprint is 81 balance units (vs +33 for the in-`ParaInfo` placement). The proof size
+wins over the 48 units.
+
+Note: Accumulate writes what the digest carries without verifying the MMR extensions. Consumers are protected against
+forged messages, not against a source rolling back its stream.
+
+
+3. Settlement ring: The last `W` enacted roots per para keyed at `0x0a ++ para_id`. This is reserved only and priced from
+day 0, but not written until Tier 1b.
+
+Sized at `W = 48` (derived from `3 elastic cores * (8 slot eviction window + 8 slot pipeline depth)`). This number must be
+fixed before baseline freezes.
 
 ```rust
 /// Keyed `0x0a ++ SCALE(para_id)`.
 /// 
 /// From Tier 1b: step 6 pushes the enacted root iff != newest entry, evicts oldest.
-/// Read only by settlement (§7.2). NEVER Merkle-proved — so width costs nothing in proof size.
+/// Read only by settlement, never proved.
 spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>
 ```
 
-| | Cell (`0x09`) | Ring (`0x0a`) |
-|---|---|---|
-| Consumer | in-core verifier (guest) | Accumulate settlement |
-| Access | Merkle proof in PoV | Direct state read |
-| Size | <= 32 B hard | unconstrained |
-| Live at | every tier | Tier 1b+ |
+The baseline footprint goes from 69,847 to 71,514 balance units. Every write and delete is balance neutral. All of this has to land before
+the first parachain registers to avoid a live migration.
 
-**Sizing:** `W = max_elastic_cores * (eviction_window + pipeline_depth)`.
-The core rate multiplies the whole exposure span. For 3 cores, 3 * (8 + 8) = **48**. Choose at *best-block*
-depth before the baseline freezes.
+> Note: Only the PoV bundle final root reaches the cell and the ring. Intermediate roots stay in headers and can never be settled on chain.
 
-`Compact(W)` is 1 byte only for W <= 63.
 
-### 1.4 Baseline Footprint
+Deferred changes:
+- Digest field `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), N>` where `N = 64` consumed changes
+- `set_requires_root` host call to set the `spec_msg_requires`
 
-PS §6.1 prices an entry at `44 + |value| + |key|` — **balance units, not bytes**:
-cell = 44 + 32 + 5 = **81**; ring at W = 48 = 44 + 1,537 + 5 = **1,586**;
-baseline bumps 69,847 to **71,514**.
+## Speculation Tiers
 
-Both are baseline-covered: writes take no balance check ("the write cannot fail"), 
-and **deletions refund nothing**, unlike `kv_remove`, the deletes in `parachain_clean_up`
-and `parachain_set_head` must not touch `used_state_balance`, or PS §6.4's exact-equality check bricks every deregistration.
+- **T0 Accumulate / Consume enacted roots (MVP)**: Parity with HRMP
+  - 1 or 2 slots from guarantee to accumulate, plus 1 or 2 for anchor lag
+  - no settlement and no requires field, verification happens with merkle proof in PoV and guest code
 
-**Land before the first parachain registers (ask 7) — plan of record.** Any later `BASELINE_FOOTPRINT` change is a live migration.
+- **T1a Backed / PrefetchHint**: prefetch on backed with zero consensus change.
+  - node reads guaranteed but not yet accumulated reports to warm cache
+  - still consumes T0 enacted roots
 
-### 1.5 Bundling and Granularity
+- **T1b Backed / Active**
+  - saves 1 or 2 slots
+  - needs a new digest field `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), N>`
+  - settlement ring gets active and settlement step consumes gas (N must be sized for gas limits)
+  - `A` guaranteed report can die and `B` burns its slot (ie `A` must land first or `B` burns a slot)
+  - Same block `A -> B` is possible since Accumulation happens in order and A's cell write lands before B's settlement runs.
 
-Provides is per block semantically, per work package in consensus. A bundle declares the
-**final** root and intermediates stay in their headers. Consequences:
+- **T2 Best Block**
+  - saves 2 to 4 slots
+  - needs offchain announce protocol, offchain verification and header-digest read path for package boundary roots
+  - Announcing a boundary then rebundling is adversarial resulting in `RequiresUnmet` and burned slot, which needs slashing to solve
+  - Recommended: high-fan-in consumption (64 sources like every tier up to here) at the lowest latency; T3 matches
+    the latency but caps fan-in at 8. Needs LLv2 ACK/Slashing on JAM
+  - Optional `prerequisites` for ordering: B's package declares A's hash. `J = 8` caps prerequisites plus segment
+    lookups per report, not consumed sources, so fan-in stays at 64. The 64 to 8 drop only happens at Tier 3.
+  - Work package hash is distributed via `/spec-msg/announce` notification protocol.
 
-- Event streams coarsen to the bundle (serving obligation, §3.3).
-- A bundling receiver merges per-block requires into one set.
-- **Bundle-intermediate roots are unsettleable at every tier**: only the digest root
-  reaches cell and ring. Tier 1b is immune (binds to bundle-final digests by construction);
-  Tier 2 must bind only to declared package-boundary roots (§7.3).
+- **T3 InCore Tier**
+  - B imports A's exported segment
+  - delivery becomes in-core and deterministic with `import_segments()`
+  - we drop the maximum communication sources from 64 to 8 (`J` constant), but keep the same latency as *T2 Best Block*
+  - Recommended: low-fan-in (8 consumed sources), latency critical (parity with T2) and segment import is straightforward without LLv2 ACK/Slashing
 
-Cycles: never between blocks (SpecMsg's invariant), never at Tier 0 (only enacted roots
-consumable).
+- **T4 SuperChains**
+  - Both A and B candidates are bundled in the same package
+  - Needs a PS service rule that if any member fails the whole group is declined.
 
-From Tier 1b, mutual requires between co-arriving candidates are handled by co-packaging or
-enactment groups (and not by mutual **prerequisites** (§12)). This means that no 
-viratual window is needed. The Accumulate processes packages in order and step 6 writes before
-the next package's setlement runs. Therefore, we can achive same-block A->B communication and
-ordering (one-directional prerequisite as Tier 2).
+## Verification
 
-### 1.6 Forced Recovery
+B's PoV carries per consumed source a Merkle proof of the `0x09` cell at the anchor. This is verified in guest code
+(ie `validate_block`) against the anchor's state root which the child PVM reads from `work_package_context()`.
 
-`parachain_set_head` (PS §6.3) **rolls back enacted history**. Two costs:
+**State key derivation**
 
-1. **Channel desync (liveness):** A's next root won't extend the old one; every consumer
-   stalls.
-2. **Economic divergence (safety):** deliveries from rolled-back enacted blocks are
-   irreversible. A burns X, emits "mint X", enacts, B delivers, recovery abandons the
-   block: re-executed txs double-mint, non-re-executed leave an unbacked mint. **B's supply
-   is permanently inflated**; no messaging-layer mechanism can undo it.
+The guest computes the cell's 31 byte state key itself. A mismatch results in a silent failure, therefore the construction matters:
 
-Handling:
+1. `h = BLAKE2b-256(0xffffffff ++ storage_key)`. The 4 byte domain prefix marks storage values
 
-- **Service:** `parachain_set_head` also deletes `0x09`/`0x0a` (balance-neutral) and recovery
-  becomes observable via the absent cell.
-  Consequence: **any mid-life `set_head` is channel-severing by construction**.
-  Coretime runbooks must treat it as "reset all inbound channels" (ask 19). No-op at registration-time use.
+2. Bytes 0-7 of the state key interleave the service id's little-endian bytes with the hash
+(ie `[id0, h0, id1, h1, id2, h2, id3, h3]`), bytes 8-30 are `h[4..27]` taken linearly.
+The interleave covers only the first eight bytes.
 
-- **Consumer:** on cell deletion or non-extending root will freeze the channel, discard
-  prefetched material. Resume **only** on a fresh `open_channel`, resetting the inbound
-  frontier to the new stream state. The re-delivered overlap is genuinely new messages
-  (Cost 2's residue), not a dedup bug. Delivered messages stand.
+Two inputs the guest must source correctly:
+- The PS service id is read from `work_items_summary()`
+- The storage key is `0x09` followed by the ParaId as a fixed 4 byte little-endian u32, not `Compact`.
 
-- **Sender (reconciliation gate, ask 19):** before reopening, enumerate messages delivered
-  under abandoned roots (archive/DA) and compensate — suppress re-emission or account the
-  drift. Skipping this makes the para an inflation source for its counterparties.
+Then the message Lifts verify against the root as on Polkadot. This means that root authenticity is now enforced by
+parachain guest code rather than consensus. A buggy runtime can disable the inbound authentication with no chain evidence.
+The alternative is to introduce the requires field settlement at every tier.
 
-**In-flight tail, accepted and bounded:** packages anchored pre-deletion still deliver
-abandoned-branch messages for up to 8 slots + accumulation lag.
+The settlement only replaces the recent root proof, not message verification. Since message verification is done by Lifts
+which verifies against `StreamRoot` by the guest in-core, a buggy guest that skips lift verification is equally broken.
 
-At Tier 1b+ in-flight settlements naming the deleted ring burn those consumers' slots.
-Robust form: a stream-generation marker in the leaf preimage (OQ 4) covers recovery,
-offboarding and ParaId reuse in one mechanism.
+The anchor must be matched against the last 8 JAM blocks at guarantee time. The 6s slots needs roughly 3-4 slots out of the
+8 for state root lag, building, distribution and inclusion. This leaves approximately 4-5 slots to match against. Missing the
+window means the re-anchoring swaps the proof envelope, not the block. Since MMR peaks are prefetched, lift generation also
+remains local. This needs to take into account AURA authorizer which makes the anchor double as the slot claim, which could 
+shrink the collator window from 8 to its own rotation run.
 
-## 2. In-Core Verification of Requires
+PoV cost is about 4KiB per touched stream plus ~2KiB per source proof. A case of 128 streams and 64 sources consumes ~640KiB
+out of the ~13MiB budget.
 
-### 2.1 State Proofs Against the Anchor
+> Unknown: The verification gas is unknown. Verification adds ~1700 blake2 calls inside Refine under a 5 * 10^9 ceiling.
+> This needs to be properly measured and the fallback is a blake2b-256 host call for the child PVM.
 
-B's PoV carries, per consumed source A with root `StreamsRootA`, a Merkle proof that
-`0x09 ++ SCALE(A) = StreamsRootA` at B's anchor which is verified in-core against
-`RefineContext.anchor.state_root` (fetched by the child PVM via
-`work_package_context()`, no wrapper involvement).
-Then Lifts are verified against `StreamsRootA` as on Polkadot. Nothing reaches Accumulate.
 
-**State-key derivation** (a mismatch is a silent, total failure, §8):
+## Transport and Discovery
 
-1. `h = BLAKE2b-256( 0xffffffff ++ storage_key )`.
-2. 31-byte key: bytes 0–7 interleave service-id LE bytes with the hash
-   `[id₀,h₀,id₁,h₁,id₂,h₂,id₃,h₃]`; bytes 8–30 = `h[4..27]`.
+We have 2 delivery paths for messages:
+- Primary offchain req-resp protocol `/spec-msg/exchange` which holds the messages in a node side archive. This outlives the DA window and gives unbounded catch-up.
+- Secondary via PVF exports of payloads to DA as framed segments.
 
-The guest reads the service id from `work_items_summary()`, never hardcoded. The anchor
-state-root is part of the package — deterministic for every guarantor. `RefineContext` has
-**no anchor timeslot**, so no in-core freshness policy is expressible.
+Since segments cannot be exported retroactively, the DA exports are used since day 0. This offers a bootnode agnostic fallback to fetch messages and
+Tier 3 (in-core tier) relies on the segments. 64 KiB of messages per block would cost 0.6% of the budget.
+The actual cost is erasure-coding bandwidth across validators.
 
-### 2.2 The Anchor Budget
+**Discovery**
 
-The anchor must be within the last **8** JAM blocks (`H`) at guarantee inclusion.
-
-- **Anchor on the best imported block, not finalized.** A dropped fork fails closed
-  (rebuild) — the exposure every work package has. Finality gates delivery confidence and
-  pruning instead (§3.3).
-- Budget at 6 s slots: state-root lag 1 (headers carry the *prior* root — freshest anchor
-  is **tip − 1**), build < 1, distribution 1–2, inclusion 1 → **3–4 of 8 used**, 4–5
-  reserve.
-- **The anchor is double-booked (ask 18).** PS §7.1's AURA authorizer makes the anchor the
-  slot claim, shrinking a collator's eligible anchors from 8 to its own rotation run —
-  degrading the reserve, the envelope cache, and re-anchoring locality.
-  
-  Either authorizers for message-consuming paras claim slots without binding anchor choice (OQ 9), or this
-  budget is re-derived at the constrained count. The unstated interaction is the only
-  unacceptable outcome.
-
-### 2.3 Re-anchoring
-
-Missing the window is cheap:
-- 1. Re-anchoring swaps the ~KiB proof envelope, never the block
-- 2. MMR peaks are prefetched continuously, so regenerating lifts is local
-- 3. keep a small cache of envelopes against recent eligible anchors.
-
-From Tier 1b the ring lets B name an older root against a newer anchor, ending forced lift regeneration.
-
-### 2.4 Verification Lives in Guest Code
-
-The proof rides the PoV in the `ParachainBlockData` framing and is verified
-via `validate_block` in cumulus guest code — **the framing needs a slot for the anchor
-proof** (V4 or a V3 field, same code for both targets, ask 14).
-
-The wrapper's requires-related delta is **zero**. All hashing is BLAKE2b-256 (state trie and message
-trees); the existing `sp_io`-on-PVM shim covers it — subject to §2.6.
-
-This implies a trust cost: root authenticity moves from a relay-consensus check to per-parachain guest code.
-A buggy runtime can disable inbound authentication with no on-chain evidence. The alternative is a
-requires field with a settlement at every tier.
-
-### 2.5 Budgets and PoV Reservation
-
-The bound is on **touched streams**, not sources (~4 KiB per touched stream worst case
-+ ~2 KiB per read-context gap; one source = many streams). Reserve in the STF as
-`proof_size`:
-
-```
-pov_reserve = Σ_touched_streams (4 KiB + gaps × 2 KiB)   # lifts
-            + Σ_consumed_sources (2 KiB)                 # state proofs (additive)
-```
-
-Aproximation: 128 streams + 64 sources = 640 KiB, well inside `W_B` ~13.15 MiB.
-A single-key proof is `32 * depth + 64` ~ 0.7–1 KiB; 2 KiB is conservative.
-Depth tracks *total* JAM state. Encode the 64 paths as a **multiproof** (~20% saving).
-
-`MAX_REQUIRES_SOURCES = 64` and `MAX_TOUCHED_STREAMS` are **guest-side, advisory at
-Tier 0** (requires is off-chain and nothing checks them).
-
-From Tier 1b the speculative subset is wrapper-bounded by `N` (§7.2).
-On-chain cost of requires at Tier 0: **zero bytes**.
-
-### 2.6 Gas — the highest-risk unknown
-
-Refine gas is a hard consensus limit. The design adds ~1,700 BLAKE2b invocations (64 paths
-× 20–30 compressions) plus lift verification, on an unmeasured transpilation baseline.
-
-Three gates: throughput (informs core time), **metered ceiling (go/no-go, before spec
-freeze**, denominator `max_refine_gas = 5×10⁹`), and accumulate settlement gas (before
-Tier 1b, §7.2).
-
-**Fallback: a BLAKE2b-256 host call for the child PVM (ask 10)**.
-
-## 3. Transport and Discovery
-
-### 3.1 Transport — dual, DA default-on
-
-- **Primary:** `/spec-msg/exchange` request-response for low latency. The payloads are retained in the sender's
-  node-side archive per §3.3 (outlives DA windows with unbounded catch-up).
-
-- **DA export, default-on:** the PVF `export()`s outbound payloads as framed segments.
-  Segments **cannot be retro-exported**, so deferring DA is irreversible for every block
-  produced meanwhile. Enabling unneeded DA is cheap. Also the zero-discovery fallback and
-  the cold-start path (signal leaves + register events in segment framing means no pre-existing
-  channel needed). Tier 3 requires it outright.
-
-- Cost: a 64 KiB/block para uses 17 segments ~ 0.6% of the export budget; the real cost is
-  erasure-coding bandwidth across the validator set (needs double checking before we decide to go with p2p only).
-
-### 3.2 Discovery — parachain-managed KV bootnodes
-
-JAM state keys are hashed and non-enumerable, so the key must be well-known. The para's
-runtime maintains its list in the existing KV store (tag `0x07`):
+For bootnode discovery, each parachain publishes its bootnodes under a well-known key in the existing KV store.
+The para's runtime maintains its list in the existing KV store (tag `0x08`):
 
 ```rust
-/// Full storage key: 0x07 ++ SCALE((para_id, SPEC_MSG_BOOTNODES_KEY)).
+/// Full storage key: 0x08 ++ SCALE((para_id, SPEC_MSG_BOOTNODES_KEY)).
 const SPEC_MSG_BOOTNODES_KEY: &[u8] = b"spec-msg/bootnodes/v1";
 
 struct BootnodeRecord {
@@ -300,28 +168,48 @@ struct BootnodeRecord {
 }
 ```
 
-Requires no changes for Parachain Service. The parachain must handle rotation and anti-spam policies.
-Note: KV writes are charged and skipped on **insufficient balance**. This is accepted since we
-have DA as independent path to fetch messsages.
+> Note: KV writes are charged and skipped on **insufficient balance**. This is accepted since we have DA as independent path to fetch messages.
 
-Note: discovery may be self-attested (KV), but Provides must be consensus written.
+**Flow**
 
-### 3.3 Irreversibility, Pruning, Serving
+Parachain A talks with Parachain B:
 
-| SM trust row | Polkadot | JAM |
-|---|---|---|
-| Different trust domain | relay inclusion | **enacted in Accumulate** (Tier 0), sanctioned exceptions per §0 |
-| Same trust domain | Low-Latency v2 ack slashing | **no equivalent** — gates Tier 2 (§7.3, OQ 5) |
-| Same super-chain | co-authored super-block | **co-packaged work package** or enactment group (§12) |
+1. B's JAM follower watches A's provides cell (`0x09++A`). When it changes to a new `StreamsRootA`, A added new outbound messages.
 
-Prune payloads below watermark `W` once the receiver block asserting `W` is irreversible
-per the row above (at MVP **enacted**).
+2. B finds A's network via JAM state keys. A published the bootnodes under `0x08 ++ SCALE((A, "spec-msg/bootnodes/v1"))`. 
+The record contains up to 8 multiaddresses (managed by parachain itself).
 
-Material for §1.6-frozen channels is retained until reconciliation (it's the evidence).
-Serving oblication by the archive node side:
-- extension proofs from any block boundary in the last **25 h**
-- payloads for every stream under any root in the last `W` ring entries
-- anchor window at Tier 0
+3. B dials bootnodes and discovers A's archive nodes. Messages plus MMR extension proof are fetched from `/spec-msg/exchange` req-resp protocol.
+
+4. Extension is verified against `StreamsRootA` locally and a prefix of the messages is consumed in the next block. The PoV carries the anchor state proof of A's cell.
+
+**Pruning**
+
+A sender may prune payloads below a watermark once the receiver block acknowledges it. Archives serve extension proofs from any block
+boundary within the last 25h, and payloads for every root still in the anchor window at Tier 0, or in the last `W` ring
+entries from Tier 1b (the ring is unwritten before that), or newer.
+
+## Forced Recovery
+
+The `parachain_set_head` rolls back enacted history:
+- each consumer channel desyncs since A's next root won't extend the old one.
+- deliveries from rolled-back blocks are irreversible
+    - A burned tokens and emitted "mint X" and enacted
+    - B delivered before the recovery abandoned that block
+    - B's supply is permanently inflated and no layer can undo it.
+
+To mitigate this the `set_head` must delete both cells, which makes recovery observable.
+The Coretime runbook must treat it as "reset all inbound channels". Consumers freeze a channel on a deleted cell
+or a non-extending root (one that does not extend the consumer's inbound frontier), discard prefetched messages
+and resume only on a fresh `open_channel`.
+
+The delivered messages stand and the re-delivered overlap after the restart. Before reopening, the recovering chain
+must communicate: what was delivered under the abandoned roots and compensate or it becomes an inflation source
+for the counterparties.
+
+> Note: A stream-generation marker in the leaf preimage could cover recovery (ie `(generation, StreamsRoot)`). 
+The generation id is bumped on every lifetime discontinuity (registration, set_head and re-onboarding).
+Then everything binds to `(paraID, generation)` instead of `paraId`
 
 ## 4. Execution: End to End
 
@@ -336,17 +224,13 @@ Serving oblication by the archive node side:
 2. **JAM:** report guaranteed -> available -> accumulated
     -  step 6 writes `cell[A]` (and from Tier 1b pushes `ring[A]`).
 
-3. **B:** node reads `cell[A]` at recent blocks, fetches payloads (p2p exchange preffered for low latency, or DA)
+3. **B:** node reads `cell[A]` at recent blocks, fetches payloads (p2p exchange preferred for low latency, or DA)
 
    - selects an anchor (best imported block where all consumed roots match, within its
    authorizer's eligible set)
    - authors a block consuming stream prefixes, reserving the proof envelope as `proof_size`
    - in-core (and in the pre-submission self-check) the guest verifies state proofs against `anchor.state_root` and lifts against each source's
    `StreamsRoot`. Calls into `report_error` with a structured payload on failure. Nothing further on-chain.
-
-Handshakes (`open_channel`/`accept_open_channel`) and flow control port unchanged 
-(in-band, stream-ordered, parachain-side). **PS §8.2's open point answered: no host functions
-needed for channel management.**
 
 ## 5. Node Stack
 
@@ -370,15 +254,11 @@ until Tier 1a).
 | Property | Polkadot | JAM |
 |---|---|---|
 | Message authenticity | PVF | PVF — unchanged |
-| Root authenticity | relay consensus check | guest state proof — per-parachain enforcement (§2.4) |
-| Provides commitment | UMP signal | digest field — unchanged guarantees |
+| Root authenticity | relay consensus check | guest state proof per-parachain enforcement |
+| Provides commitment | UMP signal | digest field - unchanged guarantees |
 | Stream monotonicity | not enforced | not enforced — self-harm, consumer-visible |
-| Sender-history irreversibility | governance-grade exception | Coretime-grade (§1.6) — more routine, hence reconciliation-gated |
 
-Polkadot capabilities: same-block A→B **deferred to Tier 1b** (free via in-order
-accumulation); atomic enactment groups, candidate cycles and super chains — **service-level
-/ handled at authoring**, see §12.
-
+Polkadot capabilities: same-block A -> B deferred to Tier 1b.
 
 > **Why not JAM's `prerequisites`?**
 >
@@ -387,183 +267,86 @@ accumulation); atomic enactment groups, candidate cycles and super chains — **
 > (2) Report is not enactment: steps 3/5 can decline after accumulation, so compare-and-reject survives anyway.
 > 
 > (3) `J = 8` is too small and shared with Tier 3's segment lookups; fan-in targets 64.
-> 
+>
 > (4) The 8-block reporting gate makes it strictly worse than proving enacted state.
-> Compact form:**available exactly where they buy nothing (Tier 0), unusable exactly where they'd help
-> (mutual dependencies never clear the ready queue, §7.3).
-> 
-> **Right solution at Tier 3: segment roots *are* content-addressed.**
-
-## 7. Latency Tiers
-
-Cumulative — each tier carries everything below it.
-
-| | Consumes | Requires settles | Ring | New GP deps |
-|---|---|---|---|---|
-| **T0** Accumulate | enacted roots | in-core | reserved, unwritten | none |
-| **T1a** Backed (hint) | enacted roots | in-core | reserved, unwritten | none |
-| **T1b** Backed (active) | guaranteed roots | **on-chain** | **written + read** | none |
-| **T2** Best block | announced roots | on-chain | written + read, deeper | optional prerequisites |
-| **T3** In-core import | exported segments | on-chain | written + read | **`J = 8` binds** |
-
-### T0 — Accumulate (MVP)
-
-HRMP latency parity (guarantee->accumulate 1–2 slots + 1–2 anchor lag).
-
-Implementation Delta:
-- digest field
-- host fn + `DuplicateProvidesDeclaration` 
-- step-8 budget check
-- cell `0x09` + reserved ring `0x0a`, baseline 71,514, all writes/deletes balance-neutral
-- step-6 cell write, no settlement; clean-up and recovery drop both tags
-- guest = trie path per source + lifts + digest/header assertion + structured `report_error`
-- PoV = proofs + lifts in the `proof_size` reservation, multiproof-encoded; framing slot for the anchor proof
-- node = cell reads at best blocks, embedded follower preferred, exchange + DA, KV bootnodes, telemetry from day zero. 
-
-Contingency: BLAKE2b host call (ask 10).
-
-### T1a — Backed, prefetch hint. Zero consensus delta.
-
-`pending_provides()` reads guaranteed-not-accumulated reports (needs block-body visibility,
-ask 13). Prefetch payloads, warm MMR peaks — still consume only enacted roots. Ship first,
-measure.
-
-### T1b — Backed, active
-
-**Gate: guarantee->accumulate survival >= 99% in a 2-slot window, read chain-weighted.**
-
-A guaranteed report can still die (availability timeout `U = 5`, step-3/5 decline).
-
-- Digest: `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), N>`, **N = 16
-  provisional**, speculative subset only, unique by ParaId, wrapper-enforced via
-  `set_requires_speculative` (at-most-once). Enacted-at-anchor roots stay in-core at zero
-  cost. `N` is sized by settlement **gas**, not digest bytes — fix before the digest
-  freezes (ask 11).
-- Ring `0x0a` written at step 6 + read by the **new settlement step at the 5/6 seam**:
-  every `(src, streams_root)` must be in `ring[src]`, newest-first. Miss = reject like a parent-head
-  mismatch, log `RequiresUnmet { src, root }`, no state change. Same-block A->B needs
-  nothing (in-order processing); ordering misses just retry.
-- Guest split: enacted-at-anchor -> prove in-core; speculative -> emit to digest.
-- Node: rebuild-and-retry on `RequiresUnmet`.
-
-**Settlement gas is the tier's real gate:** up to `N` rings × 1,537 B, newest-first, inside
-`min_item_gas` — and reports are **not replayed** after out-of-gas, so under-sizing
-silently drops *later* packages in the block (innocent paras lose slots). Size at
-worst-case fan-in; let gas bound `N` (ask 12).
-
-**Economics:** a settlement miss burns B's slot *and* withholds B's own provides, so misses
-cascade — a 5-deep chain at 99% survival clears ≈ 95%. Read the gate at the depth actually
-built; consume speculatively from sources, not from speculative consumers of sources.
-Bundling immunity: 1b binds to bundle-final digests, so §1.5's intermediate hazard cannot
-occur here. Bonus: the ring ends forced lift regeneration on re-anchor (§2.3).
-
-A must land first or B burns a slot.
-
-### T2 — Best block
-
-Consensus surface unchanged from 1b. New, node-side: `/spec-msg/announce`; off-chain block
-verification (header lineage, valid collator — needs its own definition once PS §7.1 is
-repaired, ask 9); the **header-digest read path**, correct only for **declared
-package-boundary roots** — announce carries A's intended boundary and B binds speculative
-requires only to boundary roots (§1.5); ready-queue expiry detection (OQ 3). Ring needs the
-deeper best-block `pipeline_depth` — already sized in from Tier 0, **no second migration**.
-
-- **Boundary violation is adversarial:** announcing a boundary then re-bundling inflicts
-  `RequiresUnmet` + a burned slot on every bound consumer, free and repeatable. Interim:
-  per-source backoff (violations are publicly observable). Systemic: the slashing design
-  (OQ 5).
-- **Optional prerequisites for ordering:** B's package declares A's hash; JAM orders A
-  first, same-block included. Caveats: report ≠ enactment (compare-and-reject stays); the
-  **8-block reporting gate binds at every stage** (never name a package reported > 8 blocks
-  ago — the report becomes unreportable; ξ's epoch depth is duplicate-rejection, not
-  eligibility); **silent expiry** (dropped from the ready queue after ≤ 1 epoch, no
-  on-chain trace — node detection, OQ 3); **no mutual prerequisites** — honest packages
-  can't encode them (the field hashes under the package hash) and fabricated reports never
-  clear the ready queue; super chains use co-packaging or one-directional prerequisites
-  (§12).
-- **The unfunded dependency:** SM's speculative tier is backed by acknowledgement slashing;
-  no JAM equivalent exists. Tier 2 cannot ship on its stated security basis until one does
-  (OQ 5) — the gating item, on no other list.
-
-### T3 — In-core import
-
-B imports A's exported segments; delivery becomes in-core and deterministic. No new
-consensus (settlement and ring still required); `import_segments()` exists; PoV shrinks;
-tight coupling to A's export timing and the DA window. **`J = 8` binds** — fan-in drops
-from 64 to 8. The only tier with a genuine `J`-bump motive; still wait for measured demand.
-
-### Decide before the baseline freezes
-
-1. `W` at best-block depth (§1.3). 2. Ring slot reserved at Tier 0 — **yes**. 3. Land
-before first registration (ask 7). 4. Super-chain parked reserve: **opt-in delta-charged,
-never baseline** (§12).
-
-## 9. Asks on the Parachain Service
-
-| # | Ask | Tier | Acceptance |
-|---|---|---|---|
-| 1 | `spec_msg_provides` digest field | T0 | 33 B counted in the 48 KiB budget |
-| 2 | `set_provides_root(root)` host fn | T0 | optional, at-most-once, wrapper-enforced |
-| 3 | `RefineLog::DuplicateProvidesDeclaration` | T0 | second call fails Refine |
-| 4 | Output-size check includes the field | T0 | `RefineOutputTooLarge` accounts for it |
-| 5 | Tag `0x09` + step-6 write | T0 | written only after steps 1/3/5; balance-neutral |
-| 6 | Tag `0x0a`, reserved unwritten | T0 | baseline-charged at W = 48 |
-| 7 | Baseline 69,847 → 71,514 | T0 | **lands pre-first-registration**; fallback priced (§1.4), never preferred |
-| 8 | `parachain_clean_up` drops `0x09`/`0x0a` | T0 | reused ParaId inherits nothing; deletions refund nothing |
-| 9 | `RefineContext` doc fix | T0 | records `beefy_root`; removes fields GP lacks; flags §7.1's slot claim; constrained by ask 18 |
-| 10 | BLAKE2b-256 host call for the child PVM *(contingent)* | T0 | only if §2.6's gas gate fails |
-| 11 | `spec_msg_requires` + `set_requires_speculative` + log variant | T1b | speculative subset, unique by ParaId; `N` fixed pre-freeze, sized by gas |
-| 12 | Ring write + settlement step + `RequiresUnmet` | T1b | push iff ≠ newest, balance-neutral; check after earlier same-block step 6; gas sized at worst-case fan-in in `min_item_gas` |
-| 13 | Guarantees-extrinsic visibility (node) | T1a | `ProvidesSource` reads guaranteed-not-accumulated reports |
-| 14 | `ParachainBlockData` anchor-proof slot (ours) | T0 | V4 or V3 field; both targets; guest digest/host-call assertion, fixture-backed |
-| 15 | `parachain_set_head` deletes `0x09`/`0x0a` | T0 | recovery observable; balance-neutral; no-op at registration |
-| 16 | Confirm CE 129 serving envelope (node) | T0 | non-validator peers; load; state at anchor − 8; hash-leaf preimages |
-| 17 | Pin the DA retention period | T0 | §3.3's backstop and cold-start have a number |
-| 18 | Anchor-freedom constraint on the §7.1 repair | T0 | slot claims don't bind anchor choice (OQ 9), or §2.2 re-derived |
-| 19 | Recovery runbook: reconciliation-gated re-open | T0 | `set_head` = "resets all inbound channels"; reconcile before re-opening; consumers resume only on fresh `open_channel` |
+>
+> **Right solution at Tier 3: segment roots are content-addressed.**
 
 ## 10. Open Questions
 
-1. **PVM BLAKE2b throughput + metered gas ceiling** (§2.6) — go/no-go, fallback ask 10.
-   Highest-risk item.
-2. **`W`** at best-block depth, before the baseline freezes. Worked 48; `Compact` boundary
-   at 63.
-3. **Silent ready-queue expiry** — node-side detection + rebuild-and-retry (also covers
-   §12's S1.5). Liveness, not soundness.
-4. **ParaId reuse** — re-run SM's threat assessment against Coretime-on-JAM's id policy; a
-   stream-generation marker in the leaf preimage covers reuse, offboarding *and* recovery
-   in one mechanism and makes §1.6's re-open gate structural.
-5. **Acknowledgement/slashing on JAM** — Tier 2's trust row is empty; owner needed; the
-   §7.3 grief vector is required input.
-6. **CE 129's four confirmations** (ask 16), esp. hash-leaf preimage retrieval.
-7. **Pin the rest:** DA retention (ask 17), GP equation refs for key derivation and report
-   checks.
-8. **Settlement gas at worst-case fan-in** — sizes `min_item_gas` and `N` (asks 11, 12);
-   before Tier 1b.
-9. **Authorizer anchor policy** (ask 18) — resolve with, not after, ask 9's §7.1 repair.
+1. **PVM BLAKE2b throughput + metered gas ceiling** 
+  Verification adds 1.7k blake2 calls in Refine (64 trie paths + lifts). Refine can consume max 5 billion gas.
+  If in guest blake2 doesn't fit, the fallback is a blake2 host call for the child PVM.
+
+2. **`W`** at best-block depth, before the baseline freezes.
+  The ring must be sized for the best block pipeline (announce to enact), not the backed one. Raising W later
+  is another migration. If we increase W to 64 or `Compact(W)` grows a byte the baseline pricing breaks
+
+3. **Silent ready-queue expiry**
+  If B declares a prerequisite on A and A never accumulates, B's report is dropped
+  after up to an epoch with zero on-chain trace. The node must detect the drop itself and rebuild-and-retry.
+
+4. **ParaId reuse**
+  Coretime doesn't guarantee ParaId uniqueness on JAM. 
+  Fix: a generation number in the stream leaf preimage, bumped on register/set_head/offboard.
+
+5. **Acknowledgement/slashing on JAM**
+  Tier 2's security on Polkadot rests on LLv2 ACK slashing. JAM has no equivalent
+
+6. **CE 129**
+  Can a collator without a JAM node ask another node for state? Should be ok for the cell, but breaks for bootnodes.
+
+7. **Pin the rest** 
+  JAM DA retention period is not pinned. For message recovery we'd need a real number. Similar to key derivation.
+
+8. **Settlement gas at worst-case fan-in**
+  For Tier 1B the settlement scans up to N rings per candidate on chain. Running out of gas in Accumulate silently
+  drops later packages.
+
+9. **Authorizer anchor policy**: AURA uses anchor to prove it's our turn.
+  The same anchor is also the block all message proofs verify against.
+  The current collator cannot freely pick between the 8 recent blocks anymore (only ones in the current rotation). 
+  Needs to make the slot claim independent of anchor choice.
 
 ## 12. Super Chains
 
-A superchain pair consumes each other's speculative output every step (A consumes B
-same-step; B consumes an earlier A block), all lifts valid by construction.
+A superchain pair consumes each other's speculative output every step (A consumes B in this block and B consumes an earlier A block).
+Because of how it's designed, this loop works safely on JAM.
 
-The validated ladder:
+Solving the work package ordering:
 
-- **S0 — Fusion** *(the plan)*: both candidates as work items of one package on one core —
-  one report, one invocation, availability atomic. Needs one service-level group-enactment
-  rule (any member fails means decline all). Zero JAM changes.
-  
-  This is §0's second sanctioned exception.
+> Why not mutual JAM `prerequisites`?
+> An honest author cannot even encode the cycle. `P_A` would need `hash(P_B)` which needs `hash(P_A)`
+> 
+> Colluding guarantors *can* put mutually-referencing reports on chain, but those park in the ready queue,
+> never release, and are silently discarded at the epoch boundary.
 
-- **S1.5 — Ordered pair**: two cores; B declares a one-directional prerequisite on A, A
-  imports B's exports via a `Direct` segment root.
-  
-  Zero changes; only "A enacted, B missing" remains.
+- **Solution 0: Fusion** *(the plan)*: both candidates as work items of one package on one core.
 
-- **S1 — Asymmetric parking**: closes that residual service-side (opt-in delta-charged
-  record, never baseline). Zero JAM changes.
-- **S2 — GP package groups**: format-breaking; gated on measured demand (fusion overflow ∧
-  parking pain ∧ burn cost).
+  The core idea is to bundle both candidates into a single work package and run them on the same core.
+  The PS must guarantee all or nothing, either all succeed or none succeed.
 
-The fixpoint dies at authoring (fixed intra-superstep order); mutual same-step consumption
-is a two-phase-collation STF profile, not an impossibility.
+  To prevent cycles, we enforce strict orders: B goes first, then A.
+  - B runs and looks at A's previous state
+  - A runs and looks at B's current state (by reading B's header SPMG)
+
+  Since they share the same core, they are also capped in terms of resources. Both candidates
+  must share the ~13.8 MiB and 5 billion gas limit. The most likely bottleneck would be the tiny 48 KiB limit for the result.
+
+  Securing the link between A and B inside the core:
+  - in core: We put B's header at a fixed offset. A reads and checks the `R_B` hash from the header digest. 
+  - backup: Add a new digest field that carries A's claimed `(sibling, root)` and rely on Accumulate to double check it
+  against `spec_msg_provides` of B.
+
+- **Solution 1: Ordered pair**
+  If a single core limit becomes an issue, we can separate them onto two cores but force synchronization by `prerequisites`.
+
+  B adds A's work hash as prerequisite and will never accumulate before A. Then, A can import the B's exports.
+  The timing here is a bit fragile, B must follow A in the exact slot or at most within last 8 slots. If B misses the
+  report is silently discarded at epoch boundary. 
+
+- **Solution 2: Asymmetric parking**
+
+  This is a fallback logic for when things get out of sync.
+  If A is enacted, but B fails to enact, the system won't enact A until B can enact.
+  A is parked for a timeout and if B takes too long or never arrives, A is dropped as well.

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -81,14 +81,14 @@ A forced `parachain_set_head` that overwrites a live head will also clear the ri
 spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>
 ```
 
-The ring is charged from the baseline of the parachain. Passing the settlement ring check implies that
-the candidate will enact. Every requires entry source must exist and the named root must be present in the ring.
-The candidate is rejected silently and the receiver `B` monitors offchain this behaviour, similar to
-`parent-head` or `check-code` failures. Otherwise, letting rejected candidates append `AccumulateLogs` would let junk
-candidates push out valuable entries.
+The ring reads are charged to the parachain. Every `Requires` source must exist and its root must be present in the ring.
+On the first missing entry, PS rejects the candidate and emits one bounded `AccumulateLog::RequiresUnmet { source, root }`
+allowing the receiver to identify a settlement miss and rebuild. Otherwise, the block builder cannot distinguish
+between a missing root from gas exhaustion, or queue expiry or parent-head failure. Logging only the first
+miss is bounded and the candidate has already passed authorization checks.
 
- Before processing a digest, PS charges its worst-case ring-read cost against that item’s declared accumulation gas. The
- `W` should be reasonable bounded and the scan reads the newest entries first stopping on the first match.
+Before processing a digest, PS charges its worst-case ring-read cost against that item’s declared accumulation gas. The
+`W` should be reasonable bounded and the scan reads the newest entries first stopping on the first match.
 
 > Note: A forced rollback (`ParachainSetHead` from the Coretime chain) isn't applied instantly. Its an upward message,
 replayed at step 7 when the Coretime chain's own package accumulates. Packages accumulate in order within a block,

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -16,14 +16,17 @@ anchor super-peak → belt leaf → (PS, heads_root) → Leaf { para_id, head_ha
   → header preimage → SPMS digest → StreamsRootA
 ```
 
-In core validation proves the root was enacted, while on chain liveness ensure the history remains valid.
-Every consumer records `(ParaId, Generation)` per source in its digest.
+In-core validation proves the root was enacted; on-chain settlement then re-checks every consumed root
+against the sender's ring of recently enacted roots and checks the history is still live. Every consumer
+records `(ParaId, Generation, StreamsRoot)` per source in its digest.
 
 Since old roots prove forever in-core, we need a mechanism to catch rolled back senders (ie the `Generation` field).
-The receiver `B`'s digest records `(ParaId, Generation)` and the Accumulation phase ensures the `Generation` matches
+The receiver `B`'s digest records the generation and the Accumulation phase ensures it matches
 the latest one from the sender `A`.
 
-The roots not yet enacted enacted (higher specualtion tiers) still need the settlement ring.
+The settlement ring is live from day 0: every enacted SPMS root is pushed into the sender's ring at the
+head write, and settlement requires each consumed root to be present in its source's ring. The same
+machinery settles the higher speculation tiers later with no further consensus change.
 
 
 ## Changes at Accumulation Tier MVP
@@ -69,10 +72,11 @@ a para's history).
 Decoding optimization: The field is placed ahead of any variable-length fields of the `ParaInfo` so we can keep the
 per request read check cheap.
 
-3. Digest fields: `spec_msg_requires: BoundedVec<(ParaId, Generation), 64>` on the PS work digest
+3. Digest fields: `spec_msg_requires: BoundedVec<(ParaId, Generation, StreamsRoot), 64>` on the PS work digest
 
-The field is set via `set_requires_root` host call at most once per `Refine`. 
-At 12 bytes each, full fan-in costs is ~770 bytes of the 48 KiB report.
+The field is set via `set_requires_root` host call at most once per `Refine`. Each entry names the
+consumed root itself, so settlement can re-check it against the source's ring from day 0.
+At 44 bytes each, full fan-in costs ~2.8 KiB of the 48 KiB report.
 This must be a digest field and not UpwardMessage, because UMP replays after the head write (so it can't gate enactment).
 
 4. `declare_budget(distinct_sources)` mandatory, once per Refine, before the first spec-msg call
@@ -82,25 +86,37 @@ sources it will touch. Then, lets the `Refine` wrapper reserve gas for proof ver
 work starts.
 
 
-4. Settlement step 5b `spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>`
+5. Settlement: the requires check runs at §5.1 step 6, against the day-0 ring `spec_msg_recent_provides`
 
-This is deferred to Tier 1b (not added until then) and represents the last `W` enacted roots per para keyed at `0x0a ++ para_id`.
-
-The settlement ring is charged at first write rather then priced from day-0 baseline. An unfunded parachain can consume sources at T0.
-However, it cannot consume them at T1b or above. 
+The settlement ring represents the last `W` enacted roots per para, keyed at `0x0a ++ para_id` (`0x09`
+holds `next_generation`). It is live from day 0: at the head write (§5.1 step 6), if the enacted head
+carries an SPMS digest, its root is pushed into the sender's ring — iff different from the newest entry,
+evicting the oldest beyond `W`. Paras that never emit SPMS digests never write.
 
 ```rust
 /// Keyed `0x0a ++ SCALE(para_id)`.
 /// 
-/// From Tier 1b: step 6 pushes the enacted root iff != newest entry, evicts oldest.
-/// Read only by settlement, never proved.
+/// §5.1 step 6 pushes the enacted root at the head write iff != newest entry, evicts oldest.
+/// Read by settlement, never proved.
 spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>
 ```
 
-Every requires entry's source must exist at the named generation or the candidate is rejected.
+The ring is charged at first write rather than priced from the day-0 baseline. An unfunded parachain still
+receives and consumes; what it cannot do is fund its own ring, so its roots never become consumable — it
+cannot act as a source at any tier until funded.
+
+The requires check itself sits at the head of §5.1 step 6 — the last gate, so passing implies enacting,
+and before the head write, so a rejected `B` never publishes a root of its own. Every requires entry's
+source must exist at the named generation, **and** the named root must be present in the source's ring,
+or the candidate is rejected.
 The candidate is rejected silently and the receiver `B` monitors off-chain similar to `parent-head` or 
 `check-code` failures. Otherwise, letting rejected candidates append `AccumulateLogs` would let junk
 candidates push out valuable entries.
+
+The ring check bounds which roots are consumable to the source's last `W` **enacted roots** — a bound in
+enactments, not in time: a dormant sender's ring persists, and because streams are cumulative MMRs, any
+newer root reaches every older message via lifts. Catch-up stays unbounded; consumers simply verify
+against a recent root.
 
 
 > Note: A forced rollback (`ParachainSetHead` from the Coretime chain) isn't applied instantly. Its an upward message,
@@ -114,8 +130,9 @@ this is accepted rather than solved (ie draining Coretime's commands before any 
 
 - **T0 Accumulate / Consume enacted roots (MVP)**: Parity with HRMP
   - 1 or 2 slots from guarantee to accumulate, plus 1 or 2 for anchor lag
-  - root verification in-core via the output-log proof; the requires entry carries only
-    `(ParaId, Generation)` and settlement checks generation liveness — the rollback brake
+  - root verification in-core via the output-log proof; the requires entry carries
+    `(ParaId, Generation, StreamsRoot)` and settlement checks generation liveness — the rollback
+    brake — plus the root against the source's ring
 
 - **T1a Backed / PrefetchHint**: prefetch on backed with zero consensus change.
   - node reads guaranteed but not yet accumulated reports to warm cache
@@ -123,8 +140,9 @@ this is accepted rather than solved (ie draining Coretime's commands before any 
 
 - **T1b Backed / Active**
   - saves 1 or 2 slots
-  - digest v1 widens the requires entry to `(ParaId, Generation, StreamsRoot)`
-  - settlement ring gets active and settlement adds a ring read per entry (sized for gas limits)
+  - **zero consensus change**: the requires entry already carries the root and the ring is already
+    live and checked at settlement — the tier is purely node-side (B dares to consume a root that
+    is guaranteed but not yet enacted; the in-core enactment proof is skipped since none exists yet)
   - `A` guaranteed report can die and `B` burns its slot (ie `A` must land first or `B` burns a slot)
   - Same block `A -> B` is possible since Accumulation happens in order and A's ring push lands before B's settlement runs.
 
@@ -175,8 +193,9 @@ Verification occurs in the Parachain Service Refine wrapper via
 `verify_enacted_root(para_id, proof) -> Option<(StreamsRoot,Generation)>` and not in the guest code.
 Malformed proofs abort Refine with `RefineLog::InvalidEnactmentProof`.
 
-Then the message Lifts verify against the root as on Polkadot. Settlement (step 5b) replaces only the
-liveness check and never message verification. A guest that skips lift verification is broken either way.
+Then the message Lifts verify against the root as on Polkadot. Settlement (§5.1 step 6) re-checks the
+named root against the source's ring and checks generation liveness — never message verification, which
+is inherently guest-side. A guest that skips lift verification is broken either way.
 
 The anchor must be matched against the last 8 JAM blocks at guarantee time. The 6s slots needs roughly 3-4 slots out of the
 8 for state root lag, building, distribution and inclusion. This leaves approximately 4-5 slots to match against. Missing the
@@ -250,8 +269,8 @@ The `parachain_set_head` rolls back enacted history:
     - B's supply is permanently inflated and no layer can undo it.
 
 To mitigate this, generations are bumped on `set_head` calls if and only if it overwrote a live head.
-Every consumer's requires entry names the generation it consumed under, and step 5b
-rejects any candidate still consuming the abandoned history.
+Every consumer's requires entry names the generation it consumed under, and the requires check (§5.1
+step 6) rejects any candidate still consuming the abandoned history.
 
 The Coretime runbook must treat a bump as "reset all inbound channels". Consumers freeze a channel
 on a generation bump or a non-extending root (one that does not extend the consumer's inbound frontier),
@@ -274,18 +293,19 @@ remain drainable at T0 with no state left behind.
    - PVF `export()`s payloads and node-side archives them.
 
 2. **JAM:** report guaranteed -> available -> accumulated
-    - step 6 writes A's head. The output log carries it
-      under every later super-peak (and from Tier 1b, step 6 also pushes `ring[A]`).
+    - step 6 writes A's head and pushes the enacted root into `ring[A]`. The output log carries the
+      head under every later super-peak.
 
 3. **B:** node follows A's enacted heads, fetches payloads (p2p exchange preferred for low latency, or DA)
 
    - selects an anchor (best imported block, within its authorizer's eligible set — any anchor at or after
    each source's enacting block works)
    - authors a block consuming stream prefixes, reserving the proof envelope as `proof_size`, and names each
-   source's `(ParaId, Generation)` via `set_requires_root`
+   source's `(ParaId, Generation, StreamsRoot)` via `set_requires_root`
    - in-core the wrapper walks each enactment proof from the anchor's
    super-peak and the guest verifies lifts against each source's `StreamsRoot`. Failures abort with `RefineLog`.
-   - on-chain, step 5b checks each named generation is still live, then B enacts.
+   - on-chain, §5.1 step 6 checks each named generation is still live and each named root is in its
+     source's ring, then B enacts.
 
 ## 5. Node Stack
 
@@ -301,7 +321,7 @@ anchor − 8 retained, hash-leaf preimages for `BootnodeRecord` (3) RPC / light-
 fallback.
 
 **`ProvidesSource`:** reads A's enacted heads at imported blocks — **best, not finalized**. Block
-stream, startup tip, sync gate, ring read at a recent hash (dormant until Tier 1b),
+stream, startup tip, sync gate, ring read at a recent hash,
 pending-provides hint (dormant until Tier 1a).
 
 ## 6. Trust Model
@@ -309,7 +329,7 @@ pending-provides hint (dormant until Tier 1a).
 | Property | Polkadot | JAM |
 |---|---|---|
 | Message authenticity | PVF | PVF — unchanged |
-| Root authenticity | relay consensus check | wrapper output-log proof in-core and Generation liveness checked by every validator at 5b |
+| Root authenticity | relay consensus check | wrapper output-log proof in-core; ring root check and Generation liveness at §5.1 step 6 |
 | Provides commitment | UMP signal | header digest + §5.5 enactment commitment |
 | Stream monotonicity | not enforced | not enforced — self-harm, consumer-visible |
 
@@ -334,10 +354,11 @@ Polkadot capabilities: same-block A -> B deferred to Tier 1b.
   gas ceiling shared with the parachain's own execution. If guest hashing doesn't fit, the fallback is
   hashing host calls for the child PVM.
 
-2. **`W`** at best-block depth. Tier 1b sizing input.
+2. **`W`** at best-block depth. Now a day-0 sizing input.
 
-  The ring is charged at first write, so nothing reads or prices it before Tier 1b. It must still be sized
-  for the best-block pipeline (announce to enact), not the backed one, before the ring turns on.
+  The ring is live and read by settlement from day 0, so `W` must be fixed before launch. It must be
+  sized for the best-block pipeline (announce to enact), not the backed one, since the higher tiers
+  reuse the same ring without a consensus change.
 
 3. **Silent ready-queue expiry**
   If B declares a prerequisite on A and A never accumulates, B's report is dropped
@@ -356,8 +377,8 @@ Polkadot capabilities: same-block A -> B deferred to Tier 1b.
   JAM DA retention period is not pinned. For message recovery we'd need a real number. Similar to key derivation.
 
 8. **Settlement gas at worst-case fan-in**
-  At MVP settlement reads one generation per source (up to 64 per candidate). Then Tier 1b adds a ring read per
-  entry. We don't have JAM gas per read byte estimates. 
+  At MVP settlement reads one generation plus one ring per source (up to 64 of each per candidate), and
+  the head write adds a ring push. We don't have JAM gas per read byte estimates. 
 
   This would also influence how the `Generation` field is read:
   - reading the full `ParaInfo` (~4 KiB)

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -18,13 +18,7 @@ head, it will also clear out the parachain's ring. Abandoned roots are no longer
 (resetting the channels, compensate for delivered messages) is a `Coretime` runbook procedure, not
 a consensus mechanims Speculative Messaging or PS provides.
 
-```
-anchor super-peak → belt leaf → (PS, heads_root) → Leaf { para_id, head_hash }
-  → header preimage → SPMS digest → StreamsRootA
-```
-
-
-## Changes at Accumulation Tier MVP
+## Changes at MVP Tier
 
 We are releasing SpecMsg with Accumulation Tier (HRMP parity) from day 0. The changes needed:
 
@@ -126,52 +120,6 @@ this is accepted rather than solved (ie draining Coretime's commands before any 
 - **T4 SuperChains**
   - Both A and B candidates are bundled in the same package
   - Needs a PS service rule that if any member fails the whole group is declined.
-
-## Verification
-
-B's PoV carries per consumed source an `EnactmentProof`:
-
-```rust
-struct EnactmentProof {
-    /// Path from the anchor's super-peak to the enacting block's entry in the
-    /// accumulation-output log.
-    /// 
-    /// TODO-GrayPaper: We need the exact format and hash function.
-    belt_path: Vec<u8>,
-
-    /// PS's per-block accumulation output for that block.
-    heads_root: Hash,
-
-    /// keccak path in the changed-heads tree to `Leaf { para_id, head_hash }`.
-    heads_path: Vec<Hash>,
-
-    /// Full header preimage; must hash to `head_hash`.
-    /// The SPMS digest `streams_root` is extracted out of it.
-    header: Vec<u8>,
-}
-```
-
-Verification occurs in the Parachain Service Refine wrapper via
-`verify_enacted_root(para_id, proof) -> Option<StreamsRoot>` and not in the guest code.
-Malformed proofs abort Refine with `RefineLog::InvalidEnactmentProof`.
-
-Then the message Lifts verify against the root as on Polkadot. Settlement (§5.1 step 6) re-checks the
-named root against the source's ring — never message verification, which
-is inherently guest-side. A guest that skips lift verification is broken either way.
-
-The anchor must be matched against the last 8 JAM blocks at guarantee time. The 6s slots needs roughly 3-4 slots out of the
-8 for state root lag, building, distribution and inclusion. This leaves approximately 4-5 slots to match against. Missing the
-window means the re-anchoring swaps the proof envelope, not the block. Since MMR peaks are prefetched, lift generation also
-remains local. This needs to take into account AURA authorizer which makes the anchor double as the slot claim, which could 
-shrink the collator window from 8 to its own rotation run.
-
-PoV cost is about 4KiB per touched stream plus, per source, the belt path (log2 of chain length), the heads
-path (<= log2 of core count) and A's full header preimage. For example, 128 streams and 64 sources stays well
-under 1 MiB out of the ~13MiB budget.
-
-> Unknown: The verification gas is unknown, and now needs `keccak_256` for the belt and
-> heads paths, BLAKE2b for the lifts. Needs to fit inside the Refine 5 * 10^9.
-> The fallback is hashing host calls for the child PVM, capped by a `MAX_VERIFICATION_HASHES` constant.
 
 ## Transport and Discovery
 
@@ -424,3 +372,36 @@ Solving the work package ordering:
   This is a fallback logic for when things get out of sync.
   If A is enacted, but B fails to enact, the system won't enact A until B can enact.
   A is parked for a timeout and if B takes too long or never arrives, A is dropped as well.
+
+## Apendix
+
+This sections highlights an alternative to the onchain ring settlement that is valid only
+for the MVP tier (Enactment).
+
+### Alternative Verification
+
+The RefineContext carries the anchor's accumulation-output-log super peak. The verification
+can happen in-core of the receiver parachain. Since speculation happens at enactment, the
+super peak contains the sender parachain header hash. The receiver node passes in its PoV
+an enactment proof which walks the super peak to the sender header hash, plus the full sender header.
+The receiver then extracts from the SPMS digest the `StreamsRoot` and compares against its `Provides`.
+
+Walking the super-peak:
+
+```
+anchor super-peak → belt leaf → (PS, heads_root) → Leaf { para_id, head_hash }
+  → header preimage → SPMS digest → StreamsRootA
+```
+
+```rust
+struct EnactmentProof {
+    /// Path from the anchor's super-peak to the enacting block's entry.
+    belt_path: Vec<u8>,
+    /// PS's per-block accumulation output for that block.
+    heads_root: Hash,
+    /// keccak path in the changed-heads tree to `Leaf { para_id, head_hash }`.
+    heads_path: Vec<Hash>,
+    /// Full header preimage that must match to `head_hash`.
+    header: Vec<u8>,
+}
+```

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -1,34 +1,18 @@
-# Speculative Messaging on JAM
+# Speculative Messaging on JAM: MVP
 
-The [Parachain Service](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#3-the-parachain-service) needs a robust messaging system to replace the older HRMP-style payloads, and [Speculative Messaging](https://github.com/paritytech/polkadot-sdk/blob/9d0a0daee40e6e350209aaf4b3e3bdf1fb9a8793/docs/speculative-messaging-design.md) is our primary candidate for JAM.
+The [Parachain Service](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#3-the-parachain-service) replaces HRMP-style payloads with [Speculative Messaging](https://github.com/paritytech/polkadot-sdk/blob/9d0a0daee40e6e350209aaf4b3e3bdf1fb9a8793/docs/speculative-messaging-design.md).
 
-Here is a breakdown of exactly what needs to change to make Speculative Messaging work smoothly on JAM, ensuring every Polkadot feature has a clear, explicit JAM backport.
+This doc is the implementation scope for initial launch. Chains consume at the `Enacted` tier
+(HRMP parity).The sender's root is pushed into an on-chain settlement ring when its candidate
+enacts, and the receiver's candidate enacts only if every root it consumed is in the ring.
 
-> For MVP, chains speculate at the `Enacted` tier. Sender parachain `A` writes its `Provides/StreamsRoot` entry
-> inside a `recent_provides` settlement ring (bounded vector). Receiver `B` monitors the ring, fetches messages from `A` and targets its
-> `Requires` field agains the latest `recent_provides` entry. In the `Accumulate` phase, the PS ensures that
-> all `Requires` are matched against their respective `recent_provides` entries.
-
-Therefore, we introduce on-chain settlement from the MVP. The sender `StreamsRoot` is pushed to the ring,
-the consumer `Requires` field (ie `(ParaId, StreamsRoot)`) is checked against the ring. The same
-mechanism handles settlement for all speculation tiers.
-
-## Contents
+To make this happen, we need to build three core components:
 
 1. [`Provides` and `Requires`](#1-provides-and-requires)
 2. [Settlement Ring](#2-settlement-ring)
-3. [Buffering](#3-buffering)
-4. [PS Topological Sort](#4-ps-topological-sort)
-5. [Bootnodes Discovery via Para-Owned KV](#5-bootnodes-discovery-via-para-owned-kv)
-6. [Speculation Tiers](#6-speculation-tiers)
-7. [Execution: End to End](#7-execution-end-to-end)
-8. [Forced Recovery](#8-forced-recovery)
-9. [Super Chains](#9-super-chains)
-- [Appendix](#appendix)
+3. [Bootnode Discovery](#3-bootnode-discovery)
 
-## Changes at MVP Tier
-
-We are releasing with the Enacted tier (HRMP parity) from day 0. The changes needed from PS:
+For a concrete breakdown of the work, see the [Implementation Tasks](#implementation-tasks).
 
 ## 1. `Provides` and `Requires`
 
@@ -36,81 +20,59 @@ The Parachain Service work digest gains two fields:
 
 ```rust
 struct ParachainWorkDigestOk {
-  /// ...
+  /// 33 B when present.
   spec_msg_provides: Option<StreamsRoot>,
+  /// 36 B each, ~1.1 KiB at full fan-in.
   spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 32>,
 }
 ```
 
-### Producing Sender `Provides`
-
-The sender runtime maintains its stream MMR frontiers and the commitment tree.
-When producing a block, the runtime writes the `Provides` root directly into pallet storage and the header digest.
-
-During the PS Refine phase, guarantors execute the PVF. Once execution completes, the `validate_block` wrapper
-reads the root from pallet storage and reports it via the `set_provides_root` host call.
-
-For bundled PoVs, the wrapper carries the last produced `Provides` forward to the call, even when later inner blocks send nothing.
-Intermediate roots are not settlement entries. A consumer that used an intermediate boundary must lift its endpoint
-to the candidate boundary root before it can settle.
-
-During Accumulate, the candidate's head is written for enactment. If a `Provides` root is present, it is pushed into
-the sender's settlement ring (`ring[A]`). Therefore, a root enters the ring only for a candidate that enacted.
-
-It costs 33 bytes when present.
-
-### Producing Receiver `Requires`
-
-The collator node picks the target `Provides` depending on the speculation tier and
-consumes a prefix of messages. The runtime consumes the messages and records a `ConsumptionRecord`.
-The collator then generate the Lift proofs and packages them into the PoV.
-
-In the PS Refine, the guarantors execute the PVF. Then, the `validate_block` wrapper reads the
-`ConsumptionRecords` from the pallet storage with the Lifts from the PoV. It stitches consumption gaps
-to produce a final `Requires` that is set via `set_requires_root`.
-
-For a bundle, the wrapper unions the per-block consumption records into one entry per source,
-keeping the latest root per source.
-
-PS Refine then enforces that all source parachains in the `Requires` set are unique and bounded to 32 entries.
-
-If the runtime is buggy or verifications are disabled, PS does not guarantee that the PoV lifts or stitches
-actually result in the provided `Requires`. The system relies on the Accumulation phase to verify that the
-`Requires` are present in the settlement ring.
+Two new host calls, each callable at most once per Refine:
 
 ```rust
+/// Declares the candidate's provides root. Omitted when the candidate sent nothing.
+fn set_provides_root(root: StreamsRoot);
+
 /// Declares the candidate's requires entries, one per consumed source.
-/// One call carries the whole set. May be called at most once per Refine.
-fn set_requires_root(entries: &[(ParaId, StreamsRoot)]) -> ();
+/// One call carries the whole set.
+fn set_requires_root(entries: &[(ParaId, StreamsRoot)]);
 ```
 
-During Accumulate, the system checks the settlement ring. It verifies that each declared `(ParaId, StreamsRoot)` is actually
-present in the source's ring (`ring[ParaID]`). The block is enacted only if this check passes.
+PS remains completely header-agnostic. It simply moves opaque 32-byte roots around without ever needing to decode the actual head data.
 
-> PS doesn't enforce the validity of `Requires`. It remains header agnostic (ie, no decoding) and strictly
-> moves opaque 32byte roots.
-> Moving the verification into the PS Refine wrapper doesn't change the security guarantees.
-> Instead, PS Refine would simply check the collator provided consumption record against
-> the collator provided PoV lifts.
+### Sender
 
-At 36 bytes each, full fan-in (32 entries) costs ~1.1 KiB of the 48 KiB report.
+The sender's runtime is responsible for maintaining its stream MMR frontiers and the commitment tree.
+When it produces a block, it writes the `Provides` root into both the pallet storage and the header digest.
 
-```rust
-/// Declares the candidate's provides root
-/// May be called at most once per Refine. Omitted when the candidate sent nothing.
-fn set_provides_root(root: StreamsRoot) -> ();
-```
+In Refine, after PVF execution, the `validate_block` wrapper reads the root from pallet
+storage and reports it via `set_provides_root`. For bundled PoVs, the wrapper carries the last
+produced root forward even when later inner blocks send nothing. Intermediate roots are not
+settlement entries.
+
+In Accumulate, when the candidate enacts, the root is pushed into the sender's ring
+(`ring[A]`). A root enters the ring only for an enacted candidate.
+
+### Receiver
+
+The collator targets the latest enacted `Provides` of each source and consumes a prefix of
+messages. The runtime records a `ConsumptionRecord`. The collator generates the Lift proofs
+and packages them into the PoV.
+
+In Refine, the wrapper reads the `ConsumptionRecords` from pallet storage together with the
+Lifts from the PoV, stitches consumption gaps, and sets the final `Requires` via
+`set_requires_root`. For a bundle, it unions the per-block records into one entry per source,
+keeping the latest root. Refine enforces that consumed sources are unique and at most 32.
+
+In Accumulate, settlement checks that each declared `(ParaId, StreamsRoot)` is present in
+`ring[ParaId]`. The candidate enacts only if every entry settles. Otherwise, it is rejected.
+At the Enacted tier a rejection only happens when the target root has already fallen out of
+the 64-entry window. This is mitigated with receiver monitoring and resubmissions, and should be
+rare in practice with a 64-entry window and 3 parachain cores.
 
 ## 2. Settlement Ring
 
-> Note: On polkadot missing the settlement check emplies that the lifts are regenerated and candidate
-> is resubmitted. On JAM, the re anchoring changes the package hash and the cotretime slot is burned.
-
-Every `Requires` source must exist and its root must be present in the ring.
-
-The settlement ring holds the last `W_MAX = 64` enacted roots per para.
-
-The settlement ring represents the last `W` enacted roots per para, keyed at `0x09 ++ para_id`.
+The ring holds the last `W_MAX = 64` enacted roots per para. Maximum footprint is 9747 B.
 
 ```rust
 /// Tracks order and capacity.
@@ -126,7 +88,7 @@ spec_msg_cursor: Map<ParaId, Cursor {
 }>
 
 /// Maps the sequence to the streams root.
-/// 
+///
 /// Key: `0x0b ++ para_id ++ seq`
 ///
 /// Billed: 75 B (Read on capacity eviction and lifecycle).
@@ -144,14 +106,11 @@ spec_msg_member: Map<(ParaId, StreamsRoot), MemberEntry {
 }>
 ```
 
-The ring capacity is per parachain and strictly position based. A root is only evicted after the parachain pushes `W_MAX (64)`
-new roots. Because eviction requires new messages, a block with no new messages pushes nothing.
-After 64 roots, the ring reaches a maximum capacity of 9747 B.
+The settlement check is a single 75 B point read of `spec_msg_member` per `Requires` entry.
 
-**Push Logic**
-
-If a root is repeated, the `MemberEntry` is updated with the new position, leaving the old entry in the
-`spec_msg_queue`.
+Eviction from the ring is based entirely on position. A root is only pushed out after the parachain adds 64 newer roots.
+If a block sends nothing, nothing is pushed. If a root happens to be repeated, the `MemberEntry` simply shifts to the
+new position while the old queue slot is left behind.
 
 ```rust
 fn push(para: ParaId, root: StreamsRoot) {
@@ -178,191 +137,16 @@ fn push(para: ParaId, root: StreamsRoot) {
 }
 ```
 
-| per para                | one-item ring (W = 64)          | this layout (point reads)          |
-|-------------------------|---------------------------------|------------------------------------|
-| settle, per `Requires`  | 2,345 B read                    | 75 B read                          |
-| push                    | 2,345 B read + 2,345 B write    | 197 B read + 197 B write, 2 dels   |
-| teardown                | 1 delete                        | 65 reads (~4.85 KB) + 129 deletes  |
-| resident footprint      | 2,345 B, self-pruning           | 9,647 B, ratchets until teardown   |
+**Teardown.** When `parachain_set_head` overwrites a live head, or `parachain_clean_up` is
+called, the ring is cleared. The ring is bounded by `W_MAX`, so teardown is bounded too
+(64 queue reads, 128 deletes, one cursor read and one cursor delete). 
+The Coretime call's gas budget must cover the full walk, since teardown is a fixed cost, not a failure mode.
 
+## 3. Bootnode Discovery
 
-When the `parachain_set_head` overwrites a live head, or if `parachain_clean_up` is called, the ring is cleared.
-The teardown process reads the cursor and walks backwards from `head - 1` down to `tail`.
-If the process runs out of gas, the revert leaves the cursor intact. This acts as a sentinel to detect incomplete
-teardown.
-
-> Note: A forced rollback (`ParachainSetHead` from the Coretime chain) isn't applied instantly. Its an upward message,
-replayed at step 7 when the Coretime chain's own package accumulates. Packages accumulate in order within a block,
-so if B's package sits before Coretime's in that order: B's settlement finds A's root still in the ring and B enacts.
-Moments later in the same round, Coretime's replay rolls A back and clears the ring. B consumed a history that died within the same block.
-Since this represents a tiny window of exposure relying on accumulation ordering and only reachable via Coretime intervention, at MVP
-this is accepted rather than solved (ie draining Coretime's commands before any settlement runs).
-
-## 3. Buffering
-
-A candidate that passes every check except settlement (ie, `Provides` entry
-is not yet in the ring) is rejected today. The slot is burned and the work must be redone.
-Buffering stores the work digest and applies it later, once the root arrives.
-
-> Note: #11883 §5.1's rejection path mentiones that "a candidate rejected at any
-> step changes nothing at all". A candidate that fails only settlement will be buffered.
-> The exposure is bounded by `MAX_BUFFERED_BYTES` and billed to the para balance at §6.1 rates.
-> A digest carries up to 4 KiB `head_data` plus the 40 KiB upward-message budget,
-> so `MAX_CHAIN_SIZE (16) * MAX_FORKS (2)` digests would be ~1.4 MiB per parachain.
-
-The first buffered entry must target the parachain's enacted head and all other
-entries must form a valid chain. We allow a maximum of two fork lanes. If a collator wants to abandon a branch,
-they can offer a competing one immediately without waiting for the first to expire.
-These forks can either process different messages (different `Requires`) or build a different head from the
-exact same messages (same `Requires`).
-
-Whichever fork settles first (evaluated FIFO by lane) invalidates the other. Forks are designed to be an edge case,
-not the standard operating model.
-
-Before any work items are applied, the buffered chain is walked from the front. The root parent
-must still be the enacted head and the front entry must not be expired (either failure will drop the chain).
-Then each entry's Accumulate is rerun against the current state. An entry that settles is applied and removed.
-An entry still missing its root stays buffered and ends the walk. Any other failure drops the chain.
-
-A chain front entry that is older than `buffered_at + K slots` is dropped when the next work item
-is accumulated. Buffered bytes are billed to the para's balance and are capped at `MAX_BUFFERED_BYTES` per parachain.
-An entry is never replaced or refreshed.
-
-Buffering never holds up the canonical chain.
-
-**Gas Model**
-
-The buffer walk happens before the new work item that brought the gas, but it can only spend the leftover
-gas that the item doesn't need for itself. Collators need to pad the work item to cover this walk.
-
-> Note: JAM combines all the Accumulate gas for a service's work items into one total
-> for the block. To charge this walk to a single item, we need a way to track individual
-> gas usage inside that total pool. This is the same attribution problem flagged in #11883 §5.1
-> for deferred `TransferOut` gas. The walk has to stay within the limit set by the item paying
-> for it, so it will depend on how we solve attribution there.
-
-Because the buffer is in consensus state, collators can read the walk's cost at their anchor.
-The anchor is up to `C_H = 8` slots stale and the buffer can move in between, so this is an
-estimate to over-provision against, not an exact figure.
-
-If the gas only covers part of the buffer, the walk settles what it can and pauses. Nothing is destroyed,
-and the remainder waits for the next item.
-After the walk, the new item is processed. It is either applied directly if it sits on the enacted head, or
-buffered as a chain extension if it builds on the tip.
-Ultimately, an under gassed item will never cause the buffer to be dropped, and the buffer walk will never starve the item that paid for it.
-
-Parachains can also push the buffer forward without submitting a new candidate. A settlement-only package carries
-no work digest and no parent head, so no check tied to a candidate can reject it,
-guaranteeing it reaches the walk phase and delivers gas.
-
-`SettleOnly` is a new kind of payload that doesn't include a candidate body. Refine skips the PVF completely,
-forgets about head declarations, and just hands back `RefineOutput::SettleOnly`. Once it hits Accumulate,
-the system sees what it is and sends it straight to the buffer walk. It bypasses all the usual candidate checks.
-
-> Note: #11883 needs adjusting around:
-> - §4.1 runs the PVF no matter what, so Refine needs that early exit.
-> - §4.2 insists on set_parent_head_hash and set_head every single time.
-> - §3.2 assumes every work item is a full parachain candidate.
-
-
-```rust
-/// Refine output handed to Accumulate.
-enum RefineOutput {
-    /// Full work digest.
-    Candidate(ParachainWorkDigest),
-    /// Settlement only to run the buffer walk with this item's declared gas.
-    SettleOnly,
-}
-
-/// Depth of buffered chain (per fork lane).
-pub const MAX_CHAIN_SIZE: u8 = 16;
-/// Maximum number of fork lanes.
-///
-/// This supports two forks which are common on polkadot
-/// with elastic scaling where 1 chain doesn't get finalized
-/// and a collator starts building a different chain:
-///
-/// ```ignore
-///  A -> B -> C -> D
-///    -> B' -> D'
-/// ```
-///
-/// However it doesn't support more compeating forks.
-pub const MAX_FORKS: u8 = 2;
-/// Total buffered amount per para (includes everything buffering related).
-pub const MAX_BUFFERED_BYTES: u32 = TBD;
-
-Map<ParaId, Cursor {
-    /// The start positon.
-    start: u8,
-    /// Number of elements buffered.
-    /// Supports two lane of forks.
-    len: [u8; 2],
-    /// Position where the chain diverge.
-    /// The position is <= `Cursor::len[0]`. The lane 1
-    /// exists only in `[fork_at, len[1])`
-    fork_at: u8,
-    /// Head hash of last entry. Ensures next buffered
-    /// digest forms a valid chain.
-    tip_head: [H256; 2],
-    /// If the last work digest carries a code upgrade signal
-    /// this must be last entry in the buffered chain. Every buffered
-    /// entry carry a code_hash gainst which it was validated. Any
-    /// successor would be validated against the old code.
-    tip_terminal: [bool; 2],
-    /// The parent the first entry(s), neede for making sure the buffered
-    /// element is still based on the canonical chain.
-    root_parent: H256,
-}
-Map<(ParaId, u8 /*position*/, u8 /*fork lane 0/1*/), Held {
-    /// The stored work digest.
-    digest: ParachainWorkDigest,
-    /// Validation code this entry was refined against.
-    code_hash: H256,
-    /// The head of the entry. Ensures a valid link is formed.
-    head_hash: H256,
-    /// The slot in which this buffered entry was added.
-    /// The full fork dies when the front entry expires
-    /// at `buffered_at + K`.
-    buffered_at: TimeSlot,
-}
-```
-
-## 4. PS Topological Sort
-
-Within one JAM block, the PS `Accumulate` processes digests in the order JAM provides (core order for
-newly available reports, plus ready-queue releases). If sender A and consumer B land in the same block
-but B's digest comes first, B's `Requires` check misses the ring and the digest is buffered, costing
-a slot of latency.
-
-To ensure we are not relying on JAM provided order, PS reorders the block's digests.
-The solution is to build a dependency graph based on the speculative `Provides` and `Requires`.
-
-If B's `spec_msg_requires` contains `(A, root)` and A's `spec_msg_provides` is `Some(root)`, add an
-edge from `A -> B`. The source `ParaId` selects A and root equality confirms the dependency. For a para
-with multiple candidates in the block, also add an implicit edge from each candidate to its successor, such
-that the chain order is a hard constraint of the graph.
-
-The reorder is part of the consensus logic, therefore the sort must be deterministic. This is done using
-Kahn's algorithm. Among the nodes with in-degree zero, the digest with the smallest index in JAM's
-original operand order is picked. This yields the lexicographically smallest topological order:
-deterministic, but not stable. A digest blocked behind a dependency lets later unrelated digests move
-ahead of it. Digests with no incident edges keep their relative order
-
-Cycles need no separate detection pass. When Kahn's zero in-degree set empties with nodes remaining,
-the acyclic part is already emitted in sorted order and the remaining nodes are appended in JAM's original
-order. Only the cyclic digests lose the reorder benefit, while the rest of the block is unaffected.
-The cyclic digests themselves miss settlement, are buffered, deadlock on each other and expire after `K` slots.
-
-## 5. Bootnodes Discovery via Para-Owned KV
-
-Speculative messaging relies on two mechanisms to fetch messages:
-- request-response `/spec-msg/exchange` protocol (same as v0.5 SpecMsg design)
-- (from Tier 3) PVF exported payloads to DA as framed segments
-  The DA exports are added from `Tier 3` and offers a bootnode agnostic fallback to fetch messages.
-
-Therefore, the parachain must discover bootnodes before communicating on the p2p layer.
-The para's runtime maintains its list in the existing KV store (tag `0x08`):
+Receivers fetch messages over the request-response `/spec-msg/exchange` protocol (same as the
+v0.5 SpecMsg design), so a node must discover the source para's peers first. Each para
+publishes its bootnodes in the existing para-owned KV store (tag `0x08`):
 
 ```rust
 /// Full storage key: 0x08 ++ SCALE((para_id, BOOTNODES_KEY)).
@@ -390,361 +174,83 @@ struct Bootnode {
 }
 ```
 
-The parachain service doesn't verify the `AddressRecord` fields. The admission of a new
-address into the book is part of the Parachain runtime logic.
-
-Initially the chain operator will setup the network via an explicit `--bootnodes` CLI flag. Once the chain
-is registered new collators and nodes can join by reading the `AddressRecord` under the storage key.
-
-> Note: KV writes are charged and skipped on **insufficient balance**.
-
-## 6. Speculation Tiers
-
-Each tier is named after the sender-side event the consumer trusts:
-**Enacted, then Guaranteed, then Announced, then Imported and Fused**.
-
-> Speculation risk: a race condition between A's ring push and B's requires check against the ring.
-Since both candidates are independent, they have their own travel time through guaranteed, then availability,
-then the accumulate pipeline. And either can stall or get rejected. If B report accumulates first, the
-settlement check reads A's root before the update and B is rejected.
-
-- **Tier 0: Enacted (Safe Baseline MVP)**:
-  - consume enacted roots with HRMP parity. The requires entry carries `(ParaId, StreamsRoot)` and settlement checks the root against the ring
-  - latency: 1 or 2 slots from guarantee to accumulate, plus receiver build and submission time (between 12 and 24+ seconds)
-  - optimization: node-side fetches `StreamsRoot` from guanranteed but not yet accumulated reports
-  - race condition: structurally impossible since `A` is already enacted. The only remaining risk is not matching the `Provides`
-    against the `W` settlement ring size.
-
-- **Tier 1: Guaranteed (A little faster)**
-  - consume guaranteed but not yet enacted roots (acts on optimization from Tier 0)
-  - latency: saves 1 or 2 slots
-  - risk: if settlement fails `B` burns its slot (`A` can die or `A` lands later)
-  - solution for race condition:
-    - 1. Node side timed work package submission heuristic
-    - 2. PS topological sort of dependencies
-    - 3. PS Buffering
-    - 4. (Optional): `prerequisites` fields (capped at `J = 8`)
-  - In theory, same block `A -> B` is possible 
-
-- **Tier 2: Announced (High Speed Communication)**
-  - consume best-block roots advertised via `/spec-msg/announce` notification protocol
-  - Announced roots represent fetching hints. Before `Refine`, the package builder must retarget
-  the lifts to the final candidate root. An intermediate announced root must never be writted directly into `Requires`.
-  The `/spec-msg/announce` carries the exact `work_package_hash` and the final `StreamsRoot`.
-  - latency: saves 2 or 4 slots
-  - risk: if settlement fails `B` burns its slot (`A` can die or `A` lands later)
-  - relies on llv2 ack / slashing since building block `A` is cheap
-  - solution for race condition:
-    - 1. `prerequisites` fields: work package hash is distributed offchain via `/spec-msg/announce` (capped at `J = 8`)
-    - 2. PS Buffering 
-
-**Tiers with lower implementation priority**
-
-- **Tier 3: InCore Imported/DA Layer**: delivery via in-core segment import
-  - B's report names A's segment root. JAM parks the report in the ready queue until the segement dependency is resolved
-  - B can't accumulate before A, the ring still guards cases when `A` is rejected
-  - If `A` segments never become available, `B` package isn't refined and the slot isn't burned
-  - Needs to a segment framing to export the speculative messages, which can land at a later time
-  - latency: **Same as T0/T1**
-  - race condition: doesn't apply since `B`'s report has a prerequisite on `A`
-
-- **Tier 4: Fused / SuperChains**
-  - Both candidates are bundled in the same work package, utilizing the same core
-  - Ordering is resolved while creating the work package
-  - Parachain Service must ensure that if multiple candidates are bundled in the same work package
-  the whole group is declined if one of them fails
-  - If candidates are built by different collators, they must negotiate via p2p protocols which one is trusted with the package
-
-**Node side timed work package submission**
-
-The receiver sees A's report in the guarantees extrinsic and reads the work package hash and core from the
-report and the `StreamsRoot` from `spec_msg_provides`.
-The payloads are immediately fetched from p2p layer and verified locally. The receiver `B` work package is created but not submitted.
-
-The `B` package is submitted once count assurance bits for A's core are near 2/3. This gives a higher chance for `A`'s report
-to Accumulate within 1-2 slot delay until `B` accumulates.
-
-- If `A` dies before `B` package is submitted, then `B` rebuilds against the latest T0 enacted root without burning the slot
-- If `A` dies after `B` package is submited, `B` remains buffered. `B`'s buffered digest can never settle
-  and just expires at `buffered_at + K`. Then, `B` forks immediately at T0 tier and rebuilds on the second buffered lane.
-- If `B`'s head doesn't advance after its package accumulates, then `B` burns the slot and conservatively rebuilds against T0
-
-## 7. Execution: End to End
-
-1. **A:** runtime appends outbound messages to per-destination stream MMRs
-   - Output: The runtime writes `StreamsRoot` into the pallet storage (and header digest). During the PS
-   Refine, after PVF execution the `validate_block` wrapper reads the root from the pallet and reports
-   it via `set_provides_root`. PS never decodes the header.
-   - (Tier InCore) PVF `export()`s payloads and node-side archives them.
-
-2. **JAM:** report guaranteed -> available -> accumulated
-    - step 6 writes A's head and pushes its `spec_msg_provides` root into `ring[A]`.
-
-3. **B:** node follows A's enacted heads, fetches payloads (p2p exchange preferred for low latency, or DA)
-   - verifies fetched messages and their stream proofs against each source's `StreamsRoot`
-   - authors a block consuming stream prefixes and records the consumption
-   - in-core the validation wrapper verifies the PoV-carried lifts, stitches bundle intervals and gap
-   proofs, and synthesizes each source's `(ParaId, StreamsRoot)` via `set_requires_root`. Failures
-   abort with `RefineLog`.
-   - on-chain, the settlement check (§2) verifies each named root is in its source's ring, then B enacts.
-
-## 8. Forced Recovery
-
-`parachain_set_head` rolls back A's enacted history causing two side effects:
-- Every consumer channel desyncs. The sender's next root will not extend the roots consumers are already following.
-- Deliveries from rolled-back blocks cannot be undone. If A enacts "burn, then mint X on B" and B delivers it before
-  the rollback, B's supply is permanently inflated. No layer can retract a delivered message.
-
-A `parachain_set_head` that overwrites a live chan head will clears A's settlement ring.
-If any candidate attempts to consume the abandoned history, it will reference a root that is no longer in the ring.
-Because it cannot settle, it is buffered and simply expires after `K` slots.
-
-Everything beyond this is handled via off-chain policy. Forced recovery is a runbook procedure, and Coretime ensures
-an abandoned history is never silently resumed. The runbook treats a forced `set_head` as a trigger to reset all inbound channels:
-1. Consumers freeze a channel upon seeing a ring clear or a non-extending root.
-2. Prefetched messages are discarded.
-3. The channel resumes only through an explicit reopen
-
-Before reopening the channel, the sender must reconcile what was delivered under the abandoned roots and compensate its counterparties.
-Without this, every recovery turns the sender into an inflation source. When operation resumes, re-sent messages may overlap with ones
-already delivered, but previously delivered messages always stand.
-
-> Note: A dormant chain's ring persists, meaning its final messages remain drainable at the Enacted tier.
-The `parachain_clean_up` routine removes the ring, permanently ending drainability.
-
-## 9. Super Chains
-
-A superchain pair consumes each other's speculative output every step (A consumes B in this block and B consumes an earlier A block).
-Because of how it's designed, this loop works safely on JAM.
-
-> Why not mutual JAM `prerequisites`?
-> An honest author cannot even encode the cycle. `P_A` would need `hash(P_B)` which needs `hash(P_A)`
-> Colluding guarantors *can* put mutually-referencing reports on chain, but those park in the ready queue,
-> never release, and are silently discarded at the epoch boundary.
-
-- **Solution 0: Fusion** *(the plan)*: both candidates as work items of one package on one core.
-
-  The core idea is to bundle both candidates into a single work package and run them on the same core.
-  The PS must guarantee all or nothing, either all succeed or none succeed.
-
-  To prevent cycles, we enforce strict orders: B goes first, then A.
-  - B runs and looks at A's previous state
-  - A runs and looks at B's current state (by reading B's header SPMG)
-
-  Since they share the same core, they are also capped in terms of resources. Both candidates
-  must share the ~13.8 MiB and 5 billion gas limit. The most likely bottleneck would be the tiny 48 KiB limit for the result.
-
-  Securing the link between A and B inside the core:
-  - in core: We put B's header at a fixed offset. A reads and checks the `R_B` hash from the header digest. 
-  - backup: Add a new digest field that carries A's claimed `(sibling, root)` and rely on Accumulate to double check it
-  against B's `spec_msg_provides`.
-
-- **Solution 1: Ordered pair**
-  If a single core limit becomes an issue, we can separate them onto two cores but force synchronization by `prerequisites`.
-
-  B adds A's work hash as prerequisite and will never accumulate before A. Then, A can import the B's exports.
-  The timing here is a bit fragile, B must follow A in the exact slot or at most within last 8 slots. If B misses the
-  report is silently discarded at epoch boundary. 
-
-- **Solution 2: Asymmetric parking**
-
-  This is a fallback logic for when things get out of sync.
-  If A is enacted, but B fails to enact, the system won't enact A until B can enact.
-  A is parked for a timeout and if B takes too long or never arrives, A is dropped as well.
-
-## Appendix
-
-This appendix records an unscoped alternative to on-chain ring settlement. It applies only
-to the Enacted tier and is not part of the MVP or the design above.
-
-### Alternative Verification
-
-The RefineContext carries the anchor's accumulation-output-log super peak, authenticated by JAM.
-Verification happens in-core, in the receiver parachain's Refine. Since speculation happens at
-enactment, the super peak commits to what PS accumulated at the sender's enacting block.
-
-During Accumulate, at the same point where a `Provides` root is pushed into the sender's ring,
-PS also emits `Leaf { para_id, streams_root }` into a per-block provides tree. Its root is
-committed next to the changed-heads root in PS's accumulation output:
-
-```
-output = keccak("ps-out-v1" ++ heads_root ++ provides_root)
-```
-
-A provides leaf exists only for a candidate that enacted, and it carries exactly the value the
-sender reported via `set_provides_root`: the same value ring settlement checks. No header is
-involved anywhere.
-
-The changed-heads *tree* stays byte identical, but the output commitment changes shape: every
-existing belt consumer (light clients, bridges) that walked `belt leaf → heads_root` directly
-must be upgraded to supply the `provides_root` sibling and the version tag. This is a
-coordinated format migration, not a drop-in change.
-
-**Tree construction (consensus rules).** The provides tree is a binary keccak tree with
-mandatory domain separation:
-
-- leaf: `keccak(0x00 ++ para_id ++ streams_root)`
-- interior node: `keccak(0x01 ++ left ++ right)`
-
-Leaves are sorted by `para_id`; a para enacting multiple candidates in one block contributes
-multiple leaves, ordered by accumulation order. A single-leaf tree's root is the leaf hash. A
-block in which no para provides commits the constant
-`EMPTY_PROVIDES_ROOT = keccak("ps-provides-empty-v1")`, so the output shape never varies and a
-heads-only commitment can never be reinterpreted. The in-block `(service, output)` pairs tree
-uses the same leaf/interior tags. The tags are not optional: without them a 64-byte leaf
-encoding is byte identical to an interior preimage and interior-as-leaf forgeries open up.
-Sorted leaves also make non-membership provable ("para A provided nothing at this block"),
-usable for the §8 channel-freeze policy.
-
-Walking the super-peak:
-
-```
-anchor super-peak → belt leaf → (PS, output) pair → provides_root → Leaf { para_id, streams_root }
-```
-
-### Proof Format
-
-Every path carries its position; side bits at each level derive from the index, so hashing is
-never commutative and every leaf is position bound.
-
-```rust
-/// Depth caps, enforced before any hashing. An oversize or malformed proof
-/// aborts Refine with `RefineLog`; no panics, checked index arithmetic only.
-const MAX_BELT_DEPTH: usize = 64;     // u64 leaf index bounds the MMR
-const MAX_PAIRS_DEPTH: usize = 16;    // services accumulating per block
-const MAX_PROVIDES_DEPTH: usize = 16; // provides leaves per block
-
-struct EnactmentProof {
-    /// Position of the enacting block's belt leaf in the accumulation-output log.
-    belt_leaf_index: u64,
-    /// Intra-peak siblings, `<= MAX_BELT_DEPTH`.
-    belt_peak_path: Vec<Hash>,
-    /// Remaining peak bag, folded per `belt_leaf_index`, `<= MAX_BELT_DEPTH`.
-    belt_peaks: Vec<Hash>,
-    /// Position of the `(PS, output)` pair in the block's pairs tree.
-    pairs_index: u16,
-    /// Siblings in the pairs tree, `<= MAX_PAIRS_DEPTH`.
-    pairs_path: Vec<Hash>,
-    /// PS's changed-heads root for that block, the sibling of `provides_root`
-    /// in the output commitment.
-    heads_root: Hash,
-    /// Position of the provides leaf.
-    provides_index: u16,
-    /// Siblings in the provides tree, `<= MAX_PROVIDES_DEPTH`.
-    provides_path: Vec<Hash>,
-}
-```
-
-Verification, in the receiver's Refine:
-
-1. Enforce the depth caps and decode; failure aborts with `RefineLog` before any hashing.
-2. Recompute `leaf = keccak(0x00 ++ para_id ++ streams_root)` from the verifier's own
-   `Requires` target. Nothing semantic is ever extracted from the proof.
-3. Walk `provides_path` (sides from `provides_index`) up to `provides_root`.
-4. Recombine `output = keccak("ps-out-v1" ++ heads_root ++ provides_root)`.
-5. Recompute the pair leaf from the verifier's own PS service id constant and `output`, walk
-   `pairs_path` (sides from `pairs_index`) up to the block's belt leaf.
-6. Walk `belt_peak_path` and fold `belt_peaks` per `belt_leaf_index` up to the anchor super
-   peak; compare against the RefineContext value.
-
-Every step is a hash membership check on values the receiver already holds; a proof cannot
-settle any root other than the one being asked about.
-
-**Service id binding is the security of the scheme.** Every service fully controls its own
-output bytes, so any attacker can register a service and emit
-`keccak("ps-out-v1" ++ x ++ fake_provides_root)` where the fake tree contains
-`Leaf { victim_para, evil_root }`. The only thing separating that from a universal forgery is
-step 5: the pair leaf is recomputed from the PS service id the verifier already knows, never
-read from the proof.
-
-**Replay.** Settlement (ring or proof) only ever answers "was this root enacted". Which
-messages get consumed is guarded solely by the receiver's consumption frontier, enforced by
-its registered PVF: stream positions are append-only, and a `parachain_set_head` reverts the
-frontier and the consumption effects atomically, so double delivery is impossible while both
-endpoint histories are continuous. The discontinuous cases are Known Limitations below.
-
-### Costs
-
-Proofs ride in the work item payload next to the Lift proofs, are consumed in Refine and
-discarded. Only the resulting `(ParaId, StreamsRoot)` entries (~36 B each) reach the digest;
-Accumulate performs zero settlement reads. The bytes are paid in package size, DA erasure
-coding and audit re-execution, not in the 48 KiB report.
-
-Path length grows with chain age, not activity. At ~2^26 belt leaves (about a decade of 6 s
-blocks) a proof is ~2.5 KiB per consumed source; the depth caps bound it at ~5.2 KiB. Naive
-full fan-in (32 sources, §1) is ~80 KiB, ~165 KiB at the caps (~1.2% of the package budget).
-Sources enacted in the same block share `belt_*`, `pairs_*` and `heads_root`, so the wire
-format groups proofs by enacting block: each co-enacted source adds only its provides path
-(~450 B), bringing full fan-in to ~16 KiB in the common case. Verify gas is at most ~161
-keccaks of 64 B per source.
-
-Proofs verify against the anchor super peak, so they are anchor specific: a resubmission that
-re-anchors (§2 note) needs freshly generated proofs. Collator tooling must not cache them
-across anchors.
-
-### Trust Model
-
-Ring settlement trusts an Accumulate state read. Here the load-bearing check runs in Refine,
-so the trust root moves to ELVES-audited in-core execution. The verification must live in
-PS's own Refine logic, not in the §1 wrapper checks that are explicitly collator-vs-collator.
-The digest carries a PS-attested flag marking entries as proof-settled, and Accumulate skips
-the ring read exactly for those: while both mechanisms coexist, every `Requires` entry is
-settled by exactly one of them, never neither.
-
-### Why not walk to the header
-
-An earlier form of this proof walked `belt leaf → heads_root → Leaf { para_id, head_hash }
-→ header preimage → SPMS digest → StreamsRoot`, carrying the full sender header in the PoV.
-It had provable defects:
-
-- **Unbound root.** The ring is fed from `set_provides_root` (pallet storage); the SPMS header
-  digest is written separately by the sender runtime. PS is header agnostic and never checks
-  they agree, so a buggy or malicious runtime can settle one root on-chain while its header
-  proves a different one in-core. The two settlement paths diverge silently and consumers can
-  be made to settle a root that never entered the settlement system.
-- **Bundles break the walk.** For bundled PoVs the wrapper carries the last produced `Provides`
-  forward when later inner blocks send nothing. Only the candidate-boundary head enters the
-  changed-heads tree, so the enacted header's digest need not contain the settled root at all.
-  For such candidates the proof simply has no path to the root: verification fails on honest
-  history.
-- **Opaque preimage.** `head_hash` commits to opaque head-data bytes. Decoding them as a header
-  with a known digest layout is a format assumption PS nowhere enforces, and every proof hauls
-  up to 4 KiB of header into the PoV just to read 32 bytes out of it.
-
-Pushing the root as its own PS-authored leaf removes all three: the leaf is created by PS
-itself, at enactment, from the host-call value, for the effective candidate-boundary root.
-
-### Known Limitations
-
-**1. Canonicality.** The accumulation-output log is append-only, so this proof shows a root
-*was* enacted, permanently and with unbounded reach (no `W_MAX` window). It cannot show the
-enacting history is still canonical: `parachain_set_head` (§8) clears the ring precisely so
-abandoned roots stop settling, and no rollback can retract a belt leaf. As a full replacement
-for ring settlement this scheme must be paired with a per-para generation key: the receiver's
-Accumulate checks the sender's current generation at settlement, and the generation bumps on
-every `parachain_set_head` that overwrites a live head, on `parachain_clean_up`, and on para
-id (re)registration. Bumping is coarse: it also invalidates proofs for the still-canonical
-prefix. That matches ring semantics, since a ring clear drops prefix roots too, and §8's
-runbook already freezes and explicitly reopens every channel after recovery. Alone, without
-the generation key, this scheme is only safe for histories Forced Recovery has never touched.
-
-**2. Generation TOCTOU.** The proof verifies in Refine against an anchor up to `C_H = 8`
-slots stale; the generation is checked at Accumulate. A recovery landing in that window makes
-a candidate fail on-chain after passing in-core: the slot is burned and, unlike ring
-settlement, §3 buffering cannot rescue it, because the verification is already fixed at
-Refine. Same acceptance class as the Coretime-ordering window noted in §2.
-
-**3. Para id reuse.** `parachain_clean_up` removes the ring and permanently ends drainability
-(§8); a belt leaf can never be removed. Without the generation bump on cleanup and
-re-registration above, a para id re-registered to a new chain inherits provable
-`Leaf { para_id, root }` history from its predecessor, and receivers can be made to consume
-the dead chain's messages as the new one's.
-
-**4. Enacted tier only, no buffering.** A root missing at Refine fails the candidate in-core:
-there is nothing for §3 buffering to wait on, and §4's sort cannot help. The scheme cannot
-serve Tiers 1-2, which settle at Accumulate time by construction. "Full replacement" is only
-meaningful if those tiers keep the ring or are dropped.
-
-**5. Proof-data liveness.** The ring needed only current state; generating a proof for an old
-root requires reconstructing that block's provides tree from chain history. Unless an indexer
-retains them, old roots stay theoretically provable but practically unsettleable.
+PS does not verify the `AddressRecord` fields and admission into the record is parachain runtime
+logic. KV writes are charged and skipped on insufficient balance.
+
+During the initial chain setup, the operator provides an explicit `--bootnodes` CLI flag.
+Once that record is published to the chain, any new collators and nodes can easily join by reading it.
+
+## End to End
+
+1. A's runtime appends outbound messages to per-destination stream MMRs and writes the
+   `StreamsRoot` to pallet storage.
+2. A's Refine reports the root via `set_provides_root`. A's Accumulate enacts the head and
+   pushes the root into `ring[A]`.
+3. B's node follows A's enacted heads, fetches the messages over `/spec-msg/exchange`, and
+   verifies them against A's `StreamsRoot`.
+4. B authors a block consuming stream prefixes. B's Refine verifies the PoV Lifts and sets
+   `Requires`. B's Accumulate settles each entry against the ring and enacts.
+
+## Implementation Tasks
+
+This list only covers work that is entirely new or requires changes specifically for JAM.
+
+The existing parachain-side stack from the Polkadot rollout (primitives, spec-messaging pallets,
+channel lifecycle, XCM routing, `/spec-msg/exchange`, archive, fetcher, message pool, and
+lift assembly) carries over unchanged.
+
+**Umbrella 1 — Parachain Service**
+
+- [Task 00] Work digest and host calls: Implement `spec_msg_provides` and `spec_msg_requires`
+  fields in `ParachainWorkDigestOk`.  
+  Add `set_provides_root` and `set_requires_root` host calls.  
+  Enforce Refine rules: max one call each, unique sources, and a 32-entry maximum.
+- [Task 01] Settlement ring: `spec_msg_cursor` / `spec_msg_queue` / `spec_msg_member` storage.  
+  Push on candidate enactment with position-based eviction and re-push handling.
+- [Task 02] Settlement check: Per-`Requires` membership read in Accumulate.  
+  Candidate rejected when any entry misses.
+- [Task 03] Ring teardown: Clear the ring in `parachain_set_head` (live-head overwrite) and
+  `parachain_clean_up`.  
+  Walk `head - 1` down to `tail`, Coretime provides sufficient gas budget for the full walk.
+
+**Umbrella 2 — `validate_block` wrapper**
+
+- [Task 04] Provides reporting: After PVF execution read the root from pallet storage and
+  report it via `set_provides_root`.  
+  Carry the last produced root forward across bundle blocks.
+- [Task 05] Requires synthesis: Read `ConsumptionRecords` from pallet storage, verify the PoV
+  lifts, stitch consumption gaps, union per source for bundles, report via
+  `set_requires_root`.  
+
+**Umbrella 3 — Bootnode discovery**
+
+- [Task 06] Runtime publishing: Maintain the `AddressRecord` under KV tag `0x08`
+  (`bootnodes/v1`): admission logic, `seq` bumping, expiry.
+- [Task 07] Node side: Proof-of-possession signing and verification, record reading to
+  discover a source para's peers, `--bootnodes` CLI flag for initial setup, feeding the peer
+  registry.
+
+**Umbrella 4 — Node adaptations**
+
+- [Task 08] Provides monitor on JAM: Follow PS enacted state instead of the relay
+  `RecentProvides` key.  
+  Read the source's ring, emit exactly-once per-root events into the existing fetch pipeline.
+- [Task 09] Prefetch from guaranteed reports: Read `spec_msg_provides` out of the guarantees
+  extrinsic of imported JAM blocks, before the report accumulates, and fetch the messages
+  under that root over `/spec-msg/exchange` right away.   
+  Hand them to the pool only once the monitor sees the root in the ring, since a guaranteed
+  report can still time out or be disputed.  
+  Saves network lantency and needs no consensus change.
+- [Task 10] Eviction watch and resubmit: For every candidate submitted but not yet enacted,
+  track its `Requires` roots against the source ring (`MemberEntry.seq` vs the cursor tail).  
+  When a root falls out of the 64-entry window, regenerate the lifts against the source's
+  latest enacted root and resubmit.  
+  The consumed prefix is unchanged since the MMR only grows.
+- [Task 11] Collator wiring: Wire monitor, fetcher, pool and lift assembly into the JAM
+  parachain collator node.
+
+**Umbrella 5 — End-to-end gate**
+
+- [Task 12] JAM end-to-end test: Two paras on a local JAM network: sender push into the ring,
+  receiver settlement and enactment, rejection on window eviction, ring teardown.  
+  Gates any testnet rollout.

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -155,21 +155,26 @@ If a root is repeated, the `MemberEntry` is updated with the new position, leavi
 
 ```rust
 fn push(para: ParaId, root: StreamsRoot) {
-  let mut cursor = spec_msg_cursor.get(para);
+  let mut cursor = spec_msg_cursor.get(para);                              // 47 B read
 
   // Eviction
   while cursor.head.wrapping_sub(cursor.tail) >= W_MAX {
-    let to_evict = spec_msg_queue.get(&(para, cursor.tail));  // 75 B read
-    let entry = spec_msg_member.get(&(para, to_evict));       // 75 B read
+    let to_evict = spec_msg_queue.get(&(para, cursor.tail));               // 75 B read
+    spec_msg_queue.remove(&(para, cursor.tail));                           // delete
+
+    let entry = spec_msg_member.get(&(para, to_evict));                    // 75 B read
     if entry.seq == cursor.tail {
-      // Head submitted again more recently.
-      spec_msg_member.remove(&(para, to_evict));
+      // Tail slot is this root's latest occurrence: membership expires.
+      spec_msg_member.remove(&(para, to_evict));                           // delete
     }
-    spec_msg_queue.remove(&(para, cursor.tail));              // 75 B write
-    spec_msg_member.insert((para, root), MemberEntry { seq: cursor.head}); // 75 B write 
-    cursor.head = cursor.head.wrapping_add(1);
-    spec_msg_cursor.set(para, c); // 47 B write
+    // else: root was re-pushed since; the newer slot keeps it alive.
+    cursor.tail = cursor.tail.wrapping_add(1);
   }
+
+  spec_msg_queue.insert((para, cursor.head), root);                        // 75 B write
+  spec_msg_member.insert((para, root), MemberEntry { seq: cursor.head });  // 75 B write
+  cursor.head = cursor.head.wrapping_add(1);
+  spec_msg_cursor.set(para, cursor);                                       // 47 B write
 }
 ```
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -28,10 +28,10 @@ For bundled PoV, only the candidate-boundary StreamsRoot is added to the settlem
 Messages from inner blocks can still be consumed, but the receiver PoV must lift the stream state
 to the final root. Inner blocks cannot be settled directly.
 
-To ensure we can change the digest layout in the future while having coexisting versions, the `SpmsDigest` is a versioned enum. 
+To ensure we can change the digest layout in the future while having coexisting versions, the `SpmsDigest` is a versioned enum.
 
-Refine rejects a header containing more than one SPMS digest or an unsupported version. Step 6 must
-treat either case as an absent digest. PS support for a new version must be activated before parachains emit it.
+PS Refine decodes the candidate-boundary header. It rejects more than one SPMS digest or an
+unsupported version (PS support for the new version must be released before parachains use it).
 
 ```rust
 /// SCALE-encoded payload of `DigestItem::Consensus(SPMS_ENGINE_ID, ..)`
@@ -45,16 +45,27 @@ enum SpmsDigest {
 }
 ```
 
-2. Digest fields: `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 64>` on the PS work digest
+2. `Provides` and `Requires` fields on the PS work digest
+
+```rust
+spec_msg_provides: Option<StreamsRoot>,
+spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 64>,
+```
+
+The PS Refine wrapper derives `spec_msg_provides` from the candidate-boundary `SpmsDigest`.
+`Accumulate` consumes this field and never decodes the parachain header.
 
 The `spec_msg_requires` must not be chosen by the parachain block. Otherwise it can state any consumption.
 The block records what is consumed, then the PS Refine wrapper verifies the PoV carried lift,
 stitches bundle intervals and gap proofs, and synthesizes a `(ParaId, StreamsRoot)` per source.
 
-The PS Refine should write `spec_msg_requires` directly after verifying the consumption records and PoV lifts.
+The PS Refine writes both fields after decoding the header and verifying the consumption records and PoV lifts.
 
 To ensure canonical encoding and uniqueness, the PS Refine wrapper produces unique entries sorted by `ParaId`.
 The Refine phase rejects malformed input.
+
+`spec_msg_provides` lets `Accumulate` update the sender's settlement ring and construct the dependency graph.
+It costs 33 bytes when present.
 
 `spec_msg_requires` is a digest field, because UMP signals are replayed after the head write (so it can't gate enactment).
 At 36 bytes each, full fan-in costs ~2.3 KiB of the 48 KiB report.
@@ -63,9 +74,9 @@ At 36 bytes each, full fan-in costs ~2.3 KiB of the 48 KiB report.
 
 The settlement ring represents the last `W` enacted roots per para, keyed at `0x09 ++ para_id`.
 
-It is check and ring is delivered by the MVP implementation. If the enacted head carries an SPMS digest
-its root is pushed into the senders ring only if different from the newest entry. The ring evicts the
-oldest entry beyond `W`.
+The check and ring are delivered by the MVP implementation. When a work digest enacts, its
+`spec_msg_provides` root is pushed into the sender's ring only if present and different from the
+newest entry. The ring evicts the oldest entry beyond `W`.
 
 > `W` is no longer extra pipeline headroom. It is the window against which `Requires` must match.
 If a package `Requires` is not in the ring, that slot is lost. On polkadot, a stale candidate
@@ -79,7 +90,7 @@ Its ring is removed only when clean-up completes and ParaInfo is dropped.
 ```rust
 /// Keyed `0x09 ++ SCALE(para_id)`.
 /// 
-/// Step 6 pushes the enacted root at the head write iff != newest entry, evicts oldest.
+/// Step 6 pushes `spec_msg_provides` at the head write iff present and != newest entry, evicts oldest.
 /// Cleared when a forced `parachain_set_head` overwrites a live head.
 /// Read by settlement, never proved.
 spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>
@@ -160,7 +171,8 @@ settlement check reads A's root before the update and B is rejected.
 
 1. Node side timed work package submission
 
-The receiver sees A's reportin the guarantees extrinsic and fetch the work package hash, core and `StreamsRoot` from the header digest.
+The receiver sees A's report in the guarantees extrinsic and reads the work package hash, core and
+`StreamsRoot` from `spec_msg_provides`.
 The payloads are immediately fetched from p2p layer and verified locally. The receiver `B` work package is created but not submitted.
 
 The `B` package is submitted once count assurance bits for A's core are near 2/3. This gives a higher chance for `A`'s report
@@ -178,9 +190,9 @@ If sender A and consumer B land in the same block, but B core is first, then B `
 To ensure we are not relying on JAM provided order, PS reorders the blocks's digest.
 The solution is to build a depedency graph based on the speculative `Provides` and `Requires`.
 
-If B digest contains `spec_msg_requires` towards `A` and `A` has the same `StreamsRoot` as B's `Requires`, the we have
-an edge from `A -> B`. Edges are created by `ParaID` only. Then we run topological sort on the edges. Everything
-unrelated to speculative messaging remains unchanged.
+If B's `spec_msg_requires` contains `(A, root)` and A's `spec_msg_provides` is `Some(root)`, add an
+edge from `A -> B`. The source `ParaId` selects A and root equality confirms the dependency. Then we
+run topological sort on the edges. Everything unrelated to speculative messaging remains unchanged.
 
 If a cycle is detected, PS continues with the original order from JAM. The ring will reject the candidates naturally.
 
@@ -300,12 +312,12 @@ drainability with it.
 1. **A:** runtime appends outbound messages to per-destination stream MMRs
 
    - Output: one `StreamsRoot`, committed as `SpmsDigest::V0 { streams_root }` in A's own header digest.
-   Nothing else — no host call, no work-digest field.
+   No host call is needed. PS Refine decodes the header and writes the root to `spec_msg_provides`.
 
    - PVF `export()`s payloads and node-side archives them.
 
 2. **JAM:** report guaranteed -> available -> accumulated
-    - step 6 writes A's head and pushes the enacted root into `ring[A]`.
+    - step 6 writes A's head and pushes its `spec_msg_provides` root into `ring[A]`.
 
 3. **B:** node follows A's enacted heads, fetches payloads (p2p exchange preferred for low latency, or DA)
 
@@ -378,7 +390,7 @@ Because of how it's designed, this loop works safely on JAM.
   Securing the link between A and B inside the core:
   - in core: We put B's header at a fixed offset. A reads and checks the `R_B` hash from the header digest. 
   - backup: Add a new digest field that carries A's claimed `(sibling, root)` and rely on Accumulate to double check it
-  against the SPMS digest in B's new head data.
+  against B's `spec_msg_provides`.
 
 - **Solution 1: Ordered pair**
   If a single core limit becomes an issue, we can separate them onto two cores but force synchronization by `prerequisites`.

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -4,29 +4,24 @@ The [Parachain Service](https://github.com/paritytech/polkadot-sdk/blob/afe236db
 
 Here is a breakdown of exactly what needs to change to make Speculative Messaging work smoothly on JAM, ensuring every Polkadot feature has a clear, explicit JAM backport.
 
-> For MVP, if a root has already been enacted, B can simply prove the enactment in core.
-> Enactment itself is the commitment that needs no sender host call, no dedicated state, no cell.
+> For MVP, chains speculate at `Enactment` tier. Sender parachain `A` writes its `Provides/StreamsRoot` entry
+> inside a `recent_provides` settlement ring (bounded vector). Receiver `B` monitors the ring, fetches messages from `A` and targets its
+> `Requires` field agains the latest `recent_provides` entry. In the `Accumulate` phase, the PS ensures that
+> all `Requires` are matched against their respective `recent_provides` entries.
 
-The Parachain Service refine context carries the anchor's **accumulation-output-log super-peak**, and the 
-Accumulate output commits the heads that changed per block. Therefore, any root that was enacted
-is provable in-core from any recent anchor without any recency bound on enactment.
+Therefore, we introduce on-chain settlement from the MVP. The sender `StreamsRoot` is pushed to the ring,
+the consumer `Requires` field (ie `(ParaId, StreamsRoot)`) is checked against the ring. The same
+mechanism handles settlement for all speculation tiers.
+
+The settlement ring is used for monitoring rollbacks. When a `parachain_set_head` overwrites a live
+head, it will also clear out the parachain's ring. Abandoned roots are no longer consumed and recovery
+(resetting the channels, compensate for delivered messages) is a `Coretime` runbook procedure, not
+a consensus mechanims Speculative Messaging or PS provides.
 
 ```
 anchor super-peak → belt leaf → (PS, heads_root) → Leaf { para_id, head_hash }
   → header preimage → SPMS digest → StreamsRootA
 ```
-
-In-core validation proves the root was enacted; on-chain settlement then re-checks every consumed root
-against the sender's ring of recently enacted roots. Every consumer records `(ParaId, StreamsRoot)` per
-source in its digest.
-
-The settlement ring is live from day 0: every enacted SPMS root is pushed into the sender's ring at the
-head write, and settlement requires each consumed root to be present in its source's ring. The same
-machinery settles the higher speculation tiers later with no further consensus change.
-
-The ring is also the rollback brake: a forced `parachain_set_head` that overwrites a live head clears
-the para's ring, so abandoned roots stop being consumable immediately. Recovery beyond that (resetting
-channels, compensating deliveries) is a Coretime runbook procedure, not a consensus mechanism.
 
 
 ## Changes at Accumulation Tier MVP
@@ -46,7 +41,6 @@ This is the sender's consensus commitment relying only on 33 bytes in its header
 ```rust
 /// SCALE-encoded payload of `DigestItem::Consensus(SPMS_ENGINE_ID, ..)`: 33 bytes.
 enum SpmsDigest {
-    /// Versioned so we can have coexisting diget formats and coordonate the release schedule.
     /// Encodes to u8.
     V0 {
         /// The root of the sender's outbound message streams.
@@ -58,50 +52,36 @@ enum SpmsDigest {
 2. Digest fields: `spec_msg_requires: BoundedVec<(ParaId, StreamsRoot), 64>` on the PS work digest
 
 The field is set via `set_requires_root` host call at most once per `Refine`. Each entry names the
-consumed root itself, so settlement can re-check it against the source's ring from day 0.
+consumed root itself, so settlement can check it against the source's ring.
+
 At 36 bytes each, full fan-in costs ~2.3 KiB of the 48 KiB report.
+
 This must be a digest field and not UpwardMessage, because UMP replays after the head write (so it can't gate enactment).
 
-3. `declare_budget(distinct_sources)` mandatory, once per Refine, before the first spec-msg call
+3. Settlement: ring `spec_msg_recent_provides` and `Requires` check
 
-At MVP, the `declare_budget(distinct_sources)` declares upfront how many distinct `ParaId`
-sources it will touch. Then, lets the `Refine` wrapper reserve gas for proof verification before the
-work starts.
+The settlement ring represents the last `W` enacted roots per para, keyed at `0x09 ++ para_id`.
 
+It is check and ring is delivered by the MVP implementation. If the enacted head carries an SPMS digest
+its root is pushed into the senders ring only if different from the newest entry. The ring evicts the
+oldest entry beyond `W`.
 
-4. Settlement: the requires check runs at §5.1 step 6, against the day-0 ring `spec_msg_recent_provides`
-
-The settlement ring represents the last `W` enacted roots per para, keyed at `0x09 ++ para_id`. It is
-live from day 0: at the head write (§5.1 step 6), if the enacted head carries an SPMS digest, its root
-is pushed into the sender's ring — iff different from the newest entry, evicting the oldest beyond `W`.
-Paras that never emit SPMS digests never write. A forced `parachain_set_head` that overwrites a live
-head clears the ring instead.
+A forced `parachain_set_head` that overwrites a live head will also clear the ring.
 
 ```rust
 /// Keyed `0x09 ++ SCALE(para_id)`.
 /// 
-/// §5.1 step 6 pushes the enacted root at the head write iff != newest entry, evicts oldest.
+/// Step 6 pushes the enacted root at the head write iff != newest entry, evicts oldest.
 /// Cleared when a forced `parachain_set_head` overwrites a live head.
 /// Read by settlement, never proved.
 spec_msg_recent_provides: Map<ParaId, BoundedVec<StreamsRoot, W>>
 ```
 
-The ring is charged at first write rather than priced from the day-0 baseline. An unfunded parachain still
-receives and consumes; what it cannot do is fund its own ring, so its roots never become consumable — it
-cannot act as a source at any tier until funded.
-
-The requires check itself sits at the head of §5.1 step 6 — the last gate, so passing implies enacting,
-and before the head write, so a rejected `B` never publishes a root of its own. Every requires entry's
-source must exist and the named root must be present in the source's ring, or the candidate is rejected.
-The candidate is rejected silently and the receiver `B` monitors off-chain similar to `parent-head` or 
-`check-code` failures. Otherwise, letting rejected candidates append `AccumulateLogs` would let junk
+The ring is charged from the baseline of the parachain. Passing the settlement ring check implies that
+the candidate will enact. Every requires entry source must exist and the named root must be present in the ring.
+The candidate is rejected silently and the receiver `B` monitors offchain this behaviour, similar to
+`parent-head` or `check-code` failures. Otherwise, letting rejected candidates append `AccumulateLogs` would let junk
 candidates push out valuable entries.
-
-The ring check bounds which roots are consumable to the source's last `W` **enacted roots** — a bound in
-enactments, not in time: a dormant sender's ring persists, and because streams are cumulative MMRs, any
-newer root reaches every older message via lifts. Catch-up stays unbounded; consumers simply verify
-against a recent root.
-
 
 > Note: A forced rollback (`ParachainSetHead` from the Coretime chain) isn't applied instantly. Its an upward message,
 replayed at step 7 when the Coretime chain's own package accumulates. Packages accumulate in order within a block,
@@ -124,9 +104,7 @@ this is accepted rather than solved (ie draining Coretime's commands before any 
 
 - **T1b Backed / Active**
   - saves 1 or 2 slots
-  - **zero consensus change**: the requires entry already carries the root and the ring is already
-    live and checked at settlement — the tier is purely node-side (B dares to consume a root that
-    is guaranteed but not yet enacted; the in-core enactment proof is skipped since none exists yet)
+  - needs no consensus change
   - `A` guaranteed report can die and `B` burns its slot (ie `A` must land first or `B` burns a slot)
   - Same block `A -> B` is possible since Accumulation happens in order and A's ring push lands before B's settlement runs.
 

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -24,17 +24,18 @@ We are releasing with the Enacted tier (HRMP parity) from day 0. The changes nee
 
 1. Sender header digest: `DigestItem::Consensus(SPMS_ENGINE_ID, enum SpmsDigest)`.
 
-This payload is the leaf that every enactment proof walk terminates on. To ensure we can change the
-digest layout in the future while having coexisting versions, the `SpmsDigest` is a versioned enum. 
-
 For bundled PoV, only the candidate-boundary StreamsRoot is added to the settlement ring.
 Messages from inner blocks can still be consumed, but the receiver PoV must lift the stream state
 to the final root. Inner blocks cannot be settled directly.
 
-This is the sender's consensus commitment relying only on 33 bytes in its header.
+To ensure we can change the digest layout in the future while having coexisting versions, the `SpmsDigest` is a versioned enum. 
+
+Refine rejects a header containing more than one SPMS digest or an unsupported version. Step 6 must
+treat either case as an absent digest. PS support for a new version must be activated before parachains emit it.
 
 ```rust
-/// SCALE-encoded payload of `DigestItem::Consensus(SPMS_ENGINE_ID, ..)`: 33 bytes.
+/// SCALE-encoded payload of `DigestItem::Consensus(SPMS_ENGINE_ID, ..)`
+/// Aproximately 39 bytes in its header.
 enum SpmsDigest {
     /// Encodes to u8.
     V0 {
@@ -71,6 +72,9 @@ If a package `Requires` is not in the ring, that slot is lost. On polkadot, a st
 can retry for free. On JAM, each retry costs another slot.
 
 A forced `parachain_set_head` that overwrites a live head will also clear the ring.
+For a parachain with an existing head, a byte-identical `parachain_set_head` is a no op.
+While `is_deregistering`, the parachain cannot submit work but remains a valid Requires source.
+Its ring is removed only when clean-up completes and ParaInfo is dropped.
 
 ```rust
 /// Keyed `0x09 ++ SCALE(para_id)`.

--- a/docs/speculative-messaging-on-jam.md
+++ b/docs/speculative-messaging-on-jam.md
@@ -1,0 +1,226 @@
+# Speculative Messaging on JAM
+
+The [Parachain Service](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#3-the-parachain-service) needs a robust messaging system to replace the older HRMP-style payloads, and [Speculative Messaging](https://github.com/paritytech/polkadot-sdk/blob/9d0a0daee40e6e350209aaf4b3e3bdf1fb9a8793/docs/speculative-messaging-design.md) is our primary candidate for JAM.
+
+Here is a breakdown of exactly what needs to change to make Speculative Messaging work smoothly on JAM, ensuring every Polkadot feature has a clear, explicit JAM backport.
+
+## 1. Consensus and State Changes
+
+### 1.1 Digest Fields Replace UMP Signals
+
+On Polkadot, `Provides` and `Requires` travel as [UMP signals](https://github.com/paritytech/polkadot-sdk/blob/436cd3373a71f1c2251ce3976ee04220cf2646be/polkadot/primitives/src/v9/mod.rs#L2740-L2760).
+
+In JAM, the consensus output per candidate is `ParachainWorkDigest::Ok`, which is assembled by the refine wrapper.
+
+We need to add two new digest fields (optionally present and at most once per child PVM via `set_provides_root` and `set_requires`).
+If a duplicate call is made, Refine fails. At 64 sources, this takes up about 2.3 KiB, which is a comfortable 5% of our 48 KiB work-report budget.
+
+```rust
+const MAX_REQUIRES_SOURCES: u32 = 64;
+
+struct SpecMessagingDigest {
+    provides: Option<StreamsRoot>,
+    requires: BoundedVec<(ParaId, StreamsRoot), MAX_REQUIRES_SOURCES>,
+}
+
+enum ParachainWorkDigest {
+    Ok {
+        para_id: ParaId,
+        // .. existing variants
+        spec_messaging: SpecMessagingDigest,
+    }
+}
+```
+
+### 1.2 The `RecentProvides` Service State
+
+To perform the settlement check during the `Accumulate` phase, the Parachain Service needs to maintain a ring of [RecentProvides](https://github.com/paritytech/polkadot-sdk/blob/436cd3373a71f1c2251ce3976ee04220cf2646be/polkadot/runtime/parachains/src/spec_msg.rs#L55-L70) roots for every source parachain.
+
+This is a new service [state item](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#61-state-balance-accounting) (keyed under tag 0x08) that is written exclusively by `Accumulate` upon enactment. It has a fixed worst-case footprint of 4,649 bytes, which is folded directly into the per-para [baseline footprint](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#sizing-the-baseline-footprint).
+
+> **Important**: The [parachain_clean_up](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#side-effect-host-functions) must additionally drop the ring entry when a parachain is offboarded. Otherwise a reused `ParaId` inherits the prior stale roots.
+
+```rust
+pub const RECENT_PROVIDES_WINDOW: u32 = 128;
+pub struct RecentRoots(BoundedVec<StreamsRoot, ConstU32<RECENT_PROVIDES_WINDOW>>);
+
+// Keyed under tag 0x08. Written only by Accumulate.
+recent_provides: Map<ParaId, RecentRoots>
+```
+
+### 1.3 Settlement in Accumulate
+
+Polkadot handles settlement by dropping [candidates pre-inclusion](https://github.com/paritytech/polkadot-sdk/blob/436cd3373a71f1c2251ce3976ee04220cf2646be/polkadot/runtime/parachains/src/paras_inherent/mod.rs#L1043-L1058) if Requires doesn't match Provides. Because JAM lacks a pre-inclusion hook, this check shifts into the Accumulate phase (specifically between the validation-code check and the head-data update).
+
+Every required root in the digest must match the source's recent_provides state. If there's a miss, the candidate is rejected, the receiver burns B's core slot (a difference from Polkadot), and it logs an `AccumulateLog::RequiresUnmet` error. The collator then simply drops the package, rebuilds, and retries.
+
+```rust
+5. Validation code check: ..
+6. Speculative Messaging Settlement
+7. Head-data update: ..
+```
+
+[AccumulateLog](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#31-service-state-layout) is adjusted to reflect the new settlement check:
+
+```rust
+enum AccumulateLog {
+    // .. existing variants
+    RequiresUnmet { src: ParaId, root: StreamsRoot },
+}
+```
+
+## 2. Transport And Discovery
+
+### 2.1 Transport Payload
+
+For the MVP, parachains will exchange messages strictly offchain via peer-to-peer (P2P) using a `/spec-msg/exchange` request-response protocol. The payloads remain in the sender's [node side archive](https://github.com/paritytech/polkadot-sdk/blob/436cd3373a71f1c2251ce3976ee04220cf2646be/cumulus/client/spec-msg/src/archive.rs#L18-L57) until the receiver acknowledges them.
+
+Future Extension: if P2P isn't available, the JAM-native fallback will be exporting payloads into the Data Availability (DA) lake, allowing receivers to fetch them directly from DA segments.
+
+### 2.2 The Discovery Mechanism
+
+JAM doesn't have a DHT, meaning we lose Polkadot's "Bootnodes on DHT" feature. To allow parachains to find each other and fetch messages, the parachain service introduces an authorship-derived bootnode ring.
+
+Collators will attach a publicly reachable `Multiaddr` to their work items. The refine wrapper forwards this to Accumulate, which rotates it into a `recent_collator_addr`s` map for accepted candidates. The receiving parachain uses this ring to bootstrap the DHT and fetch payloads directly.
+
+```rust
+pub const MAX_COLLATOR_ADDR_RING: u32 = 20;
+struct CollatorAddrRing(
+    BoundedVec<(Timeslot, CollatorKeyHash, Multiaddr), MAX_COLLATOR_ADDR_RING>
+);
+
+/// Discovery anchor, keyed under tag 0x09.
+recent_collator_addrs: Map<ParaId, CollatorAddrRing>
+```
+
+**Extrinsic Payload**
+
+The [work item](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#32-work-items) is naturally extended to carry the collator provided multiaddress:
+
+```rust
+ struct WorkItemExtrinsics {
+        // { validation_code_hash, pov }
+        candidate: ParachainCandidate,
+        /// The serving endpoint shouldn't be the authoring node's IP,
+        /// but a bootnode into the DHT of the parachain.
+        recent_collator_addr: Option<Multiaddr>,
+  }
+```
+
+During the refine step, this address is forwarded directly to the Accumulate phase via the `SpecMessagingDigest` (see 1).
+
+```rust
+struct SpecMessagingDigest {
+    provides: Option<StreamsRoot>,
+    requires: BoundedVec<(ParaId, StreamsRoot), MAX_REQUIRES_SOURCES>,
+
+    /// Newly added collator address, forwarded exactly by the refine step.
+    collator_addr: Option<Multiaddr>,
+}
+```
+
+**Service State Authoring ring**
+
+To maintain recent discovery addresses, the service state implements an LRU-based authoring ring (stored as a map under discovery anchor tag `0x09`).
+- Bounded Capacity: Limited to a maximum of 20 entries per parachain (similar to DHT bootnode limits).
+- Anti-Spam: Entries are keyed by `CollatorKeyHash`. This ensures a malicious collator can only occupy a single slot in the ring.
+- Temporal Decay: Entries are timestamped. The consumer-side enforces a soft limit, ignoring addresses older than 2 hours.
+- Performance: Uses an LRU eviction policy (requiring a mem-move of a few KiB to shift the vector).
+
+
+**State Transition**
+
+```rust
+// ..
+// 6. Speculative Messaging Settlement
+// 7. Head-data update: ..
+// (new) 8. Update collator ring address.
+
+    if let Some(addr) = digest.collator_addr {
+        let author = collator_key_from_authorizer_trace(&report)
+                .unwrap_or(CollatorKeyHash::LATEST_AUTHOR);
+        recent_collator_addrs[para_id].touch(timeslot, author, addr);
+    }
+```
+
+> **Important**: The [parachain_clean_up](https://github.com/paritytech/polkadot-sdk/blob/afe236db6a21ac4ca4bef93a2e7375002a068585/designs/parachain-service-on-jam/parachain-service-on-jam.md#side-effect-host-functions) needs to clean up the ring.
+
+**Node side contract**
+- Addresses outside the 2-hour window are strictly ignored.
+- Address deduplication is handled defensively at dial time.
+- The consumer node is responsible for protecting itself against invalid or malicious dials.
+
+
+**Storage overhead**
+- The `Multiaddr` is capped to 128B.
+- Worst-case footprint for `recent_collator_addrs` is `3360 B` at 128-B addresses
+- This gets folded into the per-parachain baseline_footprint, increasing it from `74,474` bytes to `77,834` bytes (including the provides ring).
+
+
+## 3. Execution and Verification
+
+### 3.1 Receiver Verification
+
+The child PVM has no crypto host calls, and the BLAKE2b-256 hash function runs in guest code. The `sp_io`-on-PVM guest shim provides hashing, crypto, and allocators in-guest via a target-generic `replace_implementation` mechanism.
+
+1. The receiver fetches payload bytes and verifies them.
+2. The PVF recomputes the hash tree using BLAKE2b-256 inside the guest code.
+3. The wrapper synthesizes the `Requires` field.
+4. Accumulate matches these roots against the `RecentProvides` ring.
+
+### 3.2 Lifts in PoV & Handshakes
+
+**Lifts**
+
+The PoV carries lifts using the [ParachainBlockData::V3](https://github.com/paritytech/polkadot-sdk/blob/436cd3373a71f1c2251ce3976ee04220cf2646be/cumulus/primitives/core/src/parachain_block_data.rs#L88-L102) framing. Lifts are bounded at ~512 KiB worst case (64 sources * a pessimistic 8 KiB of proof material), against ~13 MB of PoV headroom on JAM.
+
+The relay shaped `scheduling_proof` field rides along in V3 and is pinned `None` in the JAM.
+
+Only 36 B per source (the digest's `(ParaId, StreamsRoot)` pair is within JAM's on-chain budget of the 48 KiB per work report). The lift proofs stay in the PoV, which is consumed in-core and never lands on-chain.
+
+**Handshake**
+
+Channel handshakes (`open_channel` / `accept_open_channel`) port over perfectly.
+
+The JAM parachain service doesn't need host functions for this. It's handled entirely on the parachains side.
+
+The same holds for flow control: registers, credit windows, all in-band and stream-ordered, riding the same streams as the data.
+
+## 4. Node Stack
+
+The node side requires a new `ProvidesSource` trait to interface with the messaging pipeline. This trait must expose the following capabilities: block stream, startup tip, sync gate, ring read at a recent block hash, pending-provides hint for the guaranteed tier. 
+
+A newly introduced JAM `ProvidesSource` will be responsible for extracting the latest provides. It accomplishes this by reading the tag derived key `0x08 ++ SCALE(para_id)` at imported JAM blocks.
+
+## 5. Latency Tiers
+
+The messaging architecture is designed around progressive latency tiers, establishing a robust baseline at launch while paving the way for highly optimized pipelines post MVP.
+
+**MVP**
+- Accumulate Tier: The root becomes visible in recent_provides immediately after the Accumulate step. This is functionally equivalent to the inclusion tier on Polkadot.
+- From launch, message latency will maintain parity with Polkadot's existing HRMP performance.
+
+**Post MVP**
+- JAM Backed Tier: Work reports become available approximately 1–2 timeslots before the Accumulate step.
+  - Initially deployed as a prefetch hint. Once Accumulate survival rates exceed 99% within a 2-slot window, it can be shifted into active use.
+
+- WIP In-Core Import Tier: Parachain B's work package explicitly declares Parachain A's exported payload segments as imports. This creates a tight coupling between B's block production and A's segment export timing and Data Availability (DA) window.
+
+- BestBlock Tier: Parachain B acts proactively on Parachain A's announced "best block" before any data lands on-chain (mirroring current Polkadot behavior). This tier may require the future implementation of a dedicated `/spec-msg/announce` protocol or similar.
+
+
+## 6. Primitives
+
+- One single crate under `cumulus/primitives/spec-messaging` (StreamId, MMR, tree, lifts, wire, fixtures) compiles for `riscv64emac-unknown-none-polkavm` in CI from the moment JAM work starts.
+- Pallets are ported directly via [cumulus on JAM plan](https://github.com/paritytech/polkadot-sdk/blob/mku-cumulus-on-jam-doc/designs/cumulus-on-jam/cumulus-on-jam.md).
+
+**Migration**
+
+- No migration to tackle on JAM, implementation lands from day zero. The XCM router is simply `SpecMsgRouter` without HRMP part.
+
+### Open Questions
+- PVM blake2b throughput needs benchmarks. Fallback is coordinated via leaf version
+- DA segment for messages vs P2P only for recovering messages for MVP
+- `MAX_REQUIRES_SOURCES` bounded at 64, needs more data for a bump
+- Exposed JAM `ProvidesSource` unverified
+


### PR DESCRIPTION
This PR adds speculative messaging on JAM needed features and backports.

This PR represents the implementation scope of SpecMSG for the parachain service / JAM specific.
- includes a minimal set of `Provides` and `Requires`
- the settlement is done via a ring since that functionality is identical for higher speculation tiers
  - an alternative would be an EnactmentProof, however that adds complexity for a race condition that is mitigated via ring sizing of 64 entries (https://github.com/paritytech/polkadot-sdk/pull/13087 for more details)
- bootnode address record needed for p2p fetching of messages

Builds upon:
- https://github.com/paritytech/polkadot-sdk/pull/11883



### Patch Series
- https://github.com/paritytech/polkadot-sdk/pull/12809
  - Speculative messaging overview for JAM
 
- https://github.com/paritytech/polkadot-sdk/pull/13000 
  - Minimal PS requirements with qnt testing
  
 - https://github.com/paritytech/polkadot-sdk/pull/13087
   - Post MVP work for higher speculation tiers
   

