### PR TITLE
Flatten enums of the collator protocol

### DIFF
--- a/polkadot/node/network/bridge/src/rx/tests.rs
+++ b/polkadot/node/network/bridge/src/rx/tests.rs
@@ -1788,8 +1788,7 @@ fn network_protocol_versioning_subsystem_msg() {
 			.unwrap(),
 		};
 
-		let msg =
-			v4_collation::CollationProtocol::CollatorProtocol(advertise_segment_message.clone());
+		let msg = advertise_segment_message.clone();
 		network_handle
 			.peer_message(
 				peer,

--- a/polkadot/node/network/bridge/src/rx/tests.rs
+++ b/polkadot/node/network/bridge/src/rx/tests.rs
@@ -1774,7 +1774,7 @@ fn network_protocol_versioning_subsystem_msg() {
 		// No more messages.
 		assert_matches!(futures::poll!(virtual_overseer.recv().boxed()), Poll::Pending);
 
-		let advertise_segment_message = v4_collation::CollatorProtocolMessage::AdvertiseSegment {
+		let advertise_segment_message = v4_collation::AdvertiseSegment {
 			scheduling_parent: Hash::random(),
 			para_id: 100.into(),
 			candidates_descriptor_version: CandidateDescriptorVersion::V3,

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -987,7 +987,7 @@ async fn advertise_segment<Context>(
 
 	let message = match peer_version {
 		CollationVersion::V4 => {
-			CollationProtocols::V4(protocol_v4::CollatorProtocolMessage::AdvertiseSegment {
+			CollationProtocols::V4(protocol_v4::AdvertiseSegment {
 				scheduling_parent,
 				candidates_descriptor_version,
 				candidates: core_segment.clone(),
@@ -1222,13 +1222,12 @@ async fn handle_incoming_peer_message<Context>(
 		protocol_v1::CollatorProtocolMessage,
 		protocol_v2::CollatorProtocolMessage,
 		protocol_v3::CollatorProtocolMessage,
-		protocol_v4::CollatorProtocolMessage,
+		protocol_v4::AdvertiseSegment,
 	>,
 ) -> Result<()> {
 	use protocol_v1::CollatorProtocolMessage as V1;
 	use protocol_v2::CollatorProtocolMessage as V2;
 	use protocol_v3::CollatorProtocolMessage as V3;
-	use protocol_v4::CollatorProtocolMessage as V4;
 
 	match msg {
 		CollationProtocols::V1(V1::Declare(..)) |
@@ -1266,7 +1265,9 @@ async fn handle_incoming_peer_message<Context>(
 			))
 			.await;
 		},
-		CollationProtocols::V4(V4::AdvertiseSegment { .. }) => {
+		// `AdvertiseSegment` is the only V4 message, so this arm covers the whole
+		// version rather than one variant of it.
+		CollationProtocols::V4(_) => {
 			gum::trace!(
 				target: LOG_TARGET,
 				?origin,

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -986,14 +986,12 @@ async fn advertise_segment<Context>(
 	};
 
 	let message = match peer_version {
-		CollationVersion::V4 => {
-			CollationProtocols::V4(protocol_v4::AdvertiseSegment {
-				scheduling_parent,
-				candidates_descriptor_version,
-				candidates: core_segment.clone(),
-				para_id,
-			})
-		},
+		CollationVersion::V4 => CollationProtocols::V4(protocol_v4::AdvertiseSegment {
+			scheduling_parent,
+			candidates_descriptor_version,
+			candidates: core_segment.clone(),
+			para_id,
+		}),
 		CollationVersion::V3 => {
 			// Send V3 protocol message with the actual descriptor version
 			let newest_candidate = core_segment.last().expect("Segment is not empty; qed");

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -987,14 +987,12 @@ async fn advertise_segment<Context>(
 
 	let message = match peer_version {
 		CollationVersion::V4 => {
-			CollationProtocols::V4(protocol_v4::CollationProtocol::CollatorProtocol(
-				protocol_v4::CollatorProtocolMessage::AdvertiseSegment {
-					scheduling_parent,
-					candidates_descriptor_version,
-					candidates: core_segment.clone(),
-					para_id,
-				},
-			))
+			CollationProtocols::V4(protocol_v4::CollatorProtocolMessage::AdvertiseSegment {
+				scheduling_parent,
+				candidates_descriptor_version,
+				candidates: core_segment.clone(),
+				para_id,
+			})
 		},
 		CollationVersion::V3 => {
 			// Send V3 protocol message with the actual descriptor version

--- a/polkadot/node/network/collator-protocol/src/collator_side/tests/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/tests/mod.rs
@@ -639,7 +639,7 @@ async fn expect_advertise_segment_msg(
 		assert!(any_peers.iter().any(|p| to.contains(p)));
 		match wire_message {
 			CollationProtocols::V4(message) => {
-				assert_matches!(message, protocol_v4::CollatorProtocolMessage::AdvertiseSegment { scheduling_parent, candidates, .. } => {
+				assert_matches!(message, protocol_v4::AdvertiseSegment { scheduling_parent, candidates, .. } => {
 					assert_eq!(scheduling_parent, expected_scheduling_parent);
 					assert_eq!(candidates.len(), expected_output_heads.len());
 					for (fingerprint, expected) in candidates.iter().zip(expected_output_heads.iter()) {

--- a/polkadot/node/network/collator-protocol/src/collator_side/tests/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/tests/mod.rs
@@ -638,7 +638,7 @@ async fn expect_advertise_segment_msg(
 	) => {
 		assert!(any_peers.iter().any(|p| to.contains(p)));
 		match wire_message {
-			CollationProtocols::V4(protocol_v4::CollationProtocol::CollatorProtocol(message)) => {
+			CollationProtocols::V4(message) => {
 				assert_matches!(message, protocol_v4::CollatorProtocolMessage::AdvertiseSegment { scheduling_parent, candidates, .. } => {
 					assert_eq!(scheduling_parent, expected_scheduling_parent);
 					assert_eq!(candidates.len(), expected_output_heads.len());

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -1102,13 +1102,12 @@ async fn process_incoming_peer_message<Context>(
 		protocol_v1::CollatorProtocolMessage,
 		protocol_v2::CollatorProtocolMessage,
 		protocol_v3::CollatorProtocolMessage,
-		protocol_v4::CollatorProtocolMessage,
+		protocol_v4::AdvertiseSegment,
 	>,
 ) {
 	use protocol_v1::CollatorProtocolMessage as V1;
 	use protocol_v2::CollatorProtocolMessage as V2;
 	use protocol_v3::CollatorProtocolMessage as V3;
-	use protocol_v4::CollatorProtocolMessage as V4;
 	use sp_runtime::traits::AppVerify;
 
 	match msg {
@@ -1301,7 +1300,9 @@ async fn process_incoming_peer_message<Context>(
 		// Nodes that run this validator side pin their main collation protocol version to V3
 		// (see `main_collation_version` in the service builder), so V4 is never negotiated
 		// here — hence a log, not a panic, on this config-level guarantee.
-		CollationProtocols::V4(V4::AdvertiseSegment { .. }) => {
+		// `AdvertiseSegment` is the only V4 message, so this arm covers the whole
+		// version rather than one variant of it.
+		CollationProtocols::V4(_) => {
 			gum::error!(
 				target: LOG_TARGET,
 				peer_id = ?origin,

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/mod.rs
@@ -441,7 +441,7 @@ async fn process_incoming_peer_message<Sender, B>(
 		protocol_v1::CollatorProtocolMessage,
 		protocol_v2::CollatorProtocolMessage,
 		protocol_v3::CollatorProtocolMessage,
-		protocol_v4::CollatorProtocolMessage,
+		protocol_v4::AdvertiseSegment,
 	>,
 ) where
 	Sender: CollatorProtocolSenderTrait,
@@ -450,7 +450,7 @@ async fn process_incoming_peer_message<Sender, B>(
 	use protocol_v1::CollatorProtocolMessage as V1;
 	use protocol_v2::CollatorProtocolMessage as V2;
 	use protocol_v3::CollatorProtocolMessage as V3;
-	use protocol_v4::CollatorProtocolMessage as V4;
+	use protocol_v4::AdvertiseSegment as V4;
 
 	match msg {
 		CollationProtocols::V1(V1::Declare(_collator_id, para_id, _signature)) |
@@ -507,7 +507,7 @@ async fn process_incoming_peer_message<Sender, B>(
 				)
 				.await;
 		},
-		CollationProtocols::V4(V4::AdvertiseSegment {
+		CollationProtocols::V4(V4 {
 			scheduling_parent,
 			para_id,
 			candidates_descriptor_version,

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/tests.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/tests.rs
@@ -717,7 +717,7 @@ impl TestState {
 			&mut sender,
 			state,
 			peer_id,
-			CollationProtocols::V4(protocol_v4::CollatorProtocolMessage::AdvertiseSegment {
+			CollationProtocols::V4(protocol_v4::AdvertiseSegment {
 				scheduling_parent,
 				candidates_descriptor_version: CandidateDescriptorVersion::V3,
 				candidates: fingerprints.try_into().unwrap(),
@@ -3478,7 +3478,7 @@ async fn v4_advertise_segment_len_one_is_accepted() {
 		&mut sender,
 		&mut state,
 		peer_id,
-		CollationProtocols::V4(protocol_v4::CollatorProtocolMessage::AdvertiseSegment {
+		CollationProtocols::V4(protocol_v4::AdvertiseSegment {
 			scheduling_parent,
 			candidates_descriptor_version: CandidateDescriptorVersion::V3,
 			candidates,

--- a/polkadot/node/network/collator-protocol/tests/common/builders/peer.rs
+++ b/polkadot/node/network/collator-protocol/tests/common/builders/peer.rs
@@ -90,7 +90,7 @@ impl Peer {
 				protocol_v1::CollatorProtocolMessage,
 				protocol_v2::CollatorProtocolMessage,
 				protocol_v3::CollatorProtocolMessage,
-				protocol_v4::CollatorProtocolMessage,
+				protocol_v4::AdvertiseSegment,
 			>,
 		>,
 	) -> CollatorProtocolMessage {

--- a/polkadot/node/network/protocol/src/lib.rs
+++ b/polkadot/node/network/protocol/src/lib.rs
@@ -501,7 +501,7 @@ impl_versioned_collation_try_from!(
 	v1::CollationProtocol::CollatorProtocol(x) => x,
 	v2::CollationProtocol::CollatorProtocol(x) => x,
 	v3_collation::CollationProtocol::CollatorProtocol(x) => x,
-	v4_collation::CollationProtocol::CollatorProtocol(x) => x
+	x => x
 );
 
 /// v1 notification protocol types.
@@ -690,13 +690,10 @@ pub mod v4_collation {
 	}
 
 	/// All network messages on the collation peer-set.
-	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, derive_more::From)]
-	pub enum CollationProtocol {
-		/// Collator protocol messages
-		#[codec(index = 0)]
-		#[from]
-		CollatorProtocol(CollatorProtocolMessage),
-	}
+	///
+	/// V4 has a single message, so this is the message enum itself rather than a
+	/// wrapper: the extra SCALE tag byte would carry no information.
+	pub type CollationProtocol = CollatorProtocolMessage;
 }
 
 /// v3 network protocol types.

--- a/polkadot/node/network/protocol/src/lib.rs
+++ b/polkadot/node/network/protocol/src/lib.rs
@@ -488,7 +488,7 @@ pub type CollatorProtocolMessage = CollationProtocols<
 	v1::CollatorProtocolMessage,
 	v2::CollatorProtocolMessage,
 	v3_collation::CollatorProtocolMessage,
-	v4_collation::CollatorProtocolMessage,
+	v4_collation::AdvertiseSegment,
 >;
 impl_versioned_collation_full_protocol_from!(
 	CollatorProtocolMessage,
@@ -652,28 +652,29 @@ pub mod v4_collation {
 	use polkadot_primitives::{CandidateDescriptorVersion, Hash, Id as ParaId};
 	use sp_runtime::{traits::ConstU32, BoundedVec};
 
-	/// Network messages used by the collator protocol subsystem.
+	/// Advertise an ordered list of unincluded candidates. The list
+	/// is ordered by age. A length 1 segment is the V3 single-candidate
+	/// equivalent.
+	///
+	/// This is the *only* message on the V4 collation peer-set, so it is a struct
+	/// rather than a single-variant enum: there is nothing to discriminate, and a
+	/// tag byte would carry no information. If V4 ever gains a second message, this
+	/// becomes an enum again and the match sites below regain their inner pattern.
+	///
+	/// V4 has no `Declare` message. Although every `AdvertiseSegment`
+	/// carries a `para_id`, the peer is bound to a single para by its
+	/// first advertisement. Sending a different `para_id` in a
+	/// subsequent message results in disconnection.
 	#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
-	pub enum CollatorProtocolMessage {
-		/// Advertise an ordered list of unincluded candidates. The list
-		/// is ordered by age. A length 1 segment is the V3 single-candidate
-		/// equivalent.
-		///
-		/// V4 has no `Declare` message. Although every `AdvertiseSegment`
-		/// carries a `para_id`, the peer is bound to a single para by its
-		/// first advertisement. Sending a different `para_id` in a
-		/// subsequent message results in disconnection.
-		#[codec(index = 5)]
-		AdvertiseSegment {
-			/// Hash of the scheduling parent
-			scheduling_parent: Hash,
-			/// The para this segment collates for.
-			para_id: ParaId,
-			/// Descriptor version for the candidate.
-			candidates_descriptor_version: CandidateDescriptorVersion,
-			/// Candidates ordered by age; the list may have gaps.
-			candidates: BoundedVec<CandidateFingerprint, ConstU32<MAX_SEGMENT_LEN>>,
-		},
+	pub struct AdvertiseSegment {
+		/// Hash of the scheduling parent
+		pub scheduling_parent: Hash,
+		/// The para this segment collates for.
+		pub para_id: ParaId,
+		/// Descriptor version for the candidate.
+		pub candidates_descriptor_version: CandidateDescriptorVersion,
+		/// Candidates ordered by age; the list may have gaps.
+		pub candidates: BoundedVec<CandidateFingerprint, ConstU32<MAX_SEGMENT_LEN>>,
 	}
 
 	/// A single entry in the segment advertised by the collator.
@@ -691,9 +692,9 @@ pub mod v4_collation {
 
 	/// All network messages on the collation peer-set.
 	///
-	/// V4 has a single message, so this is the message enum itself rather than a
-	/// wrapper: the extra SCALE tag byte would carry no information.
-	pub type CollationProtocol = CollatorProtocolMessage;
+	/// V4 carries exactly one message, so the peer-set type is that message itself:
+	/// neither a wrapper enum nor a message enum earns its tag byte here.
+	pub type CollationProtocol = AdvertiseSegment;
 }
 
 /// v3 network protocol types.

--- a/polkadot/node/test-sim/src/contract/classify.rs
+++ b/polkadot/node/test-sim/src/contract/classify.rs
@@ -322,7 +322,7 @@ fn wire_kind_from_collation_protocol(
 			},
 		},
 		CollationProtocols::V4(msg) => match msg {
-			protocol_v4::CollatorProtocolMessage::AdvertiseSegment {
+			protocol_v4::AdvertiseSegment {
 				scheduling_parent,
 				para_id: _,
 				candidates_descriptor_version: _,

--- a/polkadot/node/test-sim/src/contract/classify.rs
+++ b/polkadot/node/test-sim/src/contract/classify.rs
@@ -259,7 +259,7 @@ fn wire_kind_from_collation_protocol(
 ) -> WireMsgKind {
 	use polkadot_node_network_protocol::{
 		v1::CollationProtocol as V1, v2::CollationProtocol as V2,
-		v3_collation::CollationProtocol as V3, v4_collation::CollationProtocol as V4,
+		v3_collation::CollationProtocol as V3,
 	};
 	match proto {
 		CollationProtocols::V1(V1::CollatorProtocol(msg)) => match msg {
@@ -321,7 +321,7 @@ fn wire_kind_from_collation_protocol(
 				WireMsgKind::CollationSeconded { relay_parent: *rp }
 			},
 		},
-		CollationProtocols::V4(V4::CollatorProtocol(msg)) => match msg {
+		CollationProtocols::V4(msg) => match msg {
 			protocol_v4::CollatorProtocolMessage::AdvertiseSegment {
 				scheduling_parent,
 				para_id: _,

--- a/polkadot/node/test-sim/src/contract/classify.rs
+++ b/polkadot/node/test-sim/src/contract/classify.rs
@@ -326,9 +326,8 @@ fn wire_kind_from_collation_protocol(
 			candidates,
 			..
 		}) => {
-			let tip = candidates
-				.last()
-				.expect("subsystem never emits an empty segment advertisement");
+			let tip =
+				candidates.last().expect("subsystem never emits an empty segment advertisement");
 			WireMsgKind::Advertise {
 				summary: AdvertisementSummary {
 					scheduling_parent: *scheduling_parent,

--- a/polkadot/node/test-sim/src/contract/classify.rs
+++ b/polkadot/node/test-sim/src/contract/classify.rs
@@ -321,25 +321,22 @@ fn wire_kind_from_collation_protocol(
 				WireMsgKind::CollationSeconded { relay_parent: *rp }
 			},
 		},
-		CollationProtocols::V4(msg) => match msg {
-			protocol_v4::AdvertiseSegment {
-				scheduling_parent,
-				para_id: _,
-				candidates_descriptor_version: _,
-				candidates,
-			} => {
-				let tip = candidates
-					.last()
-					.expect("subsystem never emits an empty segment advertisement");
-				WireMsgKind::Advertise {
-					summary: AdvertisementSummary {
-						scheduling_parent: *scheduling_parent,
-						candidate_hash: None,
-						parent_head_hash: Some(tip.parent_head_data_hash),
-						output_head_hash: Some(tip.output_head_data_hash),
-					},
-				}
-			},
+		CollationProtocols::V4(protocol_v4::AdvertiseSegment {
+			scheduling_parent,
+			candidates,
+			..
+		}) => {
+			let tip = candidates
+				.last()
+				.expect("subsystem never emits an empty segment advertisement");
+			WireMsgKind::Advertise {
+				summary: AdvertisementSummary {
+					scheduling_parent: *scheduling_parent,
+					candidate_hash: None,
+					parent_head_hash: Some(tip.parent_head_data_hash),
+					output_head_hash: Some(tip.output_head_data_hash),
+				},
+			}
 		},
 	}
 }


### PR DESCRIPTION
2 nested enums, each only with a single variant ... does not really make sense.