### PR TITLE
statement-store: stop exposing the statement_unstable_* RPC API

### DIFF
--- a/.github/zombienet-tests/zombienet_cumulus_tests.yml
+++ b/.github/zombienet-tests/zombienet_cumulus_tests.yml
@@ -162,10 +162,7 @@
   runner-type: "large"
   cumulus-image: "test-parachain"
 
-- job-name: "zombienet-cumulus-0036-statement_store_unstable_rpc_smoke"
-  test-filter: "zombie_ci::statement_store::integration::statement_store_unstable_rpc_smoke"
-  runner-type: "default"
-  cumulus-image: "test-parachain"
+  # TODO: test 36 is absent
 
 - job-name: "zombienet-cumulus-0037-storage_chain_tip_sync_with_renewals"
   test-filter: "zombie_ci::storage_chain::parachain_tip_sync_with_renewals::parachain_tip_sync_with_renewals_test"

--- a/cumulus/polkadot-omni-node/lib/src/common/rpc.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/rpc.rs
@@ -28,7 +28,6 @@ use sc_rpc::{
 	dev::{Dev, DevApiServer},
 	statement::{StatementApiServer, StatementStore},
 };
-use sc_rpc_spec_v2::statement::{StatementSpec, StatementSpecApiServer};
 use sp_runtime::traits::Block as BlockT;
 use std::{marker::PhantomData, sync::Arc};
 use substrate_frame_rpc_system::{System, SystemApiServer};
@@ -80,10 +79,7 @@ where
 			module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
 			module.merge(StateMigration::new(client.clone(), backend).into_rpc())?;
 			if let Some(statement_store) = statement_store {
-				module.merge(
-					StatementStore::new(statement_store.clone(), spawn_handle.clone()).into_rpc(),
-				)?;
-				module.merge(StatementSpec::new(statement_store, spawn_handle).into_rpc())?;
+				module.merge(StatementStore::new(statement_store, spawn_handle).into_rpc())?;
 			}
 			if let Some(hop_pool) = hop_pool {
 				module.merge(HopRpcServer::new(hop_pool, client.clone()).into_rpc())?;

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration.rs
@@ -120,6 +120,10 @@ async fn statement_store_basic_propagation() -> Result<(), anyhow::Error> {
 /// End-to-end smoke test of the v2 unstable statement RPC API on a two-node network: replay and
 /// live delivery on the submitting node, cross-node live delivery, and multi-filter attribution
 /// plus filter removal
+///
+/// Ignored: the node no longer registers the `statement_unstable_*` methods.
+/// TODO: remove this test together with the RPC implementation.
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn statement_store_unstable_rpc_smoke() -> Result<(), anyhow::Error> {
 	let _ = env_logger::try_init_from_env(

--- a/prdoc/pr_12859.prdoc
+++ b/prdoc/pr_12859.prdoc
@@ -11,3 +11,5 @@ doc:
 crates:
 - name: polkadot-omni-node-lib
   bump: patch
+- name: sc-rpc-spec-v2
+  bump: patch

--- a/prdoc/pr_12859.prdoc
+++ b/prdoc/pr_12859.prdoc
@@ -3,10 +3,8 @@ doc:
 - audience: Node Operator
   description: |-
     The `statement_unstable_submit`, `statement_unstable_subscribe`, `statement_unstable_add_filter`,
-    and `statement_unstable_remove_filter` methods are no longer registered by the node. The API
-    specifies a replay of the statements already in the store, which only a node holding the
-    complete store can deliver. Light nodes cannot, and full nodes will not once statements are
-    sharded by DHT affinity. Use the `statement_*` methods instead.
+    and `statement_unstable_remove_filter` methods are no longer registered by the node. Use the
+    `statement_*` methods instead.
 
     The methods were never released, so no client migration is needed. The implementation stays in
     the tree and is removed in a follow-up.

--- a/prdoc/pr_XXX.prdoc
+++ b/prdoc/pr_XXX.prdoc
@@ -1,0 +1,15 @@
+title: 'statement-store: stop exposing the statement_unstable_* JSON-RPC API'
+doc:
+- audience: Node Operator
+  description: |-
+    The `statement_unstable_submit`, `statement_unstable_subscribe`, `statement_unstable_add_filter`,
+    and `statement_unstable_remove_filter` methods are no longer registered by the node. The API
+    specifies a replay of the statements already in the store, which only a node holding the
+    complete store can deliver. Light nodes cannot, and full nodes will not once statements are
+    sharded by DHT affinity. Use the `statement_*` methods instead.
+
+    The methods were never released, so no client migration is needed. The implementation stays in
+    the tree and is removed in a follow-up.
+crates:
+- name: polkadot-omni-node-lib
+  bump: patch

--- a/substrate/client/rpc-spec-v2/src/statement/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/statement/mod.rs
@@ -16,6 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! TODO: No node registers these methods, remove this module and the statement-store support code
+//! it relies on.
+
 /// JSON-RPC method definitions for statement store RPC.
 pub mod api;
 /// Error types for statement store RPC.


### PR DESCRIPTION
# Description

Unwires the RPC added in #11989, per
https://github.com/paritytech/json-rpc-interface-spec/issues/187


## Integration

Never released, so no client migration.

## Review Notes

The implementation stays behind a TODO, its zombienet test is `#[ignore]`d and
out of CI. A follow-up deletes it.