### PR TITLE
snowbridge: pin removed SSZ merkle-proofs spec link

### DIFF
--- a/bridges/snowbridge/primitives/beacon/src/merkle_proof.rs
+++ b/bridges/snowbridge/primitives/beacon/src/merkle_proof.rs
@@ -4,7 +4,7 @@ use sp_core::H256;
 use sp_io::hashing::sha2_256;
 
 /// Specified by <https://github.com/ethereum/consensus-specs/blob/fe9c1a8cbf0c2da8a4f349efdcd77dd7ac8445c4/specs/phase0/beacon-chain.md?plain=1#L742>
-/// with improvements from <https://github.com/ethereum/consensus-specs/blob/master/ssz/merkle-proofs.md>
+/// with improvements from <https://github.com/ethereum/consensus-specs/blob/fe9c1a8cbf0c2da8a4f349efdcd77dd7ac8445c4/ssz/merkle-proofs.md>
 pub fn verify_merkle_branch(
 	leaf: H256,
 	branch: &[H256],

--- a/prdoc/pr_12879.prdoc
+++ b/prdoc/pr_12879.prdoc
@@ -1,0 +1,16 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: "snowbridge: pin removed SSZ merkle-proofs spec link"
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Doc comment only: pin the SSZ merkle-proofs spec link in
+      snowbridge-beacon-primitives to a commit, since ethereum/consensus-specs
+      removed the ssz/ directory and the master-branch link 404s, failing the
+      link-checker CI job on every PR.
+
+crates:
+  - name: snowbridge-beacon-primitives
+    bump: none


### PR DESCRIPTION
ethereum/consensus-specs removed its ssz/ directory (specs moved to ethereum/ssz-specs), so the master-branch link in merkle_proof.rs 404s and the link-checker job now fails on every PR. Pin the link to the commit the file's other spec links already use.