### PR TITLE
[RWF] sp-maybe-compressed-blob: fix bomb-limit overflow

### DIFF
--- a/prdoc/pr_12857.prdoc
+++ b/prdoc/pr_12857.prdoc
@@ -1,0 +1,48 @@
+title: '[RWF] sp-maybe-compressed-blob: fix bomb-limit overflow'
+doc:
+- audience: Runtime Dev
+  description: |-
+    # Description
+
+    Fixes #12779.
+
+    `read_from_decoder` added one to `bomb_limit` in `usize`, which panicked for
+    `decompress(..., usize::MAX)` in debug builds and wrapped to a zero-byte read cap in release
+    builds. Convert the limit to `u64` before saturating addition so valid compressed blobs decode at
+    the maximum public limit.
+
+    ## Integration
+
+    No downstream integration changes are required. The public API and ordinary bomb-limit behavior
+    remain unchanged.
+
+    ## Review Notes
+
+    The regression test performs a small zstd round trip through the public `decompress` function and
+    compares against a fixed original byte string.
+
+    RED:
+
+    - Debug: the regression test panicked with `attempt to add with overflow`.
+    - Release: the regression test received an empty decoded blob because the read cap wrapped to zero.
+
+    GREEN:
+
+    - `cargo test -p sp-maybe-compressed-blob` passes all five tests.
+    - The targeted release-mode regression test passes.
+    - Nightly rustfmt and crate-scoped clippy with warnings denied pass.
+
+    Local verification used `x86_64-unknown-linux-gnu`; a 32-bit target was not installed. On 32-bit
+    targets the new read cap is `2^32`, preserving the extra byte used to detect output above the limit.
+    On 64-bit targets the read cap saturates at `u64::MAX`.
+
+    # Checklist
+
+    * [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
+    * [ ] My PR follows the labeling requirements of this project (at minimum one label for `T` required).
+        * The external-contributor label command will request `T17-primitives`.
+    * [x] I have made corresponding changes to the documentation (not applicable; no documentation change is required).
+    * [x] I have added tests that prove my fix is effective or that my feature works.
+crates:
+- name: sp-maybe-compressed-blob
+  bump: patch

--- a/prdoc/pr_12857.prdoc
+++ b/prdoc/pr_12857.prdoc
@@ -2,47 +2,13 @@ title: '[RWF] sp-maybe-compressed-blob: fix bomb-limit overflow'
 doc:
 - audience: Runtime Dev
   description: |-
-    # Description
-
-    Fixes #12779.
-
-    `read_from_decoder` added one to `bomb_limit` in `usize`, which panicked for
-    `decompress(..., usize::MAX)` in debug builds and wrapped to a zero-byte read cap in release
-    builds. Convert the limit to `u64` before saturating addition so valid compressed blobs decode at
-    the maximum public limit.
+    Fix `sp-maybe-compressed-blob::decompress` with a `usize::MAX` bomb limit by calculating the
+    decoder read cap in `u64`. This prevents an overflow while preserving the public API and normal
+    bomb-limit behavior.
 
     ## Integration
 
-    No downstream integration changes are required. The public API and ordinary bomb-limit behavior
-    remain unchanged.
-
-    ## Review Notes
-
-    The regression test performs a small zstd round trip through the public `decompress` function and
-    compares against a fixed original byte string.
-
-    RED:
-
-    - Debug: the regression test panicked with `attempt to add with overflow`.
-    - Release: the regression test received an empty decoded blob because the read cap wrapped to zero.
-
-    GREEN:
-
-    - `cargo test -p sp-maybe-compressed-blob` passes all five tests.
-    - The targeted release-mode regression test passes.
-    - Nightly rustfmt and crate-scoped clippy with warnings denied pass.
-
-    Local verification used `x86_64-unknown-linux-gnu`; a 32-bit target was not installed. On 32-bit
-    targets the new read cap is `2^32`, preserving the extra byte used to detect output above the limit.
-    On 64-bit targets the read cap saturates at `u64::MAX`.
-
-    # Checklist
-
-    * [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
-    * [ ] My PR follows the labeling requirements of this project (at minimum one label for `T` required).
-        * The external-contributor label command will request `T17-primitives`.
-    * [x] I have made corresponding changes to the documentation (not applicable; no documentation change is required).
-    * [x] I have added tests that prove my fix is effective or that my feature works.
+    No downstream integration changes are required.
 crates:
 - name: sp-maybe-compressed-blob
   bump: patch

--- a/substrate/primitives/maybe-compressed-blob/src/lib.rs
+++ b/substrate/primitives/maybe-compressed-blob/src/lib.rs
@@ -52,7 +52,7 @@ fn read_from_decoder(
 	blob_len: usize,
 	bomb_limit: usize,
 ) -> Result<Vec<u8>, Error> {
-	let mut decoder = decoder.take((bomb_limit + 1) as u64);
+	let mut decoder = decoder.take((bomb_limit as u64).saturating_add(1));
 
 	let mut buf = Vec::with_capacity(blob_len);
 	decoder.read_to_end(&mut buf).map_err(|_| Error::Invalid)?;
@@ -157,6 +157,14 @@ mod tests {
 
 		assert_eq!(&decompress(&compressed_weakly, BOMB_LIMIT).unwrap()[..], &v[..]);
 		assert_eq!(&decompress(&compressed_strongly, BOMB_LIMIT).unwrap()[..], &v[..]);
+	}
+
+	#[test]
+	fn decompresses_at_maximum_bomb_limit() {
+		let original = b"small zstd payload";
+		let compressed = compress_weakly(original, original.len()).unwrap();
+
+		assert_eq!(decompress(&compressed, usize::MAX).unwrap().as_ref(), original);
 	}
 
 	#[test]


### PR DESCRIPTION
# Description

Fixes #12779.

`read_from_decoder` added one to `bomb_limit` in `usize`, which panicked for
`decompress(..., usize::MAX)` in debug builds and wrapped to a zero-byte read cap in release
builds. Convert the limit to `u64` before saturating addition so valid compressed blobs decode at
the maximum public limit.

## Integration

No downstream integration changes are required. The public API and ordinary bomb-limit behavior
remain unchanged.

## Review Notes

The regression test performs a small zstd round trip through the public `decompress` function and
compares against a fixed original byte string.

RED:

- Debug: the regression test panicked with `attempt to add with overflow`.
- Release: the regression test received an empty decoded blob because the read cap wrapped to zero.

GREEN:

- `cargo test -p sp-maybe-compressed-blob` passes all five tests.
- The targeted release-mode regression test passes.
- Nightly rustfmt and crate-scoped clippy with warnings denied pass.

Local verification used `x86_64-unknown-linux-gnu`; a 32-bit target was not installed. On 32-bit
targets the new read cap is `2^32`, preserving the extra byte used to detect output above the limit.
On 64-bit targets the read cap saturates at `u64::MAX`.

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the labeling requirements of this project (at minimum one label for `T` required).
    * The external-contributor label command will request `T17-primitives`.
* [x] I have made corresponding changes to the documentation (not applicable; no documentation change is required).
* [x] I have added tests that prove my fix is effective or that my feature works.
