### PR TITLE
eth-rpc: skip unresolvable streamed blocks instead of dying

### DIFF
--- a/prdoc/pr_12882.prdoc
+++ b/prdoc/pr_12882.prdoc
@@ -1,14 +1,16 @@
 # Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
 # See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
 
-title: "eth-rpc: skip unresolvable streamed blocks instead of dying"
+title: "eth-rpc: pin legacy subxt backend, survive unresolvable blocks"
 
 doc:
   - audience: Node Operator
     description: |
-      A failed streamed-block resolution (pruned or retracted block,
-      transient RPC error) killed the whole eth-rpc server. Such blocks are
-      now skipped; finalized ones are backfilled by the gap filler.
+      Pin eth-rpc to subxt's legacy backend. subxt 0.50 switched the default
+      to the chainHead-based CombinedBackend, whose pinning limits stall
+      receipt indexing under load. Also, a failed streamed-block resolution
+      no longer kills the server; such blocks are skipped and finalized ones
+      are backfilled by the gap filler.
 
 crates:
   - name: pallet-revive-eth-rpc

--- a/prdoc/pr_12882.prdoc
+++ b/prdoc/pr_12882.prdoc
@@ -6,11 +6,9 @@ title: "eth-rpc: skip unresolvable streamed blocks instead of dying"
 doc:
   - audience: Node Operator
     description: |
-      Since the subxt 0.50 bump, a failure to resolve a streamed block
-      (pruned or retracted block, transient RPC error) killed the essential
-      block-subscription task and with it the whole eth-rpc server. Such
-      blocks are now skipped; skipped finalized blocks are backfilled by the
-      gap filler.
+      A failed streamed-block resolution (pruned or retracted block,
+      transient RPC error) killed the whole eth-rpc server. Such blocks are
+      now skipped; finalized ones are backfilled by the gap filler.
 
 crates:
   - name: pallet-revive-eth-rpc

--- a/prdoc/pr_12882.prdoc
+++ b/prdoc/pr_12882.prdoc
@@ -1,0 +1,17 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: "eth-rpc: skip unresolvable streamed blocks instead of dying"
+
+doc:
+  - audience: Node Operator
+    description: |
+      Since the subxt 0.50 bump, a failure to resolve a streamed block
+      (pruned or retracted block, transient RPC error) killed the essential
+      block-subscription task and with it the whole eth-rpc server. Such
+      blocks are now skipped; skipped finalized blocks are backfilled by the
+      gap filler.
+
+crates:
+  - name: pallet-revive-eth-rpc
+    bump: patch

--- a/substrate/frame/revive/rpc/src/client.rs
+++ b/substrate/frame/revive/rpc/src/client.rs
@@ -46,7 +46,7 @@ use std::{
 use storage_api::StorageApi;
 use subxt::{
 	OnlineClient,
-	backend::{StreamOf, StreamOfResults},
+	backend::{LegacyBackend, StreamOf, StreamOfResults},
 	client::OnlineClientAtBlock,
 	config::{HashFor, RpcConfigFor},
 	rpcs::{
@@ -453,7 +453,12 @@ pub async fn connect(
 	let rpc_client = RpcClient::new(rpc_client);
 	log::info!(target: LOG_TARGET, "🌟 Connected to node at: {node_rpc_url}");
 
-	let api = OnlineClient::<SrcChainConfig>::from_rpc_client(rpc_client.clone()).await?;
+	// Pin the legacy backend explicitly. Since subxt 0.50, from_rpc_client defaults
+	// to the CombinedBackend, which routes block streams and header fetches through
+	// the chainHead protocol; its follow restarts and pinning limits stall receipt
+	// indexing under load (blocks become unresolvable once unpinned).
+	let backend = Arc::new(LegacyBackend::builder().build(rpc_client.clone()));
+	let api = OnlineClient::<SrcChainConfig>::from_backend(backend).await?;
 	let rpc = LegacyRpcMethods::<RpcConfigFor<SrcChainConfig>>::new(rpc_client.clone());
 	Ok((api, rpc_client, rpc))
 }

--- a/substrate/frame/revive/rpc/src/client.rs
+++ b/substrate/frame/revive/rpc/src/client.rs
@@ -618,12 +618,10 @@ impl Client {
 				},
 			};
 
-			// Resolution can fail for a block that got pruned or retracted in the
-			// meantime, or on a transient RPC error; failing the subscription here
-			// would take down the whole server (essential task). Skip the block
-			// instead: a skipped finalized block does not advance
-			// `last_finalized_seen`, so the next iteration queues it as a gap and
-			// the gap filler backfills it.
+			// Resolution fails for pruned/retracted blocks and on transient RPC errors;
+			// erroring out here would kill the essential subscription task and with it the
+			// whole server. Skip instead: a skipped finalized block doesn't advance
+			// `last_finalized_seen`, so the gap filler backfills it.
 			let block = match block.at().await {
 				Ok(block) => block,
 				Err(err) => {

--- a/substrate/frame/revive/rpc/src/client.rs
+++ b/substrate/frame/revive/rpc/src/client.rs
@@ -618,9 +618,24 @@ impl Client {
 				},
 			};
 
-			let block = block.at().await.inspect_err(|err| {
-				log::error!(target: LOG_TARGET, "Failed to resolve streamed block: {err:?}");
-			})?;
+			// Resolution can fail for a block that got pruned or retracted in the
+			// meantime, or on a transient RPC error; failing the subscription here
+			// would take down the whole server (essential task). Skip the block
+			// instead: a skipped finalized block does not advance
+			// `last_finalized_seen`, so the next iteration queues it as a gap and
+			// the gap filler backfills it.
+			let block = match block.at().await {
+				Ok(block) => block,
+				Err(err) => {
+					log::warn!(
+						target: LOG_TARGET,
+						"Failed to resolve streamed {subscription_type:?} block #{} ({:?}), skipping: {err:?}",
+						block.number(),
+						block.hash(),
+					);
+					continue;
+				},
+			};
 
 			// Acquire lock to ensure only one subscription can perform write operations at a time
 			let _guard = self.subscription_lock.lock().await;


### PR DESCRIPTION
The subxt 0.50 bump (#12096) silently switched eth-rpc from subxt's LegacyBackend to the chainHead-based CombinedBackend (the new `from_rpc_client` default). Under differential-test load, chainHead follow restarts and pinning limits stall receipt indexing and make streamed blocks unresolvable; a failed `block.at()` resolution then killed the essential subscription task and with it the whole server. This is why the EVM test suite is red since July 15 (receipt polls time out until the 2h job limit).

Two changes:
- pin the legacy backend in `connect()`, restoring the pre-bump wire behavior
- skip unresolvable streamed blocks instead of dying; skipped finalized blocks do not advance `last_finalized_seen`, so the gap filler backfills them

Note for reviewers: the backend pin was added after the first three approvals; please re-check.

No dedicated test: it would need a mocked chainHead session and a test constructor for `Client`, neither of which exists today. The differential-tests jobs on this PR are the regression test.