### PR TITLE
fix(state-sync): reject empty unverified state responses

### DIFF
--- a/prdoc/pr_12946.prdoc
+++ b/prdoc/pr_12946.prdoc
@@ -1,0 +1,36 @@
+title: 'fix(state-sync): reject empty unverified state responses'
+doc:
+- audience: Node Operator
+  description: |-
+    # Description
+
+    Reject state responses with no entries when state proof verification is disabled.
+
+    Previously, an empty `entries` list accompanied by non-empty `proof` bytes could reach the unverified state processing path, which assumes that at least one entry exists. Malformed peer data is now returned as `ImportResult::BadResponse`, allowing `StateStrategy` to drop the peer.
+
+    https://github.com/paritytech/polkadot-sdk/issues/12945
+
+    ## Integration
+
+    No downstream integration changes are required. Node operators receive the fix by updating `sc-network-sync`.
+
+    ## Review Notes
+
+    Response validation is now mode-specific:
+
+    - unverified state sync requires non-empty `entries`;
+    - verified state sync requires non-empty `proof`.
+
+    This avoids rejecting valid proof-only responses in verified mode.
+
+    Regression tests cover both the direct `BadResponse` result and the resulting `DropPeer` action at the strategy layer.
+
+    # Checklist
+
+    * [x] My PR includes a detailed description.
+    * [x] My PR follows the labeling requirements.
+    * [x] Documentation changes are not applicable.
+    * [x] I have added tests that prove the fix is effective.
+crates:
+- name: sc-network-sync
+  bump: patch

--- a/prdoc/pr_12946.prdoc
+++ b/prdoc/pr_12946.prdoc
@@ -2,35 +2,8 @@ title: 'fix(state-sync): reject empty unverified state responses'
 doc:
 - audience: Node Operator
   description: |-
-    # Description
-
-    Reject state responses with no entries when state proof verification is disabled.
-
-    Previously, an empty `entries` list accompanied by non-empty `proof` bytes could reach the unverified state processing path, which assumes that at least one entry exists. Malformed peer data is now returned as `ImportResult::BadResponse`, allowing `StateStrategy` to drop the peer.
-
-    https://github.com/paritytech/polkadot-sdk/issues/12945
-
-    ## Integration
-
-    No downstream integration changes are required. Node operators receive the fix by updating `sc-network-sync`.
-
-    ## Review Notes
-
-    Response validation is now mode-specific:
-
-    - unverified state sync requires non-empty `entries`;
-    - verified state sync requires non-empty `proof`.
-
-    This avoids rejecting valid proof-only responses in verified mode.
-
-    Regression tests cover both the direct `BadResponse` result and the resulting `DropPeer` action at the strategy layer.
-
-    # Checklist
-
-    * [x] My PR includes a detailed description.
-    * [x] My PR follows the labeling requirements.
-    * [x] Documentation changes are not applicable.
-    * [x] I have added tests that prove the fix is effective.
+    Reject empty state responses when proof verification is disabled, preventing
+    malformed peer data from causing a state sync panic.
 crates:
 - name: sc-network-sync
   bump: patch

--- a/substrate/client/network/sync/src/strategy/state.rs
+++ b/substrate/client/network/sync/src/strategy/state.rs
@@ -396,7 +396,7 @@ mod test {
 	use crate::{
 		schema::v1::{StateRequest, StateResponse},
 		service::network::NetworkServiceProvider,
-		strategy::state_sync::{ImportResult, StateSyncProgress, StateSyncProvider},
+		strategy::state_sync::{ImportResult, StateSync, StateSyncProgress, StateSyncProvider},
 	};
 	use codec::Decode;
 	use sc_block_builder::BlockBuilderBuilder;
@@ -672,6 +672,56 @@ mod test {
 		assert!(matches!(
 			state_strategy.on_state_response_inner(&peer_id, &dummy_response),
 			Err(BadPeer(id, _rep)) if id == peer_id,
+		));
+	}
+
+	#[test]
+	fn empty_unverified_state_response_is_rejected() {
+		let client = Arc::new(TestClientBuilder::new().set_no_genesis().build());
+		let target_block = BlockBuilderBuilder::new(&*client)
+			.on_parent_block(client.chain_info().best_hash)
+			.with_parent_block_number(client.chain_info().best_number)
+			.build()
+			.unwrap()
+			.build()
+			.unwrap()
+			.block;
+		let mut state_sync =
+			StateSync::new(client, target_block.header().clone(), None, None, true);
+
+		let response = StateResponse { entries: Vec::new(), proof: vec![1] };
+
+		assert!(matches!(state_sync.import(response), ImportResult::BadResponse));
+	}
+
+	#[test]
+	fn empty_unverified_state_response_drops_peer() {
+		let client = Arc::new(TestClientBuilder::new().set_no_genesis().build());
+		let target_block = BlockBuilderBuilder::new(&*client)
+			.on_parent_block(client.chain_info().best_hash)
+			.with_parent_block_number(client.chain_info().best_number)
+			.build()
+			.unwrap()
+			.build()
+			.unwrap()
+			.block;
+		let peer_id = PeerId::random();
+		let mut state_strategy = StateStrategy::new(
+			client,
+			target_block.header().clone(),
+			None,
+			None,
+			true,
+			std::iter::once((peer_id, 10)),
+			ProtocolName::Static(""),
+		);
+		let response = StateResponse { entries: Vec::new(), proof: vec![1] }.encode_to_vec();
+
+		state_strategy.on_state_response(&peer_id, response);
+
+		assert!(matches!(
+			state_strategy.actions.as_slice(),
+			[SyncingAction::DropPeer(BadPeer(id, _))] if *id == peer_id,
 		));
 	}
 

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -255,11 +255,10 @@ where
 {
 	///  Validate and import a state response.
 	fn import(&mut self, response: StateResponse) -> ImportResult<B> {
-		if response.entries.is_empty() && response.proof.is_empty() {
-			debug!(target: LOG_TARGET, "Bad state response");
+		if self.metadata.skip_proof && response.entries.is_empty() {
+			debug!(target: LOG_TARGET, "Missing state entries");
 			return ImportResult::BadResponse;
-		}
-		if !self.metadata.skip_proof && response.proof.is_empty() {
+		} else if !self.metadata.skip_proof && response.proof.is_empty() {
 			debug!(target: LOG_TARGET, "Missing proof");
 			return ImportResult::BadResponse;
 		}

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -217,7 +217,9 @@ where
 		// the parent cursor stays valid.
 		// Empty parent trie content only happens when all the response content
 		// is part of a single child trie.
-		if self.metadata.last_key.len() == 2 && response.entries[0].entries.is_empty() {
+		let first_entry_is_empty =
+			response.entries.first().is_some_and(|entry| entry.entries.is_empty());
+		if self.metadata.last_key.len() == 2 && first_entry_is_empty {
 			// Do not remove the parent trie position.
 			self.metadata.last_key.pop();
 		} else {


### PR DESCRIPTION
# Description

Reject state responses with no entries when state proof verification is disabled.

Previously, an empty `entries` list accompanied by non-empty `proof` bytes could reach the unverified state processing path, which assumes that at least one entry exists. Malformed peer data is now returned as `ImportResult::BadResponse`, allowing `StateStrategy` to drop the peer.

https://github.com/paritytech/polkadot-sdk/issues/12945

## Integration

No downstream integration changes are required. Node operators receive the fix by updating `sc-network-sync`.

## Review Notes

Response validation is now mode-specific:

- unverified state sync requires non-empty `entries`;
- verified state sync requires non-empty `proof`.

This avoids rejecting valid proof-only responses in verified mode.

Regression tests cover both the direct `BadResponse` result and the resulting `DropPeer` action at the strategy layer.

# Checklist

* [x] My PR includes a detailed description.
* [x] My PR follows the labeling requirements.
* [x] Documentation changes are not applicable.
* [x] I have added tests that prove the fix is effective.