### PR TITLE
fix(rpc): release capacity after registration failure

### DIFF
--- a/prdoc/stable2606/pr_12852.prdoc
+++ b/prdoc/stable2606/pr_12852.prdoc
@@ -1,0 +1,7 @@
+title: Release reserved RPC capacity after registration failure
+doc:
+- audience: Node Dev
+  description: Fix a reserved RPC connection slot remaining occupied when identifier registration fails.
+crates:
+- name: sc-rpc-spec-v2
+  bump: patch

--- a/substrate/client/rpc-spec-v2/src/common/connections.rs
+++ b/substrate/client/rpc-spec-v2/src/common/connections.rs
@@ -153,17 +153,19 @@ pub struct ReservedConnection {
 impl ReservedConnection {
 	/// Register the identifier for the given connection.
 	pub fn register(mut self, identifier: String) -> Option<RegisteredConnection> {
-		let rpc_connections = self.rpc_connections.take()?;
-
-		if rpc_connections.register_identifier(self.connection_id, identifier.clone()) {
-			Some(RegisteredConnection {
-				connection_id: self.connection_id,
-				identifier,
-				rpc_connections,
-			})
-		} else {
-			None
+		if !self
+			.rpc_connections
+			.as_ref()?
+			.register_identifier(self.connection_id, identifier.clone())
+		{
+			return None;
 		}
+
+		Some(RegisteredConnection {
+			connection_id: self.connection_id,
+			identifier,
+			rpc_connections: self.rpc_connections.take()?,
+		})
 	}
 }
 
@@ -260,6 +262,33 @@ mod tests {
 		// Ensure data is cleared.
 		drop(reserved);
 		drop(registered_second);
+		assert!(rpc_connections.data.lock().get(&conn_id).is_none());
+	}
+
+	#[test]
+	fn failed_registration_releases_reserved_space() {
+		let rpc_connections = RpcConnections::new(2);
+		let conn_id = ConnectionId(1);
+
+		let registered = rpc_connections
+			.reserve_space(conn_id)
+			.unwrap()
+			.register("identifier".to_string())
+			.unwrap();
+
+		let duplicate = rpc_connections
+			.reserve_space(conn_id)
+			.unwrap()
+			.register("identifier".to_string());
+		assert!(duplicate.is_none());
+		assert_eq!(1, rpc_connections.data.lock().get(&conn_id).unwrap().num_identifiers);
+
+		let reserved = rpc_connections.reserve_space(conn_id);
+		assert!(reserved.is_some());
+		assert_eq!(2, rpc_connections.data.lock().get(&conn_id).unwrap().num_identifiers);
+
+		drop(reserved);
+		drop(registered);
 		assert!(rpc_connections.data.lock().get(&conn_id).is_none());
 	}
 }


### PR DESCRIPTION
Fixes #12787.

## Summary

Keep a reserved RPC connection owned by `ReservedConnection` until identifier registration succeeds. If registration rejects a duplicate identifier, `Drop` now releases the reserved capacity instead of leaking it.

The regression test reserves capacity, triggers duplicate registration, and verifies that another reservation can still use the released slot.

## Testing

- `rustfmt` on the changed source
- isolated crate harness including `connections.rs`: 3 unit tests and doc tests pass

A schema-validated `prdoc/stable2606/pr_12852.prdoc` entry is included with a patch bump for `sc-rpc-spec-v2`.
