### PR TITLE
[pallet-revive] expose ReentrancyProtection

### DIFF
--- a/prdoc/pr_12866.prdoc
+++ b/prdoc/pr_12866.prdoc
@@ -1,0 +1,9 @@
+title: '[pallet-revive] expose ReentrancyProtection'
+doc:
+- audience: Runtime Dev
+  description: 'Export ReentrancyProtection from pallet_revive and pallet_revive::precompiles:
+    it is a parameter type of the public Ext::call, so it must be nameable by out-of-crate
+    precompile implementors.'
+crates:
+- name: pallet-revive
+  bump: minor

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -60,7 +60,7 @@ use crate::{
 		StateOverrideSet, TYPE_EIP1559, Tracer, TracerType, block_hash::EthereumBlockBuilderIR,
 		block_storage, fees::InfoT as FeeInfo, runtime::SetWeightLimit,
 	},
-	exec::{AccountIdOf, ExecError, ReentrancyProtection, Stack as ExecStack},
+	exec::{AccountIdOf, ExecError, Stack as ExecStack},
 	sp_runtime::TransactionOutcome,
 	storage::{AccountType, DeletionQueueManager},
 	tracing::if_tracing,
@@ -106,7 +106,10 @@ pub use crate::{
 	debug::DebugSettings,
 	deposit_payment::{Deposit, PGasDeposit},
 	evm::{Address as EthAddress, Block as EthBlock, block_hash::ReceiptGasInfo},
-	exec::{CallResources, DelegateInfo, Executable, Key, MomentOf, Origin as ExecOrigin},
+	exec::{
+		CallResources, DelegateInfo, Executable, Key, MomentOf, Origin as ExecOrigin,
+		ReentrancyProtection,
+	},
 	limits::TRANSIENT_STORAGE_BYTES as TRANSIENT_STORAGE_LIMIT,
 	metering::{
 		EthTxInfo, FrameMeter, ResourceMeter, Token as WeightToken, TransactionLimits,

--- a/substrate/frame/revive/src/precompiles.rs
+++ b/substrate/frame/revive/src/precompiles.rs
@@ -32,8 +32,7 @@ mod tests;
 pub use crate::{
 	AddressMapper, TransactionLimits,
 	exec::{
-		ExecError, PrecompileExt as Ext, PrecompileWithInfoExt as ExtWithInfo,
-		ReentrancyProtection,
+		ExecError, PrecompileExt as Ext, PrecompileWithInfoExt as ExtWithInfo, ReentrancyProtection,
 	},
 	metering::{Diff, Token},
 	vm::RuntimeCosts,

--- a/substrate/frame/revive/src/precompiles.rs
+++ b/substrate/frame/revive/src/precompiles.rs
@@ -31,7 +31,10 @@ mod tests;
 
 pub use crate::{
 	AddressMapper, TransactionLimits,
-	exec::{ExecError, PrecompileExt as Ext, PrecompileWithInfoExt as ExtWithInfo},
+	exec::{
+		ExecError, PrecompileExt as Ext, PrecompileWithInfoExt as ExtWithInfo,
+		ReentrancyProtection,
+	},
 	metering::{Diff, Token},
 	vm::RuntimeCosts,
 };


### PR DESCRIPTION
Export ReentrancyProtection from pallet_revive and pallet_revive::precompiles: it is a parameter type of the public Ext::call, so it must be nameable by out-of-crate precompile implementors.