### PR TITLE
integrate MBM limit into migration pallet as a safety mechanism for stuck migrations

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1475,8 +1475,12 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
+	// No single migration may keep the chain in migration mode for longer than a day.
+	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1475,13 +1475,10 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
 	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
-	// No single migration may keep the chain in migration mode for longer than a day. `DAYS` is
-	// derived from the 6s relay slot, while this chain authors `BLOCK_PROCESSING_VELOCITY` blocks
-	// per slot.
+	// `DAYS` is derived from the 6s relay slot; this chain authors `BLOCK_PROCESSING_VELOCITY`
+	// blocks per slot.
 	type MaxMigrationSteps = ConstU32<{ BLOCK_PROCESSING_VELOCITY * DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1475,7 +1475,9 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day. `DAYS` is
 	// derived from the 6s relay slot, while this chain authors `BLOCK_PROCESSING_VELOCITY` blocks

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1475,12 +1475,12 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
-	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
+	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
-	// No single migration may keep the chain in migration mode for longer than a day.
-	type MaxMigrationSteps = ConstU32<{ DAYS }>;
+	// No single migration may keep the chain in migration mode for longer than a day. `DAYS` is
+	// derived from the 6s relay slot, while this chain authors `BLOCK_PROCESSING_VELOCITY` blocks
+	// per slot.
+	type MaxMigrationSteps = ConstU32<{ BLOCK_PROCESSING_VELOCITY * DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -601,13 +601,10 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
 	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
-	// No single migration may keep the chain in migration mode for longer than a day. `DAYS` is
-	// derived from the 6s relay slot, while this chain authors `BLOCK_PROCESSING_VELOCITY` blocks
-	// per slot.
+	// `DAYS` is derived from the 6s relay slot; this chain authors `BLOCK_PROCESSING_VELOCITY`
+	// blocks per slot.
 	type MaxMigrationSteps = ConstU32<{ BLOCK_PROCESSING_VELOCITY * DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -601,7 +601,9 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day. `DAYS` is
 	// derived from the 6s relay slot, while this chain authors `BLOCK_PROCESSING_VELOCITY` blocks

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -601,8 +601,12 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
+	// No single migration may keep the chain in migration mode for longer than a day.
+	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -601,12 +601,12 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
-	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
+	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
-	// No single migration may keep the chain in migration mode for longer than a day.
-	type MaxMigrationSteps = ConstU32<{ DAYS }>;
+	// No single migration may keep the chain in migration mode for longer than a day. `DAYS` is
+	// derived from the 6s relay slot, while this chain authors `BLOCK_PROCESSING_VELOCITY` blocks
+	// per slot.
+	type MaxMigrationSteps = ConstU32<{ BLOCK_PROCESSING_VELOCITY * DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }
 

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1473,11 +1473,8 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
 	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
-	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1473,8 +1473,12 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
+	// No single migration may keep the chain in migration mode for longer than a day.
+	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }
 

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1473,9 +1473,7 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
-	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
+	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1473,7 +1473,9 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1385,11 +1385,8 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
 	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
-	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1385,9 +1385,7 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
-	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
+	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1385,8 +1385,12 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
+	// No single migration may keep the chain in migration mode for longer than a day.
+	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }
 

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1385,7 +1385,9 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;

--- a/prdoc/pr_0000.prdoc
+++ b/prdoc/pr_0000.prdoc
@@ -1,0 +1,47 @@
+title: '[pallet-migrations] add a blanket `MaxMigrationSteps` limit'
+
+doc:
+- audience: Runtime Dev
+  description: |-
+    `pallet-migrations` aborts a migration that exceeds its `SteppedMigration::max_steps`, but that
+    limit is opt-in and most migrations do not set one. A migration that stops making progress
+    therefore keeps the chain in migration mode - and thus rejects all non-mandatory extrinsics -
+    forever.
+
+    This PR adds a `Config::MaxMigrationSteps` that bounds every migration, both as a fallback for
+    migrations that declare no limit of their own and as an upper bound for those that declare a
+    larger one. A migration advances at most once per block, so the limit is effectively a
+    duration. Note that it applies per migration, so a tuple of `n` migrations is bounded by `n`
+    times the limit.
+
+    Runtimes must now set `MaxMigrationSteps`; use `ConstU32<{ u32::MAX }>` to keep the previous
+    unbounded behaviour. The runtimes in this repository set it to one day.
+
+    Exceeding the limit is treated as a failed migration: the migration is left partially applied,
+    is not recorded in `Historic`, and the `FailedMigrationHandler` decides what happens to the
+    chain. The runtimes in this repository therefore also switch from
+    `FreezeChainOnFailedMigration` to `ForceUnstuckOnFailedMigration`, so that a failed or timed
+    out migration leaves the chain usable and governance reachable. Freezing prevents governance
+    intervention entirely - a frozen chain only accepts inherents, so not even the pallet's own
+    `force_set_cursor` can be dispatched, and a plain runtime upgrade does not recover it either
+    because onboarding re-fails on the existing cursor. Note that force-unsticking exposes the
+    partially migrated state to users, which is the same trade-off a faulty single-block migration
+    already implies.
+
+crates:
+- name: pallet-migrations
+  bump: major
+- name: westend-runtime
+  bump: major
+- name: rococo-runtime
+  bump: major
+- name: asset-hub-westend-runtime
+  bump: major
+- name: people-westend-runtime
+  bump: major
+- name: kitchensink-runtime
+  bump: major
+- name: pallet-staking-async-rc-runtime
+  bump: major
+- name: pallet-staking-async-parachain-runtime
+  bump: major

--- a/prdoc/pr_12841.prdoc
+++ b/prdoc/pr_12841.prdoc
@@ -19,14 +19,13 @@ doc:
 
     Exceeding the limit is treated as a failed migration: the migration is left partially applied,
     is not recorded in `Historic`, and the `FailedMigrationHandler` decides what happens to the
-    chain. The runtimes in this repository therefore also switch from
-    `FreezeChainOnFailedMigration` to `ForceUnstuckOnFailedMigration`, so that a failed or timed
-    out migration leaves the chain usable and governance reachable. Freezing prevents governance
-    intervention entirely - a frozen chain only accepts inherents, so not even the pallet's own
-    `force_set_cursor` can be dispatched, and a plain runtime upgrade does not recover it either
-    because onboarding re-fails on the existing cursor. Note that force-unsticking exposes the
-    partially migrated state to users, which is the same trade-off a faulty single-block migration
-    already implies.
+    chain. The limit is therefore only a safety net if that handler leaves the chain usable. The
+    runtimes in this repository keep `FreezeChainOnFailedMigration`, which turns a timed out
+    migration into a permanently stuck chain - a frozen chain only accepts inherents, so not even
+    the pallet's own `force_set_cursor` can be dispatched. Runtimes that want a timeout to restore
+    the chain should pair the limit with `ForceUnstuckOnFailedMigration` or
+    `EnterSafeModeOnFailedMigration`, at the cost of exposing the partially migrated state - which
+    is the same trade-off a faulty single-block migration already implies.
 
 crates:
 - name: pallet-migrations

--- a/prdoc/pr_12841.prdoc
+++ b/prdoc/pr_12841.prdoc
@@ -4,34 +4,20 @@ doc:
 - audience: Runtime Dev
   description: |-
     `pallet-migrations` aborts a migration that exceeds its `SteppedMigration::max_steps`, but that
-    limit is opt-in and most migrations do not set one. A migration that stops making progress
-    therefore keeps the chain in migration mode - and thus rejects all non-mandatory extrinsics -
-    forever.
+    limit is opt-in and most migrations do not set one, so a migration that stops making progress
+    keeps the chain in migration mode - rejecting all non-mandatory extrinsics - forever.
 
-    This PR adds a `Config::MaxMigrationSteps` that bounds every migration, both as a fallback for
-    migrations that declare no limit of their own and as an upper bound for those that declare a
-    larger one. A migration advances at most once per block, so the limit is effectively a
-    duration. Note that it applies per migration, so a tuple of `n` migrations is bounded by `n`
-    times the limit.
+    The new `Config::MaxMigrationSteps` bounds every migration: a fallback for those that declare no
+    limit of their own, and an upper bound for those that declare a larger one. A migration advances
+    at most once per block, so the limit is effectively a per-migration duration.
 
     Runtimes must now set `MaxMigrationSteps`; use `ConstU32<{ u32::MAX }>` to keep the previous
     unbounded behaviour. The runtimes in this repository set it to one day.
 
-    Exceeding the limit is treated as a failed migration: the migration is left partially applied,
-    is not recorded in `Historic`, and the `FailedMigrationHandler` decides what happens to the
-    chain. The limit is therefore only a safety mechanism if that handler leaves the chain usable.
-    With `FreezeChainOnFailedMigration` it is close to a no-op: `MultiStepMigrator::ongoing()` is
-    true for both an active and a stuck cursor, so the chain only accepts inherents either way and
-    not even the pallet's own `force_set_cursor` can be dispatched to recover it. The runtimes in
-    this repository therefore also switch to `ForceUnstuckOnFailedMigration`, which is what that
-    handler was added for in https://github.com/paritytech/polkadot-sdk/pull/11194.
-
-    Force-unsticking applies to every migration failure, not only to timeouts, and it exposes the
-    partially migrated state to users - the same trade-off a faulty single-block migration already
-    implies. It buys a recovery window: the chain stays usable, so governance can enact a runtime
-    upgrade that drops the faulty migration. Note that the failed migration is not black-listed in
-    `Historic`, so an upgrade that keeps it in the tuple will restart it from scratch and consume
-    the full step budget again.
+    Exceeding the limit counts as a failed migration: it is left partially applied, is not recorded
+    in `Historic`, and is handed to the `FailedMigrationHandler`. These runtimes therefore also
+    switch to `ForceUnstuckOnFailedMigration`, so that a timed out migration leaves the chain usable
+    instead of frozen.
 
 crates:
 - name: pallet-migrations

--- a/prdoc/pr_12841.prdoc
+++ b/prdoc/pr_12841.prdoc
@@ -19,13 +19,19 @@ doc:
 
     Exceeding the limit is treated as a failed migration: the migration is left partially applied,
     is not recorded in `Historic`, and the `FailedMigrationHandler` decides what happens to the
-    chain. The limit is therefore only a safety net if that handler leaves the chain usable. The
-    runtimes in this repository keep `FreezeChainOnFailedMigration`, which turns a timed out
-    migration into a permanently stuck chain - a frozen chain only accepts inherents, so not even
-    the pallet's own `force_set_cursor` can be dispatched. Runtimes that want a timeout to restore
-    the chain should pair the limit with `ForceUnstuckOnFailedMigration` or
-    `EnterSafeModeOnFailedMigration`, at the cost of exposing the partially migrated state - which
-    is the same trade-off a faulty single-block migration already implies.
+    chain. The limit is therefore only a safety mechanism if that handler leaves the chain usable.
+    With `FreezeChainOnFailedMigration` it is close to a no-op: `MultiStepMigrator::ongoing()` is
+    true for both an active and a stuck cursor, so the chain only accepts inherents either way and
+    not even the pallet's own `force_set_cursor` can be dispatched to recover it. The runtimes in
+    this repository therefore also switch to `ForceUnstuckOnFailedMigration`, which is what that
+    handler was added for in https://github.com/paritytech/polkadot-sdk/pull/11194.
+
+    Force-unsticking applies to every migration failure, not only to timeouts, and it exposes the
+    partially migrated state to users - the same trade-off a faulty single-block migration already
+    implies. It buys a recovery window: the chain stays usable, so governance can enact a runtime
+    upgrade that drops the faulty migration. Note that the failed migration is not black-listed in
+    `Historic`, so an upgrade that keeps it in the tuple will restart it from scratch and consume
+    the full step budget again.
 
 crates:
 - name: pallet-migrations

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -2473,8 +2473,12 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
+	// No single migration may keep the chain in migration mode for longer than a day.
+	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = pallet_migrations::weights::SubstrateWeight<Runtime>;
 }
 

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -2473,11 +2473,8 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
 	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
-	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = pallet_migrations::weights::SubstrateWeight<Runtime>;
 }

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -2473,7 +2473,9 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -2473,9 +2473,7 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
-	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
+	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;

--- a/substrate/frame/migrations/src/lib.rs
+++ b/substrate/frame/migrations/src/lib.rs
@@ -423,7 +423,10 @@ pub mod pallet {
 		/// bound is per migration, so a tuple of `n` migrations can still take `n` times as long.
 		///
 		/// Exceeding it is treated as a failed migration, which leaves the migration partially
-		/// applied and is handed to the [`Config::FailedMigrationHandler`].
+		/// applied and is handed to the [`Config::FailedMigrationHandler`]. The limit is therefore
+		/// only a safety net if that handler leaves the chain usable;
+		/// [`frame_support::migrations::FreezeChainOnFailedMigration`] turns a timeout into a
+		/// permanently stuck chain instead.
 		///
 		/// Use `u32::MAX` to not impose any limit.
 		#[pallet::constant]
@@ -570,6 +573,9 @@ pub mod pallet {
 				Cursor::<T>::kill();
 			}
 
+			// The blanket step limit is sane.
+			assert!(T::MaxMigrationSteps::get() > 0, "MaxMigrationSteps must be positive");
+
 			// The per-block service weight is sane.
 			{
 				let want = T::MaxServiceWeight::get();
@@ -712,13 +718,11 @@ pub mod pallet {
 						System::<T>::block_number().saturating_sub(cursor.started_at);
 					let estimated_steps = blocks_elapsed.saturated_into::<u32>();
 
-					let max_steps = Self::nth_max_steps(cursor.index)?;
-
 					Some(MbmProgress {
 						current_migration: cursor.index,
 						total_migrations: T::Migrations::len(),
 						current_migration_steps: estimated_steps,
-						current_migration_max_steps: (max_steps != u32::MAX).then_some(max_steps),
+						current_migration_max_steps: Self::effective_max_steps(cursor.index)?,
 					})
 				},
 				_ => None,
@@ -865,7 +869,7 @@ impl<T: Config> Pallet<T> {
 			return Some(ControlFlow::Continue(cursor));
 		}
 
-		let max_steps = Self::nth_max_steps(cursor.index);
+		let max_steps = Self::effective_max_steps(cursor.index);
 
 		// If this is the first time running this migration, exec the pre-upgrade hook.
 		#[cfg(feature = "try-runtime")]
@@ -899,7 +903,7 @@ impl<T: Config> Pallet<T> {
 				Self::deposit_event(Event::MigrationAdvanced { index: cursor.index, took });
 				cursor.inner_cursor = Some(bound_next_cursor);
 
-				if took > max_steps.into() {
+				if max_steps.is_some_and(|max| took > max.into()) {
 					Self::deposit_event(Event::MigrationFailed { index: cursor.index, took });
 					Self::upgrade_failed(Some(cursor.index));
 					None
@@ -945,10 +949,15 @@ impl<T: Config> Pallet<T> {
 
 	/// The step limit of the `n`th migration, bounded by [`Config::MaxMigrationSteps`].
 	///
-	/// Returns `None` if `n` is out of bounds and `u32::MAX` if the migration is unbounded.
-	fn nth_max_steps(n: u32) -> Option<u32> {
-		T::Migrations::nth_max_steps(n)
-			.map(|max_steps| max_steps.unwrap_or(u32::MAX).min(T::MaxMigrationSteps::get()))
+	/// Returns `None` if `n` is out of bounds and `Some(None)` if neither the migration nor the
+	/// runtime imposes a limit.
+	fn effective_max_steps(n: u32) -> Option<Option<u32>> {
+		let blanket = T::MaxMigrationSteps::get();
+
+		T::Migrations::nth_max_steps(n).map(|max_steps| {
+			let bounded = max_steps.map_or(blanket, |max| max.min(blanket));
+			(bounded != u32::MAX).then_some(bounded)
+		})
 	}
 
 	/// Fail the current runtime upgrade, caused by `migration`.

--- a/substrate/frame/migrations/src/lib.rs
+++ b/substrate/frame/migrations/src/lib.rs
@@ -416,17 +416,14 @@ pub mod pallet {
 
 		/// The maximum number of steps that any single migration may take.
 		///
-		/// A migration advances at most once per block, so this bounds how long a single migration
-		/// can keep the chain in migration mode. It is applied both as a fallback for migrations
-		/// that do not set a [`SteppedMigration::max_steps`] of their own - which would otherwise
-		/// never be aborted - and as an upper bound for those that set a larger one. Note that the
-		/// bound is per migration, so a tuple of `n` migrations can still take `n` times as long.
+		/// A migration advances at most once per block, so this bounds how long it can keep the
+		/// chain in migration mode. It is a fallback for migrations that set no
+		/// [`SteppedMigration::max_steps`] of their own and an upper bound for those that set a
+		/// larger one. The bound is per migration, so a tuple of `n` migrations can still take
+		/// `n` times as long.
 		///
-		/// Exceeding it is treated as a failed migration, which leaves the migration partially
-		/// applied and is handed to the [`Config::FailedMigrationHandler`]. The limit is therefore
-		/// only a safety net if that handler leaves the chain usable;
-		/// [`frame_support::migrations::FreezeChainOnFailedMigration`] turns a timeout into a
-		/// permanently stuck chain instead.
+		/// Exceeding it is treated as a failed migration and handed to the
+		/// [`Config::FailedMigrationHandler`].
 		///
 		/// Use `u32::MAX` to not impose any limit.
 		#[pallet::constant]

--- a/substrate/frame/migrations/src/lib.rs
+++ b/substrate/frame/migrations/src/lib.rs
@@ -95,8 +95,9 @@
 //! in this block, and therefore required more than the maximum amount of weight possible, the
 //! process becomes `Stuck`. Otherwise, one re-attempt is executed with the same logic in the next
 //! block (Goal 3). Progress through the migrations is guaranteed by providing a timeout for each
-//! migration via [`SteppedMigration::max_steps`]. The pallet **ONLY** guarantees progress if this
-//! is set to sensible limits (Goal 7).
+//! migration via [`SteppedMigration::max_steps`], bounded by [`Config::MaxMigrationSteps`] as a
+//! blanket fallback for migrations that do not provide one. The pallet **ONLY** guarantees progress
+//! if at least one of the two is set to a sensible limit (Goal 7).
 //!
 //! ### Scenario: Governance cleanup
 //!
@@ -413,6 +414,21 @@ pub mod pallet {
 		/// The maximum weight to spend each block to execute migrations.
 		type MaxServiceWeight: Get<Weight>;
 
+		/// The maximum number of steps that any single migration may take.
+		///
+		/// A migration advances at most once per block, so this bounds how long a single migration
+		/// can keep the chain in migration mode. It is applied both as a fallback for migrations
+		/// that do not set a [`SteppedMigration::max_steps`] of their own - which would otherwise
+		/// never be aborted - and as an upper bound for those that set a larger one. Note that the
+		/// bound is per migration, so a tuple of `n` migrations can still take `n` times as long.
+		///
+		/// Exceeding it is treated as a failed migration, which leaves the migration partially
+		/// applied and is handed to the [`Config::FailedMigrationHandler`].
+		///
+		/// Use `u32::MAX` to not impose any limit.
+		#[pallet::constant]
+		type MaxMigrationSteps: Get<u32>;
+
 		/// Weight information for the calls and functions of this pallet.
 		type WeightInfo: WeightInfo;
 	}
@@ -452,6 +468,7 @@ pub mod pallet {
 			type MigrationStatusHandler = ();
 			type FailedMigrationHandler = FreezeChainOnFailedMigration;
 			type MaxServiceWeight = TestMaxServiceWeight;
+			type MaxMigrationSteps = ConstU32<{ u32::MAX }>;
 			type WeightInfo = ();
 		}
 	}
@@ -695,11 +712,13 @@ pub mod pallet {
 						System::<T>::block_number().saturating_sub(cursor.started_at);
 					let estimated_steps = blocks_elapsed.saturated_into::<u32>();
 
+					let max_steps = Self::nth_max_steps(cursor.index)?;
+
 					Some(MbmProgress {
 						current_migration: cursor.index,
 						total_migrations: T::Migrations::len(),
 						current_migration_steps: estimated_steps,
-						current_migration_max_steps: T::Migrations::nth_max_steps(cursor.index)?,
+						current_migration_max_steps: (max_steps != u32::MAX).then_some(max_steps),
 					})
 				},
 				_ => None,
@@ -846,7 +865,7 @@ impl<T: Config> Pallet<T> {
 			return Some(ControlFlow::Continue(cursor));
 		}
 
-		let max_steps = T::Migrations::nth_max_steps(cursor.index);
+		let max_steps = Self::nth_max_steps(cursor.index);
 
 		// If this is the first time running this migration, exec the pre-upgrade hook.
 		#[cfg(feature = "try-runtime")]
@@ -880,7 +899,7 @@ impl<T: Config> Pallet<T> {
 				Self::deposit_event(Event::MigrationAdvanced { index: cursor.index, took });
 				cursor.inner_cursor = Some(bound_next_cursor);
 
-				if max_steps.is_some_and(|max| took > max.into()) {
+				if took > max_steps.into() {
 					Self::deposit_event(Event::MigrationFailed { index: cursor.index, took });
 					Self::upgrade_failed(Some(cursor.index));
 					None
@@ -922,6 +941,14 @@ impl<T: Config> Pallet<T> {
 				None
 			},
 		}
+	}
+
+	/// The step limit of the `n`th migration, bounded by [`Config::MaxMigrationSteps`].
+	///
+	/// Returns `None` if `n` is out of bounds and `u32::MAX` if the migration is unbounded.
+	fn nth_max_steps(n: u32) -> Option<u32> {
+		T::Migrations::nth_max_steps(n)
+			.map(|max_steps| max_steps.unwrap_or(u32::MAX).min(T::MaxMigrationSteps::get()))
 	}
 
 	/// Fail the current runtime upgrade, caused by `migration`.

--- a/substrate/frame/migrations/src/mock.rs
+++ b/substrate/frame/migrations/src/mock.rs
@@ -44,10 +44,13 @@ impl frame_system::Config for Test {
 
 frame_support::parameter_types! {
 	pub const MaxServiceWeight: Weight = Weight::MAX.div(10);
+	/// The blanket step limit that applies to all migrations.
+	pub static MaxMigrationSteps: u32 = u32::MAX;
 }
 
 #[derive_impl(crate::config_preludes::TestDefaultConfig)]
 impl crate::Config for Test {
+	type MaxMigrationSteps = MaxMigrationSteps;
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = crate::mock_helpers::MockedMigrations;
 	#[cfg(not(feature = "runtime-benchmarks"))]
@@ -104,6 +107,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 /// Run this closure in test externalities.
 pub fn test_closure<R>(f: impl FnOnce() -> R) -> R {
+	// Thread locals are shared between tests running on the same thread.
+	MaxMigrationSteps::set(u32::MAX);
 	let mut ext = new_test_ext();
 	ext.execute_with(f)
 }

--- a/substrate/frame/migrations/src/mock.rs
+++ b/substrate/frame/migrations/src/mock.rs
@@ -45,7 +45,7 @@ impl frame_system::Config for Test {
 frame_support::parameter_types! {
 	pub const MaxServiceWeight: Weight = Weight::MAX.div(10);
 	/// The blanket step limit that applies to all migrations.
-	pub static MaxMigrationSteps: u32 = u32::MAX;
+	pub storage MaxMigrationSteps: u32 = u32::MAX;
 }
 
 #[derive_impl(crate::config_preludes::TestDefaultConfig)]
@@ -108,7 +108,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 /// Run this closure in test externalities.
 pub fn test_closure<R>(f: impl FnOnce() -> R) -> R {
 	// Thread locals are shared between tests running on the same thread.
-	MaxMigrationSteps::set(u32::MAX);
+	FailedUpgradeResponse::set(FailedMigrationHandling::KeepStuck);
 	let mut ext = new_test_ext();
 	ext.execute_with(f)
 }

--- a/substrate/frame/migrations/src/mock_helpers.rs
+++ b/substrate/frame/migrations/src/mock_helpers.rs
@@ -120,7 +120,8 @@ impl SteppedMigrations for MockedMigrations {
 	}
 
 	fn nth_max_steps(n: u32) -> Option<Option<u32>> {
-		MIGRATIONS::get().get(n as usize).map(|(_, s)| Some(*s))
+		// A migration configured with `u32::MAX` steps mocks one that does not declare a limit.
+		MIGRATIONS::get().get(n as usize).map(|(_, s)| (*s != u32::MAX).then_some(*s))
 	}
 
 	fn nth_migrating_prefixes(n: u32) -> Option<Option<Vec<Vec<u8>>>> {

--- a/substrate/frame/migrations/src/tests.rs
+++ b/substrate/frame/migrations/src/tests.rs
@@ -404,7 +404,7 @@ fn migration_timeout_errors() {
 #[cfg_attr(feature = "try-runtime", should_panic)]
 fn migration_without_max_steps_times_out_at_max_migration_steps() {
 	test_closure(|| {
-		MaxMigrationSteps::set(3);
+		MaxMigrationSteps::set(&3);
 		// `u32::MAX` steps mocks a migration that does not declare a limit of its own.
 		MockedMigrations::set(vec![(TimeoutAfter, u32::MAX)]);
 
@@ -431,7 +431,7 @@ fn migration_without_max_steps_times_out_at_max_migration_steps() {
 #[cfg_attr(feature = "try-runtime", should_panic)]
 fn max_migration_steps_caps_a_larger_max_steps() {
 	test_closure(|| {
-		MaxMigrationSteps::set(1);
+		MaxMigrationSteps::set(&1);
 		// The migration asks for 3 steps, but only gets the blanket 1.
 		MockedMigrations::set(vec![(TimeoutAfter, 3)]);
 
@@ -456,7 +456,7 @@ fn migration_within_max_migration_steps_completes() {
 	use Event::*;
 	test_closure(|| {
 		// The migration advances at `took` 1 and 2, so it just fits into the blanket limit.
-		MaxMigrationSteps::set(2);
+		MaxMigrationSteps::set(&2);
 		MockedMigrations::set(vec![(SucceedAfter, 2)]);
 
 		System::set_block_number(1);
@@ -482,7 +482,7 @@ fn max_steps_below_max_migration_steps_still_applies() {
 	test_closure(|| {
 		// The migration asks for less than the blanket limit, so its own limit is the one that
 		// applies.
-		MaxMigrationSteps::set(100);
+		MaxMigrationSteps::set(&100);
 		MockedMigrations::set(vec![(TimeoutAfter, 1)]);
 
 		System::set_block_number(1);
@@ -497,6 +497,32 @@ fn max_steps_below_max_migration_steps_still_applies() {
 			Event::UpgradeFailed,
 		]);
 		assert_eq!(upgrades_started_completed_failed(), (1, 0, 1));
+		assert_eq!(Cursor::<T>::get(), Some(MigrationCursor::Stuck));
+	});
+}
+
+#[test]
+#[cfg_attr(feature = "try-runtime", should_panic)]
+fn timed_out_migration_force_unstuck_works() {
+	test_closure(|| {
+		FailedUpgradeResponse::set(FailedMigrationHandling::ForceUnstuck);
+		MaxMigrationSteps::set(&1);
+		MockedMigrations::set(vec![(TimeoutAfter, u32::MAX)]);
+
+		System::set_block_number(1);
+		Migrations::on_runtime_upgrade();
+		run_to_block(5);
+
+		assert_events(vec![
+			Event::UpgradeStarted { migrations: 1 },
+			Event::MigrationAdvanced { index: 0, took: 1 },
+			Event::MigrationAdvanced { index: 0, took: 2 },
+			Event::MigrationFailed { index: 0, took: 2 },
+			Event::UpgradeFailed,
+		]);
+		// Timed out migrations are not black-listed either.
+		assert!(historic().is_empty());
+		assert!(Cursor::<T>::get().is_none(), "Must unstuck the chain");
 	});
 }
 
@@ -505,7 +531,7 @@ fn progress_reports_the_effective_max_steps() {
 	// The reported limit is the one that will be enforced, not the one that the migration
 	// declared.
 	test_closure(|| {
-		MaxMigrationSteps::set(2);
+		MaxMigrationSteps::set(&2);
 		MockedMigrations::set(vec![(SucceedAfter, 5)]);
 
 		System::set_block_number(1);
@@ -515,8 +541,7 @@ fn progress_reports_the_effective_max_steps() {
 		assert_eq!(progress.current_migration_max_steps, Some(2));
 	});
 
-	// Neither the migration nor the runtime imposes a limit, which is reported as `None` instead
-	// of the `u32::MAX` sentinel.
+	// Neither the migration nor the runtime imposes a limit, which is reported as `None`.
 	test_closure(|| {
 		MockedMigrations::set(vec![(TimeoutAfter, u32::MAX)]);
 

--- a/substrate/frame/migrations/src/tests.rs
+++ b/substrate/frame/migrations/src/tests.rs
@@ -400,6 +400,134 @@ fn migration_timeout_errors() {
 	});
 }
 
+#[test]
+#[cfg_attr(feature = "try-runtime", should_panic)]
+fn migration_without_max_steps_times_out_at_max_migration_steps() {
+	test_closure(|| {
+		MaxMigrationSteps::set(3);
+		// `u32::MAX` steps mocks a migration that does not declare a limit of its own.
+		MockedMigrations::set(vec![(TimeoutAfter, u32::MAX)]);
+
+		System::set_block_number(1);
+		Migrations::on_runtime_upgrade();
+		run_to_block(5);
+
+		// Times out after taking more than the blanket 3 steps.
+		assert_events(vec![
+			Event::UpgradeStarted { migrations: 1 },
+			Event::MigrationAdvanced { index: 0, took: 1 },
+			Event::MigrationAdvanced { index: 0, took: 2 },
+			Event::MigrationAdvanced { index: 0, took: 3 },
+			Event::MigrationAdvanced { index: 0, took: 4 },
+			Event::MigrationFailed { index: 0, took: 4 },
+			Event::UpgradeFailed,
+		]);
+		assert_eq!(upgrades_started_completed_failed(), (1, 0, 1));
+		assert_eq!(Cursor::<T>::get(), Some(MigrationCursor::Stuck));
+	});
+}
+
+#[test]
+#[cfg_attr(feature = "try-runtime", should_panic)]
+fn max_migration_steps_caps_a_larger_max_steps() {
+	test_closure(|| {
+		MaxMigrationSteps::set(1);
+		// The migration asks for 3 steps, but only gets the blanket 1.
+		MockedMigrations::set(vec![(TimeoutAfter, 3)]);
+
+		System::set_block_number(1);
+		Migrations::on_runtime_upgrade();
+		run_to_block(5);
+
+		assert_events(vec![
+			Event::UpgradeStarted { migrations: 1 },
+			Event::MigrationAdvanced { index: 0, took: 1 },
+			Event::MigrationAdvanced { index: 0, took: 2 },
+			Event::MigrationFailed { index: 0, took: 2 },
+			Event::UpgradeFailed,
+		]);
+		assert_eq!(upgrades_started_completed_failed(), (1, 0, 1));
+		assert_eq!(Cursor::<T>::get(), Some(MigrationCursor::Stuck));
+	});
+}
+
+#[test]
+fn migration_within_max_migration_steps_completes() {
+	use Event::*;
+	test_closure(|| {
+		// The migration advances at `took` 1 and 2, so it just fits into the blanket limit.
+		MaxMigrationSteps::set(2);
+		MockedMigrations::set(vec![(SucceedAfter, 2)]);
+
+		System::set_block_number(1);
+		Migrations::on_runtime_upgrade();
+		run_to_block(10);
+
+		assert_events(vec![
+			UpgradeStarted { migrations: 1 },
+			MigrationAdvanced { index: 0, took: 1 },
+			MigrationAdvanced { index: 0, took: 2 },
+			MigrationCompleted { index: 0, took: 3 },
+			UpgradeCompleted,
+		]);
+		assert_eq!(upgrades_started_completed_failed(), (1, 1, 0));
+		assert_eq!(historic(), vec![mocked_id(SucceedAfter, 2)]);
+		assert_eq!(Cursor::<T>::get(), None);
+	});
+}
+
+#[test]
+#[cfg_attr(feature = "try-runtime", should_panic)]
+fn max_steps_below_max_migration_steps_still_applies() {
+	test_closure(|| {
+		// The migration asks for less than the blanket limit, so its own limit is the one that
+		// applies.
+		MaxMigrationSteps::set(100);
+		MockedMigrations::set(vec![(TimeoutAfter, 1)]);
+
+		System::set_block_number(1);
+		Migrations::on_runtime_upgrade();
+		run_to_block(5);
+
+		assert_events(vec![
+			Event::UpgradeStarted { migrations: 1 },
+			Event::MigrationAdvanced { index: 0, took: 1 },
+			Event::MigrationAdvanced { index: 0, took: 2 },
+			Event::MigrationFailed { index: 0, took: 2 },
+			Event::UpgradeFailed,
+		]);
+		assert_eq!(upgrades_started_completed_failed(), (1, 0, 1));
+	});
+}
+
+#[test]
+fn progress_reports_the_effective_max_steps() {
+	// The reported limit is the one that will be enforced, not the one that the migration
+	// declared.
+	test_closure(|| {
+		MaxMigrationSteps::set(2);
+		MockedMigrations::set(vec![(SucceedAfter, 5)]);
+
+		System::set_block_number(1);
+		Migrations::on_runtime_upgrade();
+
+		let progress = Migrations::status().progress.unwrap();
+		assert_eq!(progress.current_migration_max_steps, Some(2));
+	});
+
+	// Neither the migration nor the runtime imposes a limit, which is reported as `None` instead
+	// of the `u32::MAX` sentinel.
+	test_closure(|| {
+		MockedMigrations::set(vec![(TimeoutAfter, u32::MAX)]);
+
+		System::set_block_number(1);
+		Migrations::on_runtime_upgrade();
+
+		let progress = Migrations::status().progress.unwrap();
+		assert_eq!(progress.current_migration_max_steps, None);
+	});
+}
+
 #[cfg(feature = "try-runtime")]
 #[test]
 fn try_runtime_success_case() {

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1115,8 +1115,12 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
+	// No single migration may keep the chain in migration mode for longer than a day.
+	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }
 

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1115,9 +1115,7 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
-	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
+	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1115,11 +1115,8 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
 	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
-	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1115,7 +1115,9 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;

--- a/substrate/frame/staking-async/runtimes/rc/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/lib.rs
@@ -1752,9 +1752,7 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
-	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
+	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;

--- a/substrate/frame/staking-async/runtimes/rc/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/lib.rs
@@ -1752,11 +1752,8 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
-	// limit, instead of freezing it.
 	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
-	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }

--- a/substrate/frame/staking-async/runtimes/rc/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/lib.rs
@@ -1752,8 +1752,12 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
+	// No single migration may keep the chain in migration mode for longer than a day.
+	type MaxMigrationSteps = ConstU32<{ DAYS }>;
 	type WeightInfo = weights::pallet_migrations::WeightInfo<Runtime>;
 }
 

--- a/substrate/frame/staking-async/runtimes/rc/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/lib.rs
@@ -1752,7 +1752,9 @@ impl pallet_migrations::Config for Runtime {
 	type CursorMaxLen = ConstU32<65_536>;
 	type IdentifierMaxLen = ConstU32<256>;
 	type MigrationStatusHandler = ();
-	type FailedMigrationHandler = frame_support::migrations::FreezeChainOnFailedMigration;
+	// Keep the chain usable and governance reachable if a migration fails or exceeds its step
+	// limit, instead of freezing it.
+	type FailedMigrationHandler = frame_support::migrations::ForceUnstuckOnFailedMigration;
 	type MaxServiceWeight = MbmServiceWeight;
 	// No single migration may keep the chain in migration mode for longer than a day.
 	type MaxMigrationSteps = ConstU32<{ DAYS }>;


### PR DESCRIPTION
In theory, misconfigured MBM migrations could run indefinitely. This PR introduces a fallback safety mechanism to cap the migrations after a configurable amount, after which the `FailedMigrationHandler` will be triggered. This is the upstream part of https://github.com/polkadot-fellows/runtimes/pull/1238.

Exceeding the limit counts as a failed migration and is handed to the `FailedMigrationHandler`, so the cap only helps if that handler leaves the chain recoverable. Hence, I switched the `FreezeChainOnFailedMigration` to `ForceUnstuckOnFailedMigration`. `EnterSafeModeOnFailedMigration` would be the better middle ground, but I deferred this change for now, see #12921.