### PR TITLE
[zombienet] make zombienet cumulus/polkadot workflows not required

### DIFF
--- a/.github/workflows/build-publish-images.yml
+++ b/.github/workflows/build-publish-images.yml
@@ -786,8 +786,10 @@ jobs:
     runs-on: ubuntu-latest
     name: All zombienet tests passed
     needs:
-      - trigger-zombienet-polkadot
-      - trigger-zombienet-cumulus
+      # disable polkadot/cumulus requirement to review multiple
+      # flaky tests.
+      # - trigger-zombienet-polkadot
+      # - trigger-zombienet-cumulus
       - trigger-zombienet-substrate
       - trigger-zombienet-parachain-template
     if: always() && !cancelled()


### PR DESCRIPTION
We started to saw a spike in failures that are causing friction in CI, let's make `cumulus`/`polkadot` workflows not required for now. Following issue https://github.com/paritytech/polkadot-sdk/issues/12871

cc: @bkchr / @sandreim 