### PR TITLE
[RWF] messages-relay: Fix MessageRaceLimits Overflow

### DIFF
--- a/bridges/relays/messages/src/message_race_limits.rs
+++ b/bridges/relays/messages/src/message_race_limits.rs
@@ -75,8 +75,12 @@ impl MessageRaceLimits {
 		let mut selected_weight = Weight::zero();
 		let mut selected_count: MessageNonce = 0;
 
+		let Some(next_nonce) = reference.best_target_nonce.checked_add(1) else {
+			return None;
+		};
+
 		let hard_selected_begin_nonce = std::cmp::max(
-			reference.best_target_nonce + 1,
+			next_nonce,
 			reference.nonces_queue[*reference.nonces_queue_range.start()].1.begin(),
 		);
 

--- a/prdoc/pr_12851.prdoc
+++ b/prdoc/pr_12851.prdoc
@@ -1,0 +1,12 @@
+title: '[RWF] messages-relay: Fix MessageRaceLimits Overflow'
+doc:
+- audience: Node Dev
+  description: |-
+    Closes #12721
+
+    ## Problem
+    `MessageRaceLimits::decide` calculates `best_target_nonce + 1` without checked arithmetic.
+
+    ## Solution
+    Add checked arithmetic.
+crates: []


### PR DESCRIPTION
Closes #12721

## Problem
`MessageRaceLimits::decide` calculates `best_target_nonce + 1` without checked arithmetic.

## Solution
Add checked arithmetic.