### PR TITLE
paras: skip undersized parachain heads in sorted_para_heads

### DIFF
--- a/polkadot/runtime/parachains/src/paras/mod.rs
+++ b/polkadot/runtime/parachains/src/paras/mod.rs
@@ -1471,6 +1471,11 @@ const INVALID_TX_UNAUTHORIZED_CODE: u8 = 4;
 /// communicate via offchain XCMP. Snowbridge will still work as it only cares about `BridgeHub`.
 pub const MAX_PARA_HEADS: usize = 1024;
 
+/// Minimum length for a parachain head to be included by [`Pallet::sorted_para_heads`]; shorter
+/// entries are skipped as a sanity bound. Encoded parachain headers are well above this, so no
+/// real parachain is affected.
+pub const MIN_PARA_HEAD_LEN: usize = 64;
+
 impl<T: Config> Pallet<T> {
 	/// This is a call to schedule code upgrades for parachains which is safe to be called
 	/// outside of this module. That means this function does all checks necessary to ensure
@@ -1544,8 +1549,11 @@ impl<T: Config> Pallet<T> {
 	/// Get a list of the first [`MAX_PARA_HEADS`] para heads sorted by para_id.
 	/// This method is likely to be removed in the future.
 	pub fn sorted_para_heads() -> Vec<(u32, Vec<u8>)> {
-		let mut heads: Vec<(u32, Vec<u8>)> =
-			Heads::<T>::iter().map(|(id, head)| (id.into(), head.0)).collect();
+		let mut heads: Vec<(u32, Vec<u8>)> = Heads::<T>::iter()
+			.map(|(id, head)| (id.into(), head.0))
+			// Skip undersized heads; see `MIN_PARA_HEAD_LEN`.
+			.filter(|(_id, head_data)| head_data.len() >= MIN_PARA_HEAD_LEN)
+			.collect();
 		heads.sort_by_key(|(id, _)| *id);
 		heads.truncate(MAX_PARA_HEADS);
 		heads

--- a/polkadot/runtime/parachains/src/paras/tests.rs
+++ b/polkadot/runtime/parachains/src/paras/tests.rs
@@ -2420,3 +2420,27 @@ fn prune_expired_authorizations_works() {
 		assert!(AuthorizedCodeHash::<Test>::get(&para_b).is_none());
 	})
 }
+
+#[test]
+fn sorted_para_heads_enforces_min_head_len() {
+	use polkadot_primitives::HeadData;
+	new_test_ext(MockGenesisConfig::default()).execute_with(|| {
+		// (para_id, head_data length in bytes)
+		let inserts = [
+			(1000u32, 228usize),           // kept
+			(1001, MIN_PARA_HEAD_LEN),     // exactly the minimum -> kept
+			(1002, 98usize),               // kept
+			(1003, MIN_PARA_HEAD_LEN - 1), // below minimum       -> excluded
+			(1004, 0usize),                // below minimum       -> excluded
+		];
+		for (id, len) in inserts {
+			let head: HeadData = vec![0u8; len].into();
+			Heads::<Test>::insert(ParaId::from(id), head);
+		}
+
+		let kept_ids: Vec<u32> = Paras::sorted_para_heads().iter().map(|(id, _)| *id).collect();
+
+		// Only heads >= MIN_PARA_HEAD_LEN are included, sorted by para id.
+		assert_eq!(kept_ids, vec![1000, 1001, 1002]);
+	});
+}

--- a/prdoc/pr_12844.prdoc
+++ b/prdoc/pr_12844.prdoc
@@ -1,0 +1,10 @@
+title: 'paras: skip undersized parachain heads in sorted_para_heads'
+doc:
+- audience: Runtime Dev
+  description: |-
+    `Paras::sorted_para_heads()` now skips parachain heads shorter than
+    `MIN_PARA_HEAD_LEN` (64 bytes). Encoded parachain headers are well above this bound, so no
+    real parachain is affected.
+crates:
+- name: polkadot-runtime-parachains
+  bump: minor


### PR DESCRIPTION
`Paras::sorted_para_heads()` now skips parachain heads shorter than `MIN_PARA_HEAD_LEN` (64 bytes) when building the parachain-heads list. Encoded parachain headers are well above this bound, so no real parachain is affected.

Relay-only, no downstream change needed. Adds a test.
