### PR TITLE
Unify PSM decimal scaling

### DIFF
--- a/prdoc/pr_12842.prdoc
+++ b/prdoc/pr_12842.prdoc
@@ -1,0 +1,18 @@
+title: 'Unify PSM decimal scaling'
+doc:
+- audience: Runtime Dev
+  description: |-
+    PSM decimal handling was scattered across several helper functions and checks,
+    which made it easy to get wrong.
+
+    This PR gathers it all into one small, validated type that every part of the
+    pallet goes through: validation happens once when an external asset is
+    registered, and swaps reuse the stored result. Amounts are rounded down so both
+    sides of a swap always match exactly, with any leftover dust staying with the
+    caller.
+
+    No behavior change. The public `MAX_DECIMALS_DIFF` constant is replaced by
+    `DecimalScale::MAX_DIFF`.
+crates:
+- name: pallet-psm
+  bump: major

--- a/substrate/frame/psm/src/decimal_scale.rs
+++ b/substrate/frame/psm/src/decimal_scale.rs
@@ -1,0 +1,254 @@
+// This file is part of Substrate.
+
+// Copyright (C) Amforc AG.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Decimal scaling between a PSM pair's external and internal asset units.
+//!
+//! [`DecimalScale`] is the single source of truth for converting amounts between the two
+//! precisions of a PSM pair: it is validated once, at construction from a [`DecimalsPair`],
+//! and every conversion afterwards relies on the established invariant. Swaps use
+//! [`DecimalScale::pair_from_external`] / [`DecimalScale::pair_from_internal`], which round
+//! an amount down to the largest value both assets can represent exactly and return it as a
+//! [`ScaledPair`].
+//!
+//! This module is pure math over an [`AtLeast32BitUnsigned`] balance and carries no pallet
+//! dependencies; should a second consumer show up it can move to `sp-arithmetic` or
+//! `frame-support` unchanged.
+
+use sp_runtime::traits::AtLeast32BitUnsigned;
+
+/// Unvalidated decimals snapshot for a PSM pair, as read from asset metadata.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct DecimalsPair {
+	/// The external asset's decimals.
+	pub external: u8,
+	/// The internal asset's decimals.
+	pub internal: u8,
+}
+
+/// An amount represented exactly in both of a PSM pair's units.
+///
+/// Produced by [`DecimalScale::pair_from_external`] / [`DecimalScale::pair_from_internal`]:
+/// `external` and `internal` always round-trip to each other without truncation, so any
+/// dust cut off the input stays with its owner.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ScaledPair<B> {
+	/// The amount in external-asset units.
+	pub external: B,
+	/// The amount in internal-asset units.
+	pub internal: B,
+}
+
+/// Why a [`DecimalScale`] could not be constructed from a [`DecimalsPair`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DecimalScaleError {
+	/// The pair's decimals differ by more than [`DecimalScale::MAX_DIFF`].
+	DiffOutOfRange,
+	/// The scaling factor `10^diff` does not fit the balance type.
+	Overflow,
+}
+
+/// Validated conversion between a PSM pair's external- and internal-asset units.
+///
+/// Invariant, established at construction: the factor is `10^diff` with
+/// `1 <= diff <= MAX_DIFF` and representable in `B`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DecimalScale<B> {
+	/// Both assets have the same precision.
+	Identity,
+	/// Internal is the higher-precision side: multiply toward internal, divide toward
+	/// external.
+	MulToInternal(B),
+	/// Internal is the lower-precision side: divide toward internal, multiply toward
+	/// external.
+	DivToInternal(B),
+}
+
+impl<B> DecimalScale<B> {
+	/// Maximum absolute difference between the two assets' decimals. Bounds the scaling
+	/// factor `10^diff` well below `u128::MAX` so realistic balances cannot overflow
+	/// during conversion.
+	pub const MAX_DIFF: u8 = 24;
+}
+
+impl<B: AtLeast32BitUnsigned + Copy> DecimalScale<B> {
+	/// Validate a [`DecimalsPair`] into a scale usable for conversions.
+	pub fn try_new(decimals: DecimalsPair) -> Result<Self, DecimalScaleError> {
+		let diff = decimals.external.abs_diff(decimals.internal);
+		if diff > Self::MAX_DIFF {
+			return Err(DecimalScaleError::DiffOutOfRange);
+		}
+		if diff == 0 {
+			return Ok(Self::Identity);
+		}
+		let factor = 10u128
+			.checked_pow(u32::from(diff))
+			.and_then(|factor| B::try_from(factor).ok())
+			.ok_or(DecimalScaleError::Overflow)?;
+		if decimals.internal > decimals.external {
+			Ok(Self::MulToInternal(factor))
+		} else {
+			Ok(Self::DivToInternal(factor))
+		}
+	}
+
+	/// Convert an external-unit amount into internal units, flooring on division.
+	/// `None` on multiplication overflow.
+	pub fn to_internal(self, external_amount: B) -> Option<B> {
+		match self {
+			Self::Identity => Some(external_amount),
+			Self::MulToInternal(factor) => external_amount.checked_mul(&factor),
+			// Factor is `10^diff` with `diff >= 1` by construction, so never zero; qed.
+			Self::DivToInternal(factor) => Some(external_amount / factor),
+		}
+	}
+
+	/// Convert an internal-unit amount into external units, flooring on division.
+	/// `None` on multiplication overflow.
+	pub fn to_external(self, internal_amount: B) -> Option<B> {
+		match self {
+			Self::Identity => Some(internal_amount),
+			// Factor is `10^diff` with `diff >= 1` by construction, so never zero; qed.
+			Self::MulToInternal(factor) => Some(internal_amount / factor),
+			Self::DivToInternal(factor) => internal_amount.checked_mul(&factor),
+		}
+	}
+
+	/// Round an external-unit amount down to the largest share of `external_amount` that
+	/// converts without truncation, paired with its exact internal equivalent.
+	/// `None` on multiplication overflow.
+	pub fn pair_from_external(self, external_amount: B) -> Option<ScaledPair<B>> {
+		match self {
+			Self::Identity => {
+				Some(ScaledPair { external: external_amount, internal: external_amount })
+			},
+			Self::MulToInternal(factor) => {
+				let internal = external_amount.checked_mul(&factor)?;
+				Some(ScaledPair { external: external_amount, internal })
+			},
+			Self::DivToInternal(factor) => {
+				let internal = external_amount / factor;
+				// Floored by `factor` above, so scaling back cannot exceed
+				// `external_amount`; qed.
+				let external = internal.checked_mul(&factor)?;
+				Some(ScaledPair { external, internal })
+			},
+		}
+	}
+
+	/// Round an internal-unit amount down the same way: mirror of
+	/// [`Self::pair_from_external`].
+	pub fn pair_from_internal(self, internal_amount: B) -> Option<ScaledPair<B>> {
+		match self {
+			Self::Identity => {
+				Some(ScaledPair { external: internal_amount, internal: internal_amount })
+			},
+			Self::MulToInternal(factor) => {
+				let external = internal_amount / factor;
+				// Floored by `factor` above, so scaling back cannot exceed
+				// `internal_amount`; qed.
+				let internal = external.checked_mul(&factor)?;
+				Some(ScaledPair { external, internal })
+			},
+			Self::DivToInternal(factor) => {
+				let external = internal_amount.checked_mul(&factor)?;
+				Some(ScaledPair { external, internal: internal_amount })
+			},
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Validated scale for an `(external, internal)` decimals pair.
+	fn scale(external: u8, internal: u8) -> DecimalScale<u128> {
+		DecimalScale::try_new(DecimalsPair { external, internal }).expect("pair within MAX_DIFF")
+	}
+
+	#[test]
+	fn to_internal_same_decimals_is_identity() {
+		assert_eq!(scale(6, 6).to_internal(1_000_000), Some(1_000_000));
+	}
+
+	#[test]
+	fn to_internal_scale_up_is_exact() {
+		// 2 decimals -> 6 decimals: multiply by 10^4.
+		assert_eq!(scale(2, 6).to_internal(100), Some(1_000_000));
+	}
+
+	#[test]
+	fn to_internal_scale_down_truncates() {
+		// 18 decimals -> 6 decimals: divide by 10^12, floor.
+		assert_eq!(scale(18, 6).to_internal(1_500_000_000_000_000_123), Some(1_500_000));
+	}
+
+	#[test]
+	fn round_trip_bounds() {
+		// For any amount, round-trip should shrink or preserve.
+		for (external, internal) in [(2u8, 6u8), (6, 6), (18, 6), (6, 18), (6, 2)] {
+			for amount in [0u128, 1, 100, 1_234_567, 10u128.pow(18)] {
+				let fwd = scale(external, internal).to_internal(amount).unwrap();
+				let rtp = scale(external, internal).to_external(fwd).unwrap();
+				assert!(rtp <= amount, "round-trip grew: amount={} got {}", amount, rtp);
+			}
+		}
+	}
+
+	#[test]
+	fn pair_from_external_rounds_down_to_round_trip_boundary() {
+		// 18 -> 6 decimals: 123 units of dust are cut off both sides.
+		let pair = scale(18, 6).pair_from_external(1_500_000_000_000_000_123).unwrap();
+		assert_eq!(pair, ScaledPair { external: 1_500_000_000_000_000_000, internal: 1_500_000 });
+		// 2 -> 6 decimals: scale-up is always exact.
+		let pair = scale(2, 6).pair_from_external(123).unwrap();
+		assert_eq!(pair, ScaledPair { external: 123, internal: 1_230_000 });
+	}
+
+	#[test]
+	fn pair_from_internal_rounds_down_to_round_trip_boundary() {
+		// 6 -> 2 decimals: 45 units of dust are cut off both sides.
+		let pair = scale(2, 6).pair_from_internal(1_230_045).unwrap();
+		assert_eq!(pair, ScaledPair { external: 123, internal: 1_230_000 });
+		// 6 -> 18 decimals: scale-up is always exact.
+		let pair = scale(18, 6).pair_from_internal(1_500_000).unwrap();
+		assert_eq!(pair, ScaledPair { external: 1_500_000_000_000_000_000, internal: 1_500_000 });
+	}
+
+	#[test]
+	fn construction_rejects_out_of_range_and_overflow() {
+		// |0 - 40| = 40 exceeds MAX_DIFF (24).
+		assert_eq!(
+			DecimalScale::<u128>::try_new(DecimalsPair { external: 0, internal: 40 }),
+			Err(DecimalScaleError::DiffOutOfRange)
+		);
+		// 10^24 is within MAX_DIFF but does not fit a u64 balance type.
+		assert_eq!(
+			DecimalScale::<u64>::try_new(DecimalsPair { external: 0, internal: 24 }),
+			Err(DecimalScaleError::Overflow)
+		);
+	}
+
+	#[test]
+	fn max_diff_const_is_protective() {
+		// Compile-time sanity: the chosen bound is wide but below the overflow point.
+		// 10^24 fits comfortably in u128 (< 10^38), and leaves ~10^14 headroom on
+		// balances. The const is documented; this asserts it has not been widened
+		// beyond the safe range.
+		assert!(DecimalScale::<u128>::MAX_DIFF <= 30);
+	}
+}

--- a/substrate/frame/psm/src/lib.rs
+++ b/substrate/frame/psm/src/lib.rs
@@ -99,6 +99,7 @@
 
 extern crate alloc;
 
+pub mod decimal_scale;
 pub mod weights;
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -108,6 +109,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+pub use decimal_scale::{DecimalScale, DecimalScaleError, DecimalsPair, ScaledPair};
 pub use pallet::*;
 pub use weights::WeightInfo;
 
@@ -144,11 +146,14 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use sp_runtime::{
-		traits::{CheckedDiv, CheckedMul, Saturating, TrailingZeroInput, Zero},
+		traits::{Saturating, TrailingZeroInput, Zero},
 		Perbill, Permill, TypeId,
 	};
 
-	use crate::WeightInfo;
+	use crate::{
+		decimal_scale::{DecimalScale, DecimalScaleError, DecimalsPair},
+		WeightInfo,
+	};
 
 	/// Circuit breaker levels for emergency control.
 	#[derive(
@@ -266,11 +271,6 @@ pub mod pallet {
 			Permill::from_parts(5_000)
 		}
 	}
-
-	/// Maximum absolute difference between an external asset's decimals and the internal
-	/// asset's decimals. Bounds the scaling factor `10^diff` well below `u128::MAX`
-	/// so realistic balances cannot overflow during conversion.
-	pub const MAX_DECIMALS_DIFF: u32 = 24;
 
 	/// On-chain record of a PSM instance.
 	#[derive(
@@ -654,6 +654,15 @@ pub mod pallet {
 		Unexpected,
 	}
 
+	impl<T: Config> From<DecimalScaleError> for Error<T> {
+		fn from(e: DecimalScaleError) -> Self {
+			match e {
+				DecimalScaleError::DiffOutOfRange => Error::<T>::DecimalsRangeExceeded,
+				DecimalScaleError::Overflow => Error::<T>::ConversionOverflow,
+			}
+		}
+	}
+
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Swap external asset for internal on a specific PSM instance.
@@ -713,31 +722,29 @@ pub mod pallet {
 				.ok_or(Error::<T>::UnsupportedAsset)?;
 			ensure!(external.status.allows_minting(), Error::<T>::MintingStopped);
 
-			let (ext_decimals, internal_decimals) =
-				Self::ensure_decimals_match(&info, &internal_asset, &external_asset, &external)?;
+			Self::ensure_decimals_match(&info, &internal_asset, &external_asset, &external)?;
+			let scale = Self::snapshot_scale(&info, &external)?;
 
-			let internal_equivalent =
-				Self::external_to_internal(external_amount, ext_decimals, internal_decimals)?;
-			ensure!(!internal_equivalent.is_zero(), Error::<T>::AmountTooSmallAfterConversion);
-			ensure!(internal_equivalent >= info.min_swap_amount, Error::<T>::BelowMinimumSwap);
-
-			let effective_external =
-				Self::internal_to_external(internal_equivalent, ext_decimals, internal_decimals)?;
+			let swap = scale
+				.pair_from_external(external_amount)
+				.ok_or(Error::<T>::ConversionOverflow)?;
+			ensure!(!swap.internal.is_zero(), Error::<T>::AmountTooSmallAfterConversion);
+			ensure!(swap.internal >= info.min_swap_amount, Error::<T>::BelowMinimumSwap);
 
 			let fee_rate = MintingFee::<T>::get(&internal_asset, &external_asset);
 			ensure!(fee_rate <= max_fee, Error::<T>::FeeTooHigh);
-			let fee = fee_rate.mul_ceil(internal_equivalent);
-			let internal_to_user = internal_equivalent.saturating_sub(fee);
+			let fee = fee_rate.mul_ceil(swap.internal);
+			let internal_to_user = swap.internal.saturating_sub(fee);
 
 			let current_total_psm_debt = Self::total_psm_debt(&internal_asset);
 			ensure!(
-				current_total_psm_debt.saturating_add(internal_equivalent) <= info.max_debt,
+				current_total_psm_debt.saturating_add(swap.internal) <= info.max_debt,
 				Error::<T>::ExceedsMaxPsmDebt
 			);
 
 			let current_debt = PsmDebt::<T>::get(&internal_asset, &external_asset);
 			let max_debt = Self::max_asset_debt(&internal_asset, &external_asset, &info);
-			let new_debt = current_debt.saturating_add(internal_equivalent);
+			let new_debt = current_debt.saturating_add(swap.internal);
 			ensure!(new_debt <= max_debt, Error::<T>::ExceedsMaxPsmDebt);
 
 			let psm_account = Self::psm_account(&internal_asset);
@@ -745,7 +752,7 @@ pub mod pallet {
 				external_asset.clone(),
 				&who,
 				&psm_account,
-				effective_external,
+				swap.external,
 				Preservation::Expendable,
 			)?;
 			T::Fungibles::mint_into(internal_asset.clone(), &who, internal_to_user)?;
@@ -759,7 +766,7 @@ pub mod pallet {
 				who,
 				internal_asset,
 				external_asset,
-				external_consumed: effective_external,
+				external_consumed: swap.external,
 				internal_received: internal_to_user,
 				internal_fee: fee,
 			});
@@ -822,8 +829,9 @@ pub mod pallet {
 				.ok_or(Error::<T>::UnsupportedAsset)?;
 			ensure!(external.status.allows_redemption(), Error::<T>::AllSwapsStopped);
 
-			let ext_decimals = external.decimals;
-			let internal_decimals = info.internal_decimals;
+			// Unlike `mint`, no live-decimals check: the scale comes from the snapshots taken
+			// at registration, so existing positions can unwind even under metadata drift.
+			let scale = Self::snapshot_scale(&info, &external)?;
 
 			ensure!(internal_amount >= info.min_swap_amount, Error::<T>::BelowMinimumSwap);
 
@@ -832,24 +840,21 @@ pub mod pallet {
 			let fee = fee_rate.mul_ceil(internal_amount);
 			let internal_net = internal_amount.saturating_sub(fee);
 
-			let external_out =
-				Self::internal_to_external(internal_net, ext_decimals, internal_decimals)?;
+			// `swap.internal` is what we actually burn and what the tracked debt decreases by;
+			// truncation dust stays in the caller's internal balance, symmetric with `mint`,
+			// which takes only the round-tripped share of the external amount.
+			let swap =
+				scale.pair_from_internal(internal_net).ok_or(Error::<T>::ConversionOverflow)?;
 			ensure!(
-				internal_net.is_zero() || !external_out.is_zero(),
+				internal_net.is_zero() || !swap.external.is_zero(),
 				Error::<T>::AmountTooSmallAfterConversion
 			);
-			// `effective_internal_net` is the internal value that round-trips to `external_out`;
-			// it is what we actually burn and what the tracked debt decreases by. Any truncation
-			// dust stays in the caller's internal balance, symmetric with `mint`, which takes
-			// only the round-tripped share of the external amount.
-			let effective_internal_net =
-				Self::external_to_internal(external_out, ext_decimals, internal_decimals)?;
 
 			let current_debt = PsmDebt::<T>::get(&internal_asset, &external_asset);
-			ensure!(current_debt >= effective_internal_net, Error::<T>::InsufficientReserve);
+			ensure!(current_debt >= swap.internal, Error::<T>::InsufficientReserve);
 
 			let reserve = Self::get_reserve(&internal_asset, &external_asset);
-			if reserve < external_out {
+			if reserve < swap.external {
 				defensive!("PSM reserve is less than expected output amount");
 				return Err(Error::<T>::Unexpected.into());
 			}
@@ -864,11 +869,11 @@ pub mod pallet {
 				)?;
 			}
 
-			if !effective_internal_net.is_zero() {
+			if !swap.internal.is_zero() {
 				T::Fungibles::burn_from(
 					internal_asset.clone(),
 					&who,
-					effective_internal_net,
+					swap.internal,
 					Preservation::Expendable,
 					Precision::Exact,
 					Fortitude::Polite,
@@ -876,26 +881,26 @@ pub mod pallet {
 			}
 
 			let psm_account = Self::psm_account(&internal_asset);
-			if !external_out.is_zero() {
+			if !swap.external.is_zero() {
 				T::Fungibles::transfer(
 					external_asset.clone(),
 					&psm_account,
 					&who,
-					external_out,
+					swap.external,
 					Preservation::Expendable,
 				)?;
 			}
 
 			PsmDebt::<T>::mutate(&internal_asset, &external_asset, |debt| {
-				*debt = debt.saturating_sub(effective_internal_net);
+				*debt = debt.saturating_sub(swap.internal);
 			});
 
 			Self::deposit_event(Event::Redeemed {
 				who,
 				internal_asset,
 				external_asset,
-				internal_consumed: effective_internal_net.saturating_add(fee),
-				external_received: external_out,
+				internal_consumed: swap.internal.saturating_add(fee),
+				external_received: swap.external,
 				internal_fee: fee,
 			});
 			Ok(())
@@ -1306,7 +1311,8 @@ pub mod pallet {
 		/// - [`Error::DecimalsMismatch`]: If the internal asset's live decimals diverged from the
 		///   snapshot in [`PsmInfo`].
 		/// - [`Error::DecimalsRangeExceeded`]: If `|asset_decimals − internal_decimals|` exceeds
-		///   [`MAX_DECIMALS_DIFF`].
+		///   [`DecimalScale::MAX_DIFF`].
+		/// - [`Error::ConversionOverflow`]: If the scaling factor does not fit the balance type.
 		///
 		/// ## Events
 		///
@@ -1335,10 +1341,14 @@ pub mod pallet {
 				T::Fungibles::decimals(internal_asset.clone()) == info.internal_decimals,
 				Error::<T>::DecimalsMismatch
 			);
-			ensure!(
-				(asset_decimals.abs_diff(info.internal_decimals) as u32) <= MAX_DECIMALS_DIFF,
-				Error::<T>::DecimalsRangeExceeded
-			);
+			// The only place the pair's decimals difference is validated: a pair is only
+			// registered if the scale can be built, so swaps can always rebuild it from
+			// the snapshots.
+			DecimalScale::<BalanceOf<T>>::try_new(DecimalsPair {
+				external: asset_decimals,
+				internal: info.internal_decimals,
+			})
+			.map_err(Error::<T>::from)?;
 
 			ExternalAssets::<T>::insert(
 				&internal_asset,
@@ -1572,62 +1582,22 @@ pub mod pallet {
 			T::Fungibles::balance(external_asset.clone(), &Self::psm_account(internal_asset))
 		}
 
-		/// Convert an amount denominated in external-asset units into internal units.
+		/// Rebuild the pair's [`DecimalScale`] from the snapshots taken at registration.
 		///
-		/// Scales by `10^(ext_decimals - internal_decimals)` — multiplies up when internal has more
-		/// decimals, floor-divides when it has fewer. Returns [`Error::ConversionOverflow`] if
-		/// the scaling factor or the product does not fit in the balance type.
-		pub(crate) fn external_to_internal(
-			amount: BalanceOf<T>,
-			ext_decimals: u8,
-			internal_decimals: u8,
-		) -> Result<BalanceOf<T>, Error<T>> {
-			use core::cmp::Ordering::*;
-			match ext_decimals.cmp(&internal_decimals) {
-				Equal => Ok(amount),
-				Less => {
-					let diff = (internal_decimals - ext_decimals) as u32;
-					let factor = Self::pow10(diff)?;
-					amount.checked_mul(&factor).ok_or(Error::<T>::ConversionOverflow)
-				},
-				Greater => {
-					let diff = (ext_decimals - internal_decimals) as u32;
-					let factor = Self::pow10(diff)?;
-					Ok(amount.checked_div(&factor).unwrap_or_else(BalanceOf::<T>::zero))
-				},
-			}
-		}
-
-		/// Convert an amount denominated in internal units into external-asset units.
-		///
-		/// Inverse of [`Self::external_to_internal`]. Floor-divides when internal has more
-		/// decimals, multiplies up when it has fewer.
-		pub(crate) fn internal_to_external(
-			amount: BalanceOf<T>,
-			ext_decimals: u8,
-			internal_decimals: u8,
-		) -> Result<BalanceOf<T>, Error<T>> {
-			use core::cmp::Ordering::*;
-			match ext_decimals.cmp(&internal_decimals) {
-				Equal => Ok(amount),
-				Less => {
-					let diff = (internal_decimals - ext_decimals) as u32;
-					let factor = Self::pow10(diff)?;
-					Ok(amount.checked_div(&factor).unwrap_or_else(BalanceOf::<T>::zero))
-				},
-				Greater => {
-					let diff = (ext_decimals - internal_decimals) as u32;
-					let factor = Self::pow10(diff)?;
-					amount.checked_mul(&factor).ok_or(Error::<T>::ConversionOverflow)
-				},
-			}
-		}
-
-		/// Compute `10^exp` as a [`BalanceOf`]. Returns [`Error::ConversionOverflow`] if the result
-		/// does not fit in `u128` or in `BalanceOf<T>`.
-		fn pow10(exp: u32) -> Result<BalanceOf<T>, Error<T>> {
-			let factor_u128 = 10u128.checked_pow(exp).ok_or(Error::<T>::ConversionOverflow)?;
-			factor_u128.try_into().map_err(|_| Error::<T>::ConversionOverflow)
+		/// [`Pallet::add_external_asset`] only registers pairs whose scale can be built,
+		/// so a failure here means corrupted storage.
+		pub(crate) fn snapshot_scale(
+			info: &PsmInfo<T>,
+			external: &ExternalAssetInfo,
+		) -> Result<DecimalScale<BalanceOf<T>>, DispatchError> {
+			DecimalScale::try_new(DecimalsPair {
+				external: external.decimals,
+				internal: info.internal_decimals,
+			})
+			.map_err(|_| {
+				defensive!("stored decimals snapshot no longer yields a valid scale");
+				Error::<T>::Unexpected.into()
+			})
 		}
 
 		/// Verify the live decimals for an external still match the snapshot taken at
@@ -1638,7 +1608,7 @@ pub mod pallet {
 			internal_asset: &T::AssetId,
 			external_asset: &T::AssetId,
 			external: &ExternalAssetInfo,
-		) -> Result<(u8, u8), DispatchError> {
+		) -> DispatchResult {
 			ensure!(
 				T::Fungibles::decimals(external_asset.clone()) == external.decimals,
 				Error::<T>::DecimalsMismatch
@@ -1647,7 +1617,7 @@ pub mod pallet {
 				T::Fungibles::decimals(internal_asset.clone()) == info.internal_decimals,
 				Error::<T>::DecimalsMismatch
 			);
-			Ok((external.decimals, info.internal_decimals))
+			Ok(())
 		}
 
 		/// Authorise an operation on the PSM keyed by `internal_asset`.
@@ -1690,12 +1660,18 @@ pub mod pallet {
 				{
 					counted = counted.saturating_add(1);
 
-					// 1. Per-external reserve covers tracked debt.
+					// 1. Per-external reserve covers tracked debt, at the snapshot rate (the
+					// check stays valid under live-metadata drift).
 					let debt = PsmDebt::<T>::get(&internal_asset, &external_asset);
 					let reserve = Self::get_reserve(&internal_asset, &external_asset);
-					let debt_as_external =
-						Self::internal_to_external(debt, external.decimals, info.internal_decimals)
-							.map_err(|_| "Failed to convert tracked debt to external units")?;
+					let scale = DecimalScale::<BalanceOf<T>>::try_new(DecimalsPair {
+						external: external.decimals,
+						internal: info.internal_decimals,
+					})
+					.map_err(|_| "Stored decimals snapshot does not yield a valid scale")?;
+					let debt_as_external = scale
+						.to_external(debt)
+						.ok_or("Failed to convert tracked debt to external units")?;
 					ensure!(
 						reserve >= debt_as_external,
 						"PSM reserve is less than tracked debt for an asset"

--- a/substrate/frame/psm/src/tests.rs
+++ b/substrate/frame/psm/src/tests.rs
@@ -1084,7 +1084,7 @@ mod governance {
 	fn add_external_asset_accepts_differing_decimals_within_range() {
 		new_test_ext().execute_with(|| {
 			let new_asset = 99u32;
-			// Asset with 8 decimals vs internal's 6 — within MAX_DECIMALS_DIFF.
+			// Asset with 8 decimals vs internal's 6 — within DecimalScale::MAX_DIFF.
 			assert_ok!(Assets::create(RuntimeOrigin::signed(ALICE), new_asset, ALICE, 1));
 			assert_ok!(Assets::set_metadata(
 				RuntimeOrigin::signed(ALICE),
@@ -1109,7 +1109,7 @@ mod governance {
 	fn add_external_asset_fails_decimals_out_of_range() {
 		new_test_ext().execute_with(|| {
 			let new_asset = 99u32;
-			// Decimals 6 + 25 = 31 exceeds MAX_DECIMALS_DIFF (24).
+			// Decimals 6 + 25 = 31 exceeds DecimalScale::MAX_DIFF (24).
 			assert_ok!(Assets::create(RuntimeOrigin::signed(ALICE), new_asset, ALICE, 1));
 			assert_ok!(Assets::set_metadata(
 				RuntimeOrigin::signed(ALICE),
@@ -2454,64 +2454,10 @@ mod cycles {
 /// registered with PSM via `register_external_asset_with_weight` inside each test.
 mod decimal_scaling {
 	use super::*;
-	use crate::MAX_DECIMALS_DIFF;
 
 	fn set_zero_fees(asset_id: u32) {
 		set_minting_fee(asset_id, Permill::zero());
 		set_redemption_fee(asset_id, Permill::zero());
-	}
-
-	// Conversion helpers
-
-	#[test]
-	fn external_to_internal_same_decimals_is_identity() {
-		new_test_ext().execute_with(|| {
-			assert_eq!(Psm::external_to_internal(1_000_000, 6, 6).unwrap(), 1_000_000);
-		});
-	}
-
-	#[test]
-	fn external_to_internal_scale_up_is_exact() {
-		new_test_ext().execute_with(|| {
-			// USDX (2) -> internal (6): multiply by 10^4.
-			assert_eq!(Psm::external_to_internal(100, 2, 6).unwrap(), 1_000_000);
-		});
-	}
-
-	#[test]
-	fn external_to_internal_scale_down_truncates() {
-		new_test_ext().execute_with(|| {
-			// DAI (18) -> internal (6): divide by 10^12, floor.
-			assert_eq!(
-				Psm::external_to_internal(1_500_000_000_000_000_123, 18, 6).unwrap(),
-				1_500_000
-			);
-		});
-	}
-
-	#[test]
-	fn internal_to_external_round_trip_bounds() {
-		new_test_ext().execute_with(|| {
-			// For any amount, round-trip should shrink or preserve.
-			for (ext_decimals, internal_decimals) in [(2u8, 6u8), (6, 6), (18, 6), (6, 18), (6, 2)]
-			{
-				for amount in [0u128, 1, 100, 1_234_567, 10u128.pow(18)] {
-					let fwd =
-						Psm::external_to_internal(amount, ext_decimals, internal_decimals).unwrap();
-					let rtp =
-						Psm::internal_to_external(fwd, ext_decimals, internal_decimals).unwrap();
-					assert!(rtp <= amount, "round-trip grew: amount={} got {}", amount, rtp);
-				}
-			}
-		});
-	}
-
-	#[test]
-	fn conversion_overflow_surfaces_error() {
-		new_test_ext().execute_with(|| {
-			// 10^40 overflows u128 (max ~3.4e38).
-			assert!(Psm::external_to_internal(1, 0, 40).is_err());
-		});
 	}
 
 	// Mint with scale-up (fewer external decimals)
@@ -3158,15 +3104,6 @@ mod decimal_scaling {
 		});
 	}
 
-	#[test]
-	fn max_decimals_diff_const_is_protective() {
-		// Compile-time sanity: the chosen bound is wide but below the overflow point.
-		// 10^24 fits comfortably in u128 (< 10^38), and leaves ~10^14 headroom on
-		// balances. The const is documented; this asserts it has not been widened
-		// beyond the safe range.
-		assert!(MAX_DECIMALS_DIFF <= 30);
-	}
-
 	// Mixed-decimal aggregate bookkeeping
 
 	#[test]
@@ -3279,8 +3216,8 @@ mod decimal_scaling {
 				1000 * INTERNAL_UNIT
 			);
 
-			// Donate extra DAI straight to the PSM account. Reserve now exceeds
-			// internal_to_external(debt). try_state check 2 uses the external-side
+			// Donate extra DAI straight to the PSM account. Reserve now exceeds the debt
+			// scaled to external units. try_state check 2 uses the external-side
 			// comparison and must still pass.
 			let psm = psm_account();
 			fund_external_asset(DAI_MOCK_ASSET_ID, psm.clone(), 7 * DAI_UNIT);


### PR DESCRIPTION
PSM decimal handling was scattered across several helper functions and checks, which made it easy to get wrong. 

This PR gathers it all into one small, validated type that every part of the pallet goes through: validation happens once when an external asset is registered, and swaps reuse the stored result. Amounts are rounded down so both sides of a swap always match exactly, with any leftover dust staying with the caller.

Follow-up to https://github.com/paritytech/polkadot-sdk/pull/12245#pullrequestreview-4635769921,
based on @lrazovic's draft.