### PR TITLE
ci: bind workflow/action inputs via env before shell

### DIFF
--- a/.github/actions/build-push-image/action.yml
+++ b/.github/actions/build-push-image/action.yml
@@ -40,22 +40,26 @@ runs:
       env:
         ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.105"
         IMAGE_TAG: europe-docker.pkg.dev/parity-ci-2024/temp-images/${{ inputs.image-name }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        DOCKERFILE: ${{ inputs.dockerfile }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
-        export DOCKER_IMAGES_VERSION=${{ github.event.pull_request.head.sha || 'master' }}
-        if [[ ${{ github.event_name }} == "merge_group" ]]; then export DOCKER_IMAGES_VERSION="${GITHUB_SHA::8}"; fi
-        if [[ ${{ github.event_name }} == "push" ]]; then export DOCKER_IMAGES_VERSION="master-${GITHUB_SHA::8}"; fi
+        export DOCKER_IMAGES_VERSION=${PR_HEAD_SHA:-master}
+        if [[ "$EVENT_NAME" == "merge_group" ]]; then export DOCKER_IMAGES_VERSION="${GITHUB_SHA::8}"; fi
+        if [[ "$EVENT_NAME" == "push" ]]; then export DOCKER_IMAGES_VERSION="master-${GITHUB_SHA::8}"; fi
         export IMAGE_TAG_TIMESTAMP="$(date -u '+%Y%m%d-%H%M%S')"
         echo "IMAGE_TAG_TIMESTAMP=${IMAGE_TAG_TIMESTAMP}" >> "$GITHUB_ENV"
         export DOCKER_IMAGES_VERSION="${DOCKER_IMAGES_VERSION}-${IMAGE_TAG_TIMESTAMP}"
         docker build \
           --build-arg VCS_REF="${GITHUB_SHA}" \
           --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
-          --build-arg IMAGE_NAME="${{ inputs.image-name }}" \
+          --build-arg IMAGE_NAME="${IMAGE_NAME}" \
           --build-arg ZOMBIENET_IMAGE="${ZOMBIENET_IMAGE}" \
-          -t "${{ env.IMAGE_TAG }}:$DOCKER_IMAGES_VERSION" \
-          -f ${{ inputs.dockerfile }} \
+          -t "${IMAGE_TAG}:$DOCKER_IMAGES_VERSION" \
+          -f "$DOCKERFILE" \
           .
-        docker push "${{ env.IMAGE_TAG }}:$DOCKER_IMAGES_VERSION"
+        docker push "${IMAGE_TAG}:$DOCKER_IMAGES_VERSION"
 
     - name: login to dockerhub
       id: login
@@ -71,14 +75,17 @@ runs:
       if: ${{ inputs.username != '' && inputs.password != '' && github.event_name != 'merge_group' }}
       env:
         GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        export DOCKERHUB_TAG=docker.io/paritypr/${{ inputs.image-name }}:${{ github.event.pull_request.number || 'master' }}
-        if [[ ${{ github.event_name }} == "pull_request" ]]; then export DOCKERHUB_TAG=$DOCKERHUB_TAG-${GITHUB_PR_HEAD_SHA::8}; fi
-        if [[ ${{ github.event_name }} == "push" ]]; then export DOCKERHUB_TAG=$DOCKERHUB_TAG-${GITHUB_SHA::8}; fi
+        export DOCKERHUB_TAG=docker.io/paritypr/${IMAGE_NAME}:${PR_NUMBER:-master}
+        if [[ "$EVENT_NAME" == "pull_request" ]]; then export DOCKERHUB_TAG=$DOCKERHUB_TAG-${GITHUB_PR_HEAD_SHA::8}; fi
+        if [[ "$EVENT_NAME" == "push" ]]; then export DOCKERHUB_TAG=$DOCKERHUB_TAG-${GITHUB_SHA::8}; fi
         #
-        export SOURCE_TAG=${{ github.event.pull_request.head.sha || 'master' }}
-        if [[ ${{ github.event_name }} == "push" ]]; then export SOURCE_TAG="master-${GITHUB_SHA::8}"; fi
+        export SOURCE_TAG=${GITHUB_PR_HEAD_SHA:-master}
+        if [[ "$EVENT_NAME" == "push" ]]; then export SOURCE_TAG="master-${GITHUB_SHA::8}"; fi
         export SOURCE_TAG="${SOURCE_TAG}-${IMAGE_TAG_TIMESTAMP}"
-        docker tag "europe-docker.pkg.dev/parity-ci-2024/temp-images/${{ inputs.image-name }}:${SOURCE_TAG}" $DOCKERHUB_TAG
+        docker tag "europe-docker.pkg.dev/parity-ci-2024/temp-images/${IMAGE_NAME}:${SOURCE_TAG}" $DOCKERHUB_TAG
         docker push $DOCKERHUB_TAG
 

--- a/.github/workflows/bench-all-runtimes.yml
+++ b/.github/workflows/bench-all-runtimes.yml
@@ -144,6 +144,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           BRANCH: ${{ needs.runtime-matrix.outputs.branch }}
           DATE: ${{ needs.runtime-matrix.outputs.date }}
+          MAYBE_DRAFT_FLAG: ${{ inputs.draft && '--draft' || '' }}
         run: |
           git --version          
           git config user.name "github-actions[bot]"
@@ -200,7 +201,7 @@ jobs:
           git commit -m "Update all weights weekly for $DATE"
           git push --set-upstream origin "$BRANCH"
 
-          MAYBE_DRAFT=${{ inputs.draft && '--draft' || '' }}
+          MAYBE_DRAFT="$MAYBE_DRAFT_FLAG"
           
           PR_TITLE="Auto-update of all weights for $DATE"
           gh pr create \

--- a/.github/workflows/command-prdoc.yml
+++ b/.github/workflows/command-prdoc.yml
@@ -62,17 +62,25 @@ jobs:
           pr-number: ${{ inputs.pr }}
           GH_TOKEN: ${{ github.token }}
       - name: Generate PrDoc
+        env:
+          PR: ${{ inputs.pr }}
+          BUMP: ${{ inputs.bump }}
+          AUDIENCE: ${{ inputs.audience }}
+          OVERWRITE: ${{ inputs.overwrite }}
         run: |
           python3 -m pip install -q cargo-workspace PyGithub whatthepatch pyyaml toml
 
-          python3 .github/scripts/generate-prdoc.py --pr "${{ inputs.pr }}" --bump "${{ inputs.bump }}" --audience "${{ inputs.audience }}" --force "${{ inputs.overwrite }}"
+          python3 .github/scripts/generate-prdoc.py --pr "$PR" --bump "$BUMP" --audience "$AUDIENCE" --force "$OVERWRITE"
 
       - name: Report failure
         if: ${{ failure() }}
-        run: gh pr comment ${{ inputs.pr }} --body "<h2>Command failed ❌</h2> Run by @${{ github.actor }} for <code>${{ github.workflow }}</code> failed. See logs <a href=\"$RUN\">here</a>."
         env:
           RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_TOKEN: ${{ github.token }}
+          PR: ${{ inputs.pr }}
+          ACTOR: ${{ github.actor }}
+          WORKFLOW: ${{ github.workflow }}
+        run: gh pr comment "$PR" --body "<h2>Command failed ❌</h2> Run by @$ACTOR for <code>$WORKFLOW</code> failed. See logs <a href=\"$RUN\">here</a>."
       - name: Push Commit
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:

--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -221,14 +221,17 @@ jobs:
           rm -f "${{ env.template-path }}/src/lib.rs"
 
       - name: Run psvm on monorepo workspace dependencies
+        env:
+          PATCH_INPUT: ${{ github.event.inputs.patch }}
+          STABLE_RELEASE_BRANCH: ${{ github.event.inputs.stable_release_branch }}
         run: |
-          patch_input="${{ github.event.inputs.patch }}"
+          patch_input="$PATCH_INPUT"
           if [[ -n "$patch_input" ]]; then
             patch="-$patch_input"
           else
             patch=""
           fi
-          psvm -o -v "${{ github.event.inputs.stable_release_branch }}$patch" -p ./Cargo.toml
+          psvm -o -v "${STABLE_RELEASE_BRANCH}$patch" -p ./Cargo.toml
         working-directory: polkadot-sdk/
       - name: Copy over required workspace dependencies
         run: |


### PR DESCRIPTION
## Summary
Bind composite/workflow inputs into step `env:` before shell use in:
- `.github/actions/build-push-image`
- `.github/workflows/command-prdoc.yml`
- `.github/workflows/misc-sync-templates.yml` (psvm step)

Keeps `${{ }}` expansions out of `run:` scripts. `if:` / `with:` expressions are unchanged.

## Test plan
- [ ] Confirm YAML still validates
- [ ] Optional: re-run image build / command-prdoc / template sync paths that consume these inputs

Made with [Cursor](https://cursor.com)