### PR TITLE
[RWF] polkadot-gossip-support: fix authority refresh erasing a surviv…

### DIFF
--- a/polkadot/node/network/gossip-support/src/lib.rs
+++ b/polkadot/node/network/gossip-support/src/lib.rs
@@ -127,7 +127,12 @@ pub struct GossipSupport<AD> {
 	resolved_authorities: HashMap<AuthorityDiscoveryId, HashSet<Multiaddr>>,
 
 	/// Actually connected authorities.
-	connected_authorities: HashMap<AuthorityDiscoveryId, PeerId>,
+	///
+	/// The same authority may be reachable through more than one connected peer, e.g. while a
+	/// validator that changed its network key is still connected under both its old and its new
+	/// `PeerId`. An authority is present here for as long as at least one connected peer carries
+	/// it, which makes this the exact inverse of [`Self::connected_peers`].
+	connected_authorities: HashMap<AuthorityDiscoveryId, HashSet<PeerId>>,
 	/// By `PeerId`.
 	///
 	/// Needed for efficient handling of disconnect events.
@@ -640,7 +645,7 @@ where
 					.await;
 
 				for a in current.drain() {
-					self.connected_authorities.remove(&a);
+					disconnect_authority(&mut self.connected_authorities, &a, peer_id);
 				}
 			}
 		}
@@ -656,12 +661,12 @@ where
 					})
 					.await;
 
-				prev.iter().for_each(|a| {
-					self.connected_authorities.remove(a);
-				});
-				new.iter().for_each(|a| {
-					self.connected_authorities.insert(a.clone(), peer_id);
-				});
+				for a in prev.iter() {
+					disconnect_authority(&mut self.connected_authorities, a, &peer_id);
+				}
+				for a in new.iter() {
+					self.connected_authorities.entry(a.clone()).or_default().insert(peer_id);
+				}
 
 				self.connected_peers.insert(peer_id, new);
 			}
@@ -673,7 +678,7 @@ where
 			NetworkBridgeEvent::PeerConnected(peer_id, _, _, o_authority) => {
 				if let Some(authority_ids) = o_authority {
 					authority_ids.iter().for_each(|a| {
-						self.connected_authorities.insert(a.clone(), peer_id);
+						self.connected_authorities.entry(a.clone()).or_default().insert(peer_id);
 					});
 					self.connected_peers.insert(peer_id, authority_ids);
 				} else {
@@ -683,7 +688,7 @@ where
 			NetworkBridgeEvent::PeerDisconnected(peer_id) => {
 				if let Some(authority_ids) = self.connected_peers.remove(&peer_id) {
 					authority_ids.into_iter().for_each(|a| {
-						self.connected_authorities.remove(&a);
+						disconnect_authority(&mut self.connected_authorities, &a, &peer_id);
 					});
 				}
 			},
@@ -728,6 +733,26 @@ where
 			unconnected_authorities = %pretty,
 			"Connectivity Report"
 		);
+	}
+}
+
+/// Stop tracking `peer_id` as a connection carrying `authority`.
+///
+/// The authority itself is only dropped once no connected peer carries it anymore, so that a
+/// stale peer going away cannot erase an authority that another peer still provides.
+///
+/// Takes the map rather than `&mut self` so that it stays callable while `connected_peers` is
+/// borrowed.
+fn disconnect_authority(
+	connected_authorities: &mut HashMap<AuthorityDiscoveryId, HashSet<PeerId>>,
+	authority: &AuthorityDiscoveryId,
+	peer_id: &PeerId,
+) {
+	if let Some(peers) = connected_authorities.get_mut(authority) {
+		peers.remove(peer_id);
+		if peers.is_empty() {
+			connected_authorities.remove(authority);
+		}
 	}
 }
 

--- a/polkadot/node/network/gossip-support/src/tests.rs
+++ b/polkadot/node/network/gossip-support/src/tests.rs
@@ -1548,3 +1548,106 @@ quickcheck! {
 		data1 == data2
 	}
 }
+
+/// Resolve the single `PeerId` the mock associates with a known authority.
+fn peer_id_of_authority(mock: &MockAuthorityDiscovery, authority: &AuthorityDiscoveryId) -> PeerId {
+	let addrs = mock
+		.addrs
+		.lock()
+		.get(authority)
+		.cloned()
+		.expect("authority is known to the mock");
+	let addr = addrs.into_iter().next().expect("authority has a registered address");
+	parse_addr(addr).expect("mock address is a valid p2p multiaddr").0
+}
+
+/// Assert that `connected_authorities` and `connected_peers` are exact inverses of one another:
+/// every peer listed under an authority must list that authority back, and vice versa. Also
+/// asserts that no authority is left behind with an empty peer set.
+fn assert_maps_are_inverse<AD>(gs: &GossipSupport<AD>) {
+	for (authority, peers) in &gs.connected_authorities {
+		assert!(!peers.is_empty(), "{authority:?} left with an empty peer set");
+		for peer_id in peers {
+			assert!(
+				gs.connected_peers.get(peer_id).is_some_and(|set| set.contains(authority)),
+				"{authority:?} maps to {peer_id}, which does not carry it back",
+			);
+		}
+	}
+	for (peer_id, authorities) in &gs.connected_peers {
+		for authority in authorities {
+			assert!(
+				gs.connected_authorities
+					.get(authority)
+					.is_some_and(|peers| peers.contains(peer_id)),
+				"{peer_id} carries {authority:?}, which does not map back to it",
+			);
+		}
+	}
+}
+
+/// An authority may be reachable through several connected peers at once, e.g. while a validator
+/// that changed its network key is connected under both its old and its new `PeerId`. Refreshing
+/// the authority ids must then drop only the stale peer, and must not erase the authority that the
+/// surviving peer still provides.
+#[test]
+fn update_authority_ids_keeps_authority_shared_with_surviving_peer() {
+	let authority = AUTHORITIES[0].clone();
+
+	let mock = MockAuthorityDiscovery::new(AUTHORITIES.clone());
+	// The peer id the authority resolves to, and a second, stale one that still carries it.
+	let surviving_peer = peer_id_of_authority(&mock, &authority);
+	let stale_peer = PeerId::random();
+
+	let mut gs = make_subsystem_with_authority_discovery(mock);
+	for peer_id in [surviving_peer, stale_peer] {
+		gs.handle_connect_disconnect(NetworkBridgeEvent::PeerConnected(
+			peer_id,
+			ObservedRole::Authority,
+			ValidationVersion::V3.into(),
+			Some(HashSet::from([authority.clone()])),
+		));
+	}
+	assert_maps_are_inverse(&gs);
+
+	// Resolves the authority to `surviving_peer` only, so `stale_peer` is drained.
+	let (mut sender, _rx) = test_helpers::sender_receiver();
+	executor::block_on(gs.update_authority_ids(&mut sender, vec![authority.clone()]));
+
+	assert_eq!(gs.connected_peers.get(&stale_peer), Some(&HashSet::new()));
+	assert_eq!(
+		gs.connected_authorities.get(&authority),
+		Some(&HashSet::from([surviving_peer])),
+		"authority must stay tracked as long as a connected peer carries it",
+	);
+	assert_maps_are_inverse(&gs);
+}
+
+/// Same invariant, but for the disconnect path: one of two peers carrying the same authority
+/// going away must not untrack the authority.
+#[test]
+fn disconnect_keeps_authority_shared_with_another_peer() {
+	let authority = AUTHORITIES[0].clone();
+	let (surviving_peer, leaving_peer) = (PeerId::random(), PeerId::random());
+
+	let mut gs =
+		make_subsystem_with_authority_discovery(MockAuthorityDiscovery::new(AUTHORITIES.clone()));
+	for peer_id in [surviving_peer, leaving_peer] {
+		gs.handle_connect_disconnect(NetworkBridgeEvent::PeerConnected(
+			peer_id,
+			ObservedRole::Authority,
+			ValidationVersion::V3.into(),
+			Some(HashSet::from([authority.clone()])),
+		));
+	}
+
+	gs.handle_connect_disconnect(NetworkBridgeEvent::PeerDisconnected(leaving_peer));
+
+	assert_eq!(gs.connected_authorities.get(&authority), Some(&HashSet::from([surviving_peer])));
+	assert_maps_are_inverse(&gs);
+
+	// The last peer leaving drops the authority entirely.
+	gs.handle_connect_disconnect(NetworkBridgeEvent::PeerDisconnected(surviving_peer));
+	assert!(gs.connected_authorities.is_empty());
+	assert_maps_are_inverse(&gs);
+}

--- a/prdoc/pr_12864.prdoc
+++ b/prdoc/pr_12864.prdoc
@@ -1,0 +1,35 @@
+title: '[RWF] polkadot-gossip-support: authority refresh can erase a surviving peer mapping'
+doc:
+- audience: Node Dev
+  description: |-
+    Closes #12783.
+
+    ## Summary
+    `GossipSupport` tracks connected validators in two maps that are meant to be inverses of each
+    other: `connected_authorities` and `connected_peers`. The same `AuthorityDiscoveryId` can
+    legitimately be carried by more than one connected peer — for instance while a validator that
+    changed its network key is still connected under both its old and its new `PeerId` — but
+    `connected_authorities` was a `HashMap<AuthorityDiscoveryId, PeerId>` and could only hold one
+    of them.
+
+    Because of that, every removal was a guess. When `update_authority_ids` drained a peer that no
+    longer resolves to any authority, it unconditionally removed each of that peer's authorities
+    from `connected_authorities`, without checking whether another connected peer still carried
+    them. The second loop then skipped the surviving peer, since its authority set had not
+    changed, so the mapping was never restored. The authority stayed in `connected_peers` but was
+    permanently absent from `connected_authorities` until that peer reconnected. `PeerDisconnected`
+    had the same defect.
+
+    The visible effect is that `check_connectivity` undercounts connected authorities, deflating
+    the reported connectivity ratio and potentially emitting a spurious "Connectivity seems low"
+    error on a node that is in fact fully connected.
+
+    ## Fix
+    `connected_authorities` is now a `HashMap<AuthorityDiscoveryId, HashSet<PeerId>>`, making it
+    the exact inverse of `connected_peers`. Removals disassociate a single peer and only drop the
+    authority once no connected peer carries it anymore, which fixes both the refresh and the
+    disconnect path. `check_connectivity` is unaffected: it only uses `len()` and `contains_key()`,
+    whose meaning is unchanged.
+crates:
+- name: polkadot-gossip-support
+  bump: patch


### PR DESCRIPTION
# Description

Closes #12783

`GossipSupport` tracks connected validators in two maps that are meant to be inverses of each other:

```rust
connected_authorities: HashMap<AuthorityDiscoveryId, PeerId>,
connected_peers:       HashMap<PeerId, HashSet<AuthorityDiscoveryId>>,
```

The same `AuthorityDiscoveryId` can legitimately be carried by more than one connected peer — most commonly while a validator that changed its network key is still connected under both its old and its new `PeerId`. `connected_peers` represents that fine; `connected_authorities` could only hold one of the peers, so every removal from it was a guess.

Concretely, with `connected_peers = {P_stale: {A}, P_surviving: {A}}` and an authority refresh that resolves `A` to `P_surviving` only:

1. The first loop in `update_authority_ids` treats `P_stale` as stale and drains it, calling `connected_authorities.remove(&A)` unconditionally — without checking whether `P_surviving` still carries `A`.
2. The second loop skips `P_surviving`, because `.filter(|x| x != &&new)` sees its authority set as unchanged, so the mapping is never restored.

`A` remains in `connected_peers` but is permanently absent from `connected_authorities`, and nothing repairs it until that peer reconnects. `PeerDisconnected` had the identical defect: one of two peers sharing an authority leaving would untrack the authority entirely.

**Impact.** `check_connectivity` derives everything from `connected_authorities.len()` and `contains_key`, so affected authorities are counted as unconnected. That deflates the reported connectivity ratio and can emit a spurious `"Connectivity seems low, we are only connected to X% of available validators"` error on a node that is in fact fully connected.

The fix makes the forward map many-valued so that it is the exact inverse of `connected_peers`, and drops an authority only once no connected peer carries it.

## Integration

No integration work is required by downstream projects.

`connected_authorities` is a private field of `GossipSupport`; the type change is not observable outside the crate. There is no change to the public API, to any subsystem message, to on-chain logic, or to the wire protocol, and no storage or host-function change. The only externally visible effect is that the `parachain::gossip-support` connectivity report now counts authorities correctly, so operators may see the `connected_ratio` in the `"Connectivity Report"` debug log — and the corresponding low-connectivity error — become accurate where it was previously understated.

## Review Notes

The root cause is the type: `HashMap<AuthorityDiscoveryId, PeerId>` cannot represent the one-authority-to-many-peers state that `connected_peers` allows, so every `remove` was a guess. Fixing the removals in place would have left the map lossy and the same class of bug able to resurface, so the map itself is now many-valued:

```diff
      /// Actually connected authorities.
-     connected_authorities: HashMap<AuthorityDiscoveryId, PeerId>,
+     ///
+     /// The same authority may be reachable through more than one connected peer, e.g. while a
+     /// validator that changed its network key is still connected under both its old and its new
+     /// `PeerId`. An authority is present here for as long as at least one connected peer carries
+     /// it, which makes this the exact inverse of [`Self::connected_peers`].
+     connected_authorities: HashMap<AuthorityDiscoveryId, HashSet<PeerId>>,
```

All removals now go through a single helper that disassociates one peer and drops the authority only once nobody carries it. This fixes the refresh path and the disconnect path with the same change:

```rust
fn disconnect_authority(
      connected_authorities: &mut HashMap<AuthorityDiscoveryId, HashSet<PeerId>>,
      authority: &AuthorityDiscoveryId,
      peer_id: &PeerId,
) {
      if let Some(peers) = connected_authorities.get_mut(authority) {
              peers.remove(peer_id);
              if peers.is_empty() {
                      connected_authorities.remove(authority);
              }
      }
}
```

It takes the map rather than `&mut self` deliberately: the first loop in `update_authority_ids` holds a `self.connected_peers.iter_mut()` borrow for its whole body, and only a direct field path (`&mut self.connected_authorities`) lets the borrow checker see the two maps as disjoint. A `&mut self` method would not compile there.

Insertions became `entry(a.clone()).or_default().insert(peer_id)` in `update_authority_ids` and in the `PeerConnected` arm.

Three important points:

- **The second loop's change-detection is deliberately left alone.** `.filter(|x| x != &&new)` was where the missing re-insertion happened, but with sets it is no longer a bug: the surviving peer's entry is never removed in the first place, so there is nothing to restore. Keeping it means the `UpdatedAuthorityIds` message is still sent only to peers whose authority set actually changed, preserving existing network-bridge behaviour.
- **`check_connectivity` is untouched and its semantics are unchanged.** It only uses `.len()` and `.contains_key()`, which now mean "authorities with at least one connected peer" — the same thing they were meant to mean before. `connected_authorities` has no other readers anywhere in the tree.
- **The map never holds an empty `HashSet`.** Entries are only created by `or_default().insert(..)`, and `disconnect_authority` removes the key as soon as its set empties. The tests assert this invariant directly.
a peer's set changes from `{A}` to `{B}` while a second peer still holds `A`.

### Tests

Two regression tests in `polkadot/node/network/gossip-support/src/tests.rs`:

- `update_authority_ids_keeps_authority_shared_with_surviving_peer` — the reported bug: two peers carry the same authority, discovery resolves it to one of them, the authority must stay tracked.
- `disconnect_keeps_authority_shared_with_another_peer` — the disconnect path, including that the *last* peer leaving does still drop the authority.

Both call a shared `assert_maps_are_inverse` helper that checks the invariant in both directions and that no authority is left with an empty peer set.

Because the fix changes the field's type, these tests cannot be compiled against unpatched `master` to demonstrate the failure. They were instead verified to be genuine regression tests by temporarily restoring the old unconditional `connected_authorities.remove(authority)` behaviour inside `disconnect_authority`, against which both fail:

```
assertion `left == right` failed: authority must stay tracked as long as a connected peer carries it
  left: None
 right: Some({PeerId("1AkR6w2T6c4ALsJDFrCnHBUXnJVoyyLyVTGnn9gsVE7E8v")})
```

With the fix in place the full crate suite passes (11/11, none ignored), `cargo clippy -p polkadot-gossip-support --all-targets` is clean, and the code is `cargo +nightly fmt`-formatted.

No leftover TODOs.

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [x] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: Use `/cmd label <label-name>` to add labels
    * Maintainers can also add labels manually
* [x] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
