### PR TITLE
test(zombienet): expect full core saturation in approved_peer_mixed_collators

### DIFF
--- a/polkadot/zombienet-sdk-tests/tests/functional/approved_peer_mixed_collators.rs
+++ b/polkadot/zombienet-sdk-tests/tests/functional/approved_peer_mixed_collators.rs
@@ -91,12 +91,17 @@ async fn approved_peer_mixed_collators_test() -> Result<(), anyhow::Error> {
 
 	// The parachain should keep producing blocks at a healthy rate, regardless of which collator
 	// (recent or old) authored a given block.
+	//
+	// Both paras are bulk-scheduled in genesis and `num_cores` resolves to 2, so each para owns
+	// one core for the whole run. One core backs at most one candidate per relay block, so over
+	// the 20 counted blocks the ceiling is 20 candidates per para -- and both paras are expected
+	// to sit at that ceiling.
 	assert_para_throughput(
 		&relay_client,
 		20,
 		[
-			(ParaId::from(PRE_APPROVED_UMP_SIGNAL_PARA_ID), 10..16),
-			(ParaId::from(V1_PARA_ID), 10..16),
+			(ParaId::from(PRE_APPROVED_UMP_SIGNAL_PARA_ID), 19..21),
+			(ParaId::from(V1_PARA_ID), 19..21),
 		],
 		[],
 	)


### PR DESCRIPTION
`zombienet-polkadot-approved-peer-mixed-collators` has been failing on master since #12255 merged:

```
Error: ParaId 2001: candidate count 20 not within expected range 10..16
```

The test is not flaky and #12255 is not a regression. The `10..16` bound encoded the throughput loss that #12255 fixed, so the test started failing once the paras reached the throughput the setup can actually sustain.

## Why 20 is the expected number

Both paras are registered `InGenesis` (bulk-scheduled) and `num_cores` resolves to `2` for this network, so each para owns one core for the whole run — confirmed in the run log:

```
Raw overrides info: num_cores: 2, para_to_register_in_genesis_len: 2
```

One core backs at most one candidate per relay block, and `assert_para_throughput` counts over 20 relay blocks (skipping session-change blocks and the initial warm-up). So the ceiling is **20 candidates per para**, and with a healthy backing pipeline both paras should sit at it.

The new bound is `19..21`, i.e. 19 or 20, leaving one candidate of slack so a single slow collation under CI load does not fail the test.

## What the old bound was measuring

The relaychain runs with `--experimental-collator-protocol`. Before #12255, the experimental validator side derived the claim-queue window length in `our_window` from the allowed-ancestry path length instead of the runtime `SchedulingLookahead`. `fetch_ancestors` truncates ancestry at a session boundary, because the relay chain cannot back candidates from a previous session. So for the first `lookahead - 1` blocks of every session that estimate was too small, `our_window` returned fewer claim-queue positions than were really schedulable, and `can_keep_advertisement` refused otherwise-valid advertisements with `PeerLimitReached`.

Node logs from the two runs, all four validators:

| | before #12255 (`dd75ae95066`) | after #12255 (`ffaca8ccf22`) |
|---|---|---|
| advertisements received | 156 | 148 |
| accepted | 140 | **148** |
| dropped | **16** | **0** |
| rejection reason | **16x `PeerLimitReached`** | none |
| candidates per para | **11** | **20** |

The 16 rejections are exactly 4 per validator across 4 validators — one per session boundary each. Both runs have identical session structure (10-block epoch under `fast-runtime`, session changes at relay blocks 21 and 31, same 20-block counting window), so the two columns are directly comparable.

Per-block, before the fix, the zero-candidate blocks cluster right after each session change:

```
15, 16              tail of the first session window
21                  session change (skipped by the harness)
23, 24, 25, 26      the four blocks after session change 21   <- lookahead - 1 = 4
31                  session change (skipped by the harness)
33, 34, 35          blocks after session change 31
```

Four consecutive dead blocks after block 21, and `lookahead - 1 = 5 - 1 = 4`. After the fix there are no gaps at all: every counted block backs both paras, including the blocks immediately following both session changes.

With a 10-block epoch and lookahead 5, roughly 40% of blocks fell inside the affected window, which matches the observed shortfall (11 of 20).

## Notes

- Test-only change; `polkadot-zombienet-sdk-tests` is `publish = false`, so this needs the `R0-no-crate-publish-required` label rather than a prdoc.
- The sibling `approved_peer_mixed_validators` test is unaffected and stays green.