### PR TITLE
[pallet-revive] jit: gas estimation: always assume cold modules

### DIFF
--- a/substrate/client/virtualization/src/lib.rs
+++ b/substrate/client/virtualization/src/lib.rs
@@ -419,6 +419,10 @@ impl VirtManagerBackend for VirtManager {
 		};
 		instance.write_memory(offset, src).map_err(map_memory_error)
 	}
+
+	fn reset_module_cache(&mut self) {
+		self.cache.clear();
+	}
 }
 
 #[cfg(test)]

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -2032,14 +2032,8 @@ impl<T: Config> Pallet<T> {
 		let dry_run_results = [high, Self::evm_max_extrinsic_weight_in_gas()]
 			.map(|gas_limit| (gas_limit, dry_run_at(gas_limit)));
 		let (gas_limit, first_dry_run_result) = match dry_run_results {
-			[(gas_limit1, Ok(dry_run_result1)), (gas_limit2, Ok(mut dry_run_result2))] => {
+			[(gas_limit1, Ok(dry_run_result1)), (gas_limit2, Ok(dry_run_result2))] => {
 				if dry_run_result2.eth_gas >= gas_limit2 {
-					// The first dry run executed against the cold module cache, exactly like the
-					// actual transaction will; the second already hit the cache warmed by the
-					// first. Seed the search with the cold measurement so it cannot converge on
-					// a gas value that only suffices for a warm cache.
-					dry_run_result2.eth_gas =
-						dry_run_result2.eth_gas.max(dry_run_result1.eth_gas);
 					(gas_limit1, dry_run_result1)
 				} else {
 					(gas_limit2, dry_run_result2)
@@ -2185,6 +2179,10 @@ impl<T: Config> Pallet<T> {
 		CallOf<T>: SetWeightLimit,
 	{
 		log::debug!(target: LOG_TARGET, "dry_run_eth_transact: {tx:?}");
+
+		// Start from the empty module cache of the fresh block the transaction will execute in.
+		#[cfg(revive_jit)]
+		sp_virtualization::reset_module_cache();
 
 		let origin = T::AddressMapper::to_account_id(&tx.from.unwrap_or_default());
 		Self::prepare_dry_run(&origin);

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -2032,8 +2032,14 @@ impl<T: Config> Pallet<T> {
 		let dry_run_results = [high, Self::evm_max_extrinsic_weight_in_gas()]
 			.map(|gas_limit| (gas_limit, dry_run_at(gas_limit)));
 		let (gas_limit, first_dry_run_result) = match dry_run_results {
-			[(gas_limit1, Ok(dry_run_result1)), (gas_limit2, Ok(dry_run_result2))] => {
+			[(gas_limit1, Ok(dry_run_result1)), (gas_limit2, Ok(mut dry_run_result2))] => {
 				if dry_run_result2.eth_gas >= gas_limit2 {
+					// The first dry run executed against the cold module cache, exactly like the
+					// actual transaction will; the second already hit the cache warmed by the
+					// first. Seed the search with the cold measurement so it cannot converge on
+					// a gas value that only suffices for a warm cache.
+					dry_run_result2.eth_gas =
+						dry_run_result2.eth_gas.max(dry_run_result1.eth_gas);
 					(gas_limit1, dry_run_result1)
 				} else {
 					(gas_limit2, dry_run_result2)

--- a/substrate/primitives/virtualization/src/forwarder.rs
+++ b/substrate/primitives/virtualization/src/forwarder.rs
@@ -48,6 +48,11 @@ impl Module {
 	}
 }
 
+/// Clear the module cache so every subsequent [`Module::lookup`] misses, as in a fresh block.
+pub fn reset_module_cache() {
+	host_fn::reset_module_cache()
+}
+
 /// An idle virtualization instance.
 pub struct Instance(InstanceId);
 

--- a/substrate/primitives/virtualization/src/host_functions.rs
+++ b/substrate/primitives/virtualization/src/host_functions.rs
@@ -440,6 +440,14 @@ pub trait Virtualization {
 			.expect("VirtManagerExt not registered in externalities")
 			.write_memory(instance_id, offset, src)
 	}
+
+	/// Clear the module cache so every subsequent [`lookup`] misses, as in a fresh block.
+	fn reset_module_cache(&mut self) {
+		use sp_externalities::ExternalitiesExt as _;
+		self.extension::<crate::VirtManagerExt>()
+			.expect("VirtManagerExt not registered in externalities")
+			.reset_module_cache()
+	}
 }
 
 /// The host-side operations driven by the virtualization host functions.
@@ -493,6 +501,9 @@ pub trait VirtManagerBackend: Send + 'static {
 		offset: u32,
 		src: &[u8],
 	) -> Result<(), MemoryError>;
+
+	/// Clear the module cache so every subsequent [`VirtManagerBackend::lookup`] misses.
+	fn reset_module_cache(&mut self);
 }
 
 #[cfg(not(substrate_runtime))]

--- a/substrate/primitives/virtualization/src/lib.rs
+++ b/substrate/primitives/virtualization/src/lib.rs
@@ -51,7 +51,7 @@ mod host_functions;
 pub mod tests;
 
 pub use crate::tests::run as run_tests;
-pub use forwarder::{Execution, Instance, Module};
+pub use forwarder::{Execution, Instance, Module, reset_module_cache};
 #[cfg(not(substrate_runtime))]
 pub use host_functions::{ExecBuffer, ExecStatus, VirtManagerBackend, VirtManagerExt};
 

--- a/substrate/primitives/virtualization/src/lib.rs
+++ b/substrate/primitives/virtualization/src/lib.rs
@@ -51,7 +51,7 @@ mod host_functions;
 pub mod tests;
 
 pub use crate::tests::run as run_tests;
-pub use forwarder::{Execution, Instance, Module, reset_module_cache};
+pub use forwarder::{reset_module_cache, Execution, Instance, Module};
 #[cfg(not(substrate_runtime))]
 pub use host_functions::{ExecBuffer, ExecStatus, VirtManagerBackend, VirtManagerExt};
 


### PR DESCRIPTION
This fix makes a full retester differential test suite run pass against the JIT backend without regressions.