### PR TITLE
Update trie-db to 0.32.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,7 +2610,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "schemars 1.2.1",
+ "schemars 0.8.13",
  "serde",
 ]
 
@@ -22812,7 +22812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "763f8cd0d4c71ed8389c90cb8100cba87e763bd01a8e614d4f0af97bcd50a161"
 dependencies = [
  "dyn-clone",
- "schemars_derive 0.8.13",
+ "schemars_derive",
  "serde",
  "serde_json",
 ]
@@ -22837,7 +22837,6 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -22850,20 +22849,8 @@ checksum = "ec0f696e21e10fa546b7ffb1c9672c6de8fbc7a81acf59524386d8639bf12737"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "serde_derive_internals 0.26.0",
+ "serde_derive_internals",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
-dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "serde_derive_internals 0.29.1",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -23221,17 +23208,6 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
-dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,7 +2610,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "schemars 0.8.13",
+ "schemars 1.2.1",
  "serde",
 ]
 
@@ -2838,7 +2838,7 @@ dependencies = [
  "sp-std 14.0.0",
  "sp-trie 29.0.0",
  "tracing",
- "trie-db",
+ "trie-db 0.32.0",
 ]
 
 [[package]]
@@ -5095,7 +5095,7 @@ dependencies = [
  "sp-version 29.0.0",
  "staging-xcm",
  "staging-xcm-builder",
- "trie-db",
+ "trie-db 0.32.0",
  "trie-standardmap",
 ]
 
@@ -22812,7 +22812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "763f8cd0d4c71ed8389c90cb8100cba87e763bd01a8e614d4f0af97bcd50a161"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.13",
  "serde",
  "serde_json",
 ]
@@ -22837,6 +22837,7 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -22849,8 +22850,20 @@ checksum = "ec0f696e21e10fa546b7ffb1c9672c6de8fbc7a81acf59524386d8639bf12737"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "serde_derive_internals",
+ "serde_derive_internals 0.26.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "serde_derive_internals 0.29.1",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -23208,6 +23221,17 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -25591,7 +25615,7 @@ dependencies = [
  "sp-trie 29.0.0",
  "thiserror 1.0.65",
  "tracing",
- "trie-db",
+ "trie-db 0.32.0",
 ]
 
 [[package]]
@@ -25612,7 +25636,7 @@ dependencies = [
  "sp-trie 44.0.0",
  "thiserror 1.0.65",
  "tracing",
- "trie-db",
+ "trie-db 0.31.0",
 ]
 
 [[package]]
@@ -25768,7 +25792,7 @@ dependencies = [
  "thiserror 1.0.65",
  "tracing",
  "trie-bench",
- "trie-db",
+ "trie-db 0.32.0",
  "trie-root",
  "trie-standardmap",
 ]
@@ -25795,7 +25819,7 @@ dependencies = [
  "substrate-prometheus-endpoint 0.17.7",
  "thiserror 1.0.65",
  "tracing",
- "trie-db",
+ "trie-db 0.31.0",
  "trie-root",
 ]
 
@@ -26761,7 +26785,7 @@ dependencies = [
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
  "sp-trie 29.0.0",
- "trie-db",
+ "trie-db 0.32.0",
 ]
 
 [[package]]
@@ -26841,7 +26865,7 @@ dependencies = [
  "substrate-test-runtime-client",
  "substrate-wasm-builder",
  "tracing",
- "trie-db",
+ "trie-db 0.32.0",
 ]
 
 [[package]]
@@ -28652,16 +28676,16 @@ dependencies = [
 
 [[package]]
 name = "trie-bench"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bee4700c5dd6b2ceba5e4e4d5a7017704a761481824d3033d223f9660973a"
+checksum = "5bdf11c77ca165a25b7e22acff7c05b7888794acb84d21078305b41ab6b5f627"
 dependencies = [
  "criterion",
  "hash-db",
  "keccak-hasher",
  "memory-db",
  "parity-scale-codec",
- "trie-db",
+ "trie-db 0.32.0",
  "trie-root",
  "trie-standardmap",
 ]
@@ -28671,6 +28695,18 @@ name = "trie-db"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7795f2df2ef744e4ffb2125f09325e60a21d305cc3ecece0adeef03f7a9e560"
+dependencies = [
+ "hash-db",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "559b3902fbd74c14b64ea1690792be25bd5ccd3820f8b6b6228754e00fe3c1d6"
 dependencies = [
  "hash-db",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1479,8 +1479,8 @@ tracing-futures = { version = "0.2.4" }
 tracing-log = { version = "0.2.0" }
 tracing-subscriber = { version = "=0.3.19" }
 tracking-allocator = { path = "polkadot/node/tracking-allocator", default-features = false, package = "staging-tracking-allocator" }
-trie-bench = { version = "0.42.1" }
-trie-db = { version = "0.31.0", default-features = false }
+trie-bench = { version = "0.42.2" }
+trie-db = { version = "0.32.0", default-features = false }
 trie-root = { version = "0.18.0", default-features = false }
 trie-standardmap = { version = "0.16.0" }
 trybuild = { version = "1.0.103" }

--- a/cumulus/pallets/parachain-system/src/validate_block/implementation.rs
+++ b/cumulus/pallets/parachain-system/src/validate_block/implementation.rs
@@ -181,7 +181,7 @@ where
 	let num_blocks = blocks.len();
 
 	// Create the db
-	let mut db = match proof.to_memory_db(Some(parent_header.state_root())) {
+	let mut db = match proof.to_memory_db(parent_header.state_root()) {
 		Ok((db, _)) => db,
 		Err(_) => panic!("Compact proof decoding failure."),
 	};

--- a/prdoc/pr_12935.prdoc
+++ b/prdoc/pr_12935.prdoc
@@ -1,0 +1,29 @@
+title: Update trie-db to 0.32.0
+
+doc:
+  - audience: Node Dev
+    description: |
+      Bumps `trie-db` to 0.32.0 and `trie-bench` to 0.42.2.
+
+      Compact proof encoding now deduplicates value nodes that are shared between the top trie
+      and child tries, resulting in smaller compact proofs.
+
+      Breaking change: `sp_trie::decode_compact`, `CompactProof::to_storage_proof` and
+      `CompactProof::to_memory_db` now take the expected root as `&H::Out` instead of
+      `Option<&H::Out>`. The decoded root is always checked against the expected root.
+
+crates:
+  - name: sp-trie
+    bump: major
+  - name: sp-state-machine
+    bump: patch
+  - name: sc-service
+    bump: patch
+  - name: cumulus-pallet-parachain-system
+    bump: patch
+  - name: substrate-state-trie-migration-rpc
+    bump: none
+    validate: false
+  - name: bp-runtime
+    bump: none
+    validate: false

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -1390,7 +1390,7 @@ where
 		sp_trie::decode_compact::<sp_state_machine::LayoutV0<HashingFor<Block>>, _, _>(
 			&mut db,
 			proof.iter_compact_encoded_nodes(),
-			Some(&root),
+			&root,
 		)
 		.map_err(|e| sp_blockchain::Error::from_state(Box::new(e)))?;
 		let proving_backend = sp_state_machine::TrieBackendBuilder::new(db, root).build();

--- a/substrate/primitives/state-machine/src/lib.rs
+++ b/substrate/primitives/state-machine/src/lib.rs
@@ -1582,10 +1582,7 @@ mod tests {
 	fn test_compact(remote_proof: StorageProof, remote_root: &sp_core::H256) -> StorageProof {
 		let compact_remote_proof =
 			remote_proof.into_compact_proof::<BlakeTwo256>(*remote_root).unwrap();
-		compact_remote_proof
-			.to_storage_proof::<BlakeTwo256>(Some(remote_root))
-			.unwrap()
-			.0
+		compact_remote_proof.to_storage_proof::<BlakeTwo256>(remote_root).unwrap().0
 	}
 
 	#[test]

--- a/substrate/primitives/trie/src/storage_proof.rs
+++ b/substrate/primitives/trie/src/storage_proof.rs
@@ -184,9 +184,11 @@ impl CompactProof {
 	}
 
 	/// Decode to a full storage_proof.
+	///
+	/// The decoded root is always checked against `expected_root`.
 	pub fn to_storage_proof<H: Hasher>(
 		&self,
-		expected_root: Option<&H::Out>,
+		expected_root: &H::Out,
 	) -> Result<(StorageProof, H::Out), crate::CompactProofError<H::Out, crate::Error<H::Out>>> {
 		let mut db = crate::MemoryDB::<H>::new(&[]);
 		let root = crate::decode_compact::<Layout<H>, _, _>(
@@ -208,12 +210,13 @@ impl CompactProof {
 
 	/// Convert self into a [`MemoryDB`](crate::MemoryDB).
 	///
-	/// `expected_root` is the expected root of this compact proof.
+	/// `expected_root` is the expected root of this compact proof. The decoded root is always
+	/// checked against it.
 	///
 	/// Returns the memory db and the root of the trie.
 	pub fn to_memory_db<H: Hasher>(
 		&self,
-		expected_root: Option<&H::Out>,
+		expected_root: &H::Out,
 	) -> Result<(crate::MemoryDB<H>, H::Out), crate::CompactProofError<H::Out, crate::Error<H::Out>>>
 	{
 		let mut db = crate::MemoryDB::<H>::new(&[]);
@@ -250,7 +253,8 @@ pub mod tests {
 	#[test]
 	fn invalid_compact_proof_does_not_panic_when_decoding() {
 		let invalid_proof = CompactProof { encoded_nodes: vec![vec![135]] };
-		let result = invalid_proof.to_memory_db::<Hasher>(None);
+		// Decoding fails before the root is ever compared, so any expected root will do.
+		let result = invalid_proof.to_memory_db::<Hasher>(&Default::default());
 		assert!(result.is_err());
 	}
 }

--- a/substrate/primitives/trie/src/trie_codec.rs
+++ b/substrate/primitives/trie/src/trie_codec.rs
@@ -259,9 +259,8 @@ mod tests {
 			let mut trie = TrieDBMutBuilder::<Layout>::new(&mut db, &mut root).build();
 			trie.insert(b"top_key", &shared_value).expect("Inserts data");
 
-			let mut child_storage_key = sp_core::storage::well_known_keys::
-				DEFAULT_CHILD_STORAGE_KEY_PREFIX
-				.to_vec();
+			let mut child_storage_key =
+				sp_core::storage::well_known_keys::DEFAULT_CHILD_STORAGE_KEY_PREFIX.to_vec();
 			child_storage_key.extend(b"child1");
 			trie.insert(&child_storage_key, child_root.as_ref()).expect("Inserts data");
 		}

--- a/substrate/primitives/trie/src/trie_codec.rs
+++ b/substrate/primitives/trie/src/trie_codec.rs
@@ -53,12 +53,14 @@ impl<H, CodecError> From<Box<trie_db::TrieError<H, CodecError>>> for Error<H, Co
 /// Takes as input a destination `db` for decoded node and `encoded`
 /// an iterator of compact encoded nodes.
 ///
+/// The decoded root is always checked against `expected_root`.
+///
 /// Child trie are decoded in order of child trie root present
 /// in the top trie.
 pub fn decode_compact<'a, L, DB, I>(
 	db: &mut DB,
 	encoded: I,
-	expected_root: Option<&TrieHash<L>>,
+	expected_root: &TrieHash<L>,
 ) -> Result<TrieHash<L>, Error<TrieHash<L>, CError<L>>>
 where
 	L: TrieConfiguration,
@@ -68,8 +70,7 @@ where
 	let mut nodes_iter = encoded.into_iter();
 	let (top_root, _nb_used) = trie_db::decode_compact_from_iter::<L, _, _>(db, &mut nodes_iter)?;
 
-	// Only check root if expected root is passed as argument.
-	if let Some(expected_root) = expected_root.filter(|expected| *expected != &top_root) {
+	if &top_root != expected_root {
 		return Err(Error::RootMismatch(top_root, *expected_root));
 	}
 
@@ -155,6 +156,7 @@ where
 	L: TrieConfiguration,
 	DB: HashDBT<L::Hash, trie_db::DBValue> + hash_db::HashDBRef<L::Hash, trie_db::DBValue>,
 {
+	let mut seen = trie_db::SeenHashes::<L>::default();
 	let mut child_tries = Vec::new();
 	let mut compact_proof = {
 		let trie = crate::TrieDBBuilder::<L>::new(partial_db, root).build();
@@ -185,7 +187,7 @@ where
 			}
 		}
 
-		trie_db::encode_compact::<L>(&trie)?
+		trie_db::encode_compact_skip_duplicates::<L>(&trie, &mut seen)?
 	};
 
 	for child_root in child_tries {
@@ -196,7 +198,7 @@ where
 		}
 
 		let trie = crate::TrieDBBuilder::<L>::new(partial_db, &child_root).build();
-		let child_proof = trie_db::encode_compact::<L>(&trie)?;
+		let child_proof = trie_db::encode_compact_skip_duplicates::<L>(&trie, &mut seen)?;
 
 		compact_proof.extend(child_proof);
 	}
@@ -234,6 +236,61 @@ mod tests {
 		}
 
 		(db, root)
+	}
+
+	#[test]
+	fn values_shared_between_top_and_child_trie_are_deduplicated() {
+		let mut db = MemoryDB::default();
+
+		// A value above `TRIE_VALUE_NODE_THRESHOLD` that is stored as a separate value node
+		// referenced by hash. It is present in the top trie and in a child trie; the
+		// deduplication state must be shared across the per-trie encodings so it is only
+		// emitted once in the whole proof.
+		let shared_value = vec![42u8; 64];
+
+		let mut child_root = Default::default();
+		{
+			let mut trie = TrieDBMutBuilder::<Layout>::new(&mut db, &mut child_root).build();
+			trie.insert(b"child_key", &shared_value).expect("Inserts data");
+		}
+
+		let mut root = Default::default();
+		{
+			let mut trie = TrieDBMutBuilder::<Layout>::new(&mut db, &mut root).build();
+			trie.insert(b"top_key", &shared_value).expect("Inserts data");
+
+			let mut child_storage_key = sp_core::storage::well_known_keys::
+				DEFAULT_CHILD_STORAGE_KEY_PREFIX
+				.to_vec();
+			child_storage_key.extend(b"child1");
+			trie.insert(&child_storage_key, child_root.as_ref()).expect("Inserts data");
+		}
+
+		let compact_proof = encode_compact::<Layout, _>(&db, &root).unwrap();
+
+		// The shared value must only be contained once in the compact proof, even though the
+		// top trie and the child trie are encoded separately.
+		let occurrences = compact_proof
+			.encoded_nodes
+			.iter()
+			.filter(|node| node.as_slice() == shared_value.as_slice())
+			.count();
+		assert_eq!(occurrences, 1);
+
+		// The proof still decodes and gives access to the value through both tries.
+		let mut res_db = MemoryDB::new(&[]);
+		decode_compact::<Layout, _, _>(
+			&mut res_db,
+			compact_proof.iter_compact_encoded_nodes(),
+			&root,
+		)
+		.unwrap();
+
+		let trie = TrieDBBuilder::<Layout>::new(&res_db, &root).build();
+		assert_eq!(trie.get(b"top_key").unwrap().unwrap(), shared_value);
+
+		let child_trie = TrieDBBuilder::<Layout>::new(&res_db, &child_root).build();
+		assert_eq!(child_trie.get(b"child_key").unwrap().unwrap(), shared_value);
 	}
 
 	struct Overlay<'a> {
@@ -398,7 +455,7 @@ mod tests {
 		decode_compact::<Layout, _, _>(
 			&mut res_db,
 			compact_proof.iter_compact_encoded_nodes(),
-			Some(&root),
+			&root,
 		)
 		.unwrap();
 


### PR DESCRIPTION
Updated trie-db to v0.32.0. Fixes #12565 .

Also make root checks mandatory in the API. This provides some safety against misuse, because the check is necessary to prevent overly long proof decoding.