### PR TITLE
primitives: Check length of received vectors

### DIFF
--- a/prdoc/pr_12834.prdoc
+++ b/prdoc/pr_12834.prdoc
@@ -1,0 +1,8 @@
+title: 'primitives: Check length of received vectors'
+doc:
+- audience: Node Dev
+  description: |-
+    Tiny PR to enhance the API surface by check the length of the G points before passing them down
+crates:
+- name: sp-crypto-ec-utils
+  bump: patch

--- a/substrate/primitives/crypto/ec-utils/src/utils.rs
+++ b/substrate/primitives/crypto/ec-utils/src/utils.rs
@@ -193,6 +193,9 @@ impl<P: TECurveConfig> IntoAffineSafe for TEProjective<P> {
 pub fn multi_miller_loop<T: Pairing>(g1: &[u8], g2: &[u8], out: &mut [u8]) -> Result<(), Error> {
 	let g1 = decode::<Vec<<T as Pairing>::G1Affine>>(g1)?;
 	let g2 = decode::<Vec<<T as Pairing>::G2Affine>>(g2)?;
+	if g1.len() != g2.len() {
+		return Err(Error::LengthMismatch);
+	}
 	let res = T::multi_miller_loop(g1, g2);
 	encode_into(res.0, out)
 }


### PR DESCRIPTION
Tiny PR to enhance the API surface by check the length of the G points before passing them down

