### PR TITLE
Increase default light client slots

### DIFF
--- a/prdoc/pr_12887.prdoc
+++ b/prdoc/pr_12887.prdoc
@@ -1,8 +1,9 @@
 title: Increase default light client slots
 doc:
 - audience: Node Operator
-  description: 'This increases the default light-client slots to a conservative 500
-    as per investigation in #12846.'
+  description: 'The default of `--in-peers-light` is raised from 100 to 500, since
+    measurements showed nodes handle far more light peers than the old default
+    allowed (#12846).'
 crates:
 - name: sc-cli
   bump: major

--- a/prdoc/pr_12887.prdoc
+++ b/prdoc/pr_12887.prdoc
@@ -1,0 +1,8 @@
+title: Increase default light client slots
+doc:
+- audience: Node Operator
+  description: 'This increases the default light-client slots to a conservative 500
+    as per investigation in #12846.'
+crates:
+- name: sc-cli
+  bump: major

--- a/substrate/client/cli/src/params/network_params.rs
+++ b/substrate/client/cli/src/params/network_params.rs
@@ -115,7 +115,7 @@ pub struct NetworkParams {
 	pub in_peers: u32,
 
 	/// Maximum number of inbound light nodes peers.
-	#[arg(long, value_name = "COUNT", default_value_t = 100)]
+	#[arg(long, value_name = "COUNT", default_value_t = 500)]
 	pub in_peers_light: u32,
 
 	/// Disable mDNS discovery (default: true).


### PR DESCRIPTION
This increases the default light-client slots to a conservative 500 as per investigation in #12846.