### PR TITLE
`pallet-ranked-collective`: fix vote weight overflow at the maximum rank

### DIFF
--- a/prdoc/pr_12972.prdoc
+++ b/prdoc/pr_12972.prdoc
@@ -1,0 +1,18 @@
+title: 'pallet-ranked-collective: fix vote weight overflow at the maximum rank'
+doc:
+- audience: Runtime Dev
+  description: |-
+    `Linear` and `Geometric` computed `r + 1` in `Rank` (`u16`), which overflows at an excess rank
+    of `Rank::MAX`. With overflow checks the `vote` extrinsic panicked; without them the addition
+    wrapped and the member was credited 0 votes. `Geometric` also overflowed `Votes` on
+    `v * (v + 1)` for results that fit once halved.
+
+    Both converters now widen before adding: `Linear` computes in `Votes`, `Geometric` in `u64`.
+    Weights are unchanged below `Rank::MAX`.
+- audience: Runtime User
+  description: |-
+    A member at the maximum excess rank is credited the documented vote weight instead of 0. Ranks
+    reachable in existing collectives are unaffected.
+crates:
+- name: pallet-ranked-collective
+  bump: patch

--- a/substrate/frame/ranked-collective/src/lib.rs
+++ b/substrate/frame/ranked-collective/src/lib.rs
@@ -56,7 +56,7 @@ use frame_support::{
 use scale_info::TypeInfo;
 use sp_arithmetic::traits::Saturating;
 use sp_runtime::{
-	traits::{Convert, StaticLookup},
+	traits::{Convert, SaturatedConversion, StaticLookup},
 	ArithmeticError::Overflow,
 	Debug, DispatchError, Perbill,
 };
@@ -236,7 +236,7 @@ impl Convert<Rank, Votes> for Unit {
 pub struct Linear;
 impl Convert<Rank, Votes> for Linear {
 	fn convert(r: Rank) -> Votes {
-		(r + 1) as Votes
+		Votes::from(r) + 1
 	}
 }
 
@@ -251,8 +251,9 @@ impl Convert<Rank, Votes> for Linear {
 pub struct Geometric;
 impl Convert<Rank, Votes> for Geometric {
 	fn convert(r: Rank) -> Votes {
-		let v = (r + 1) as Votes;
-		v * (v + 1) / 2
+		// `v * (v + 1)` exceeds `Votes` at high ranks; the halved result does not.
+		let v = u64::from(r) + 1;
+		(v * (v + 1) / 2).saturated_into()
 	}
 }
 

--- a/substrate/frame/ranked-collective/src/tests.rs
+++ b/substrate/frame/ranked-collective/src/tests.rs
@@ -434,6 +434,29 @@ fn voting_works() {
 }
 
 #[test]
+fn vote_weight_of_max_excess_rank_works() {
+	// `65535 + 1` and `65536 * 65537 / 2`, both within `Votes`.
+	assert_eq!(Linear::convert(Rank::MAX), 65_536);
+	assert_eq!(Geometric::convert(Rank::MAX), 2_147_516_416);
+}
+
+#[test]
+fn voting_at_max_rank_works() {
+	// Not `build_and_execute`: `do_try_state` sums rank indexes in `u16` and cannot represent a
+	// member at `Rank::MAX`.
+	ExtBuilder::default().build().execute_with(|| {
+		// Class 0 has a minimum rank of 0, so the excess rank is the full `Rank::MAX`.
+		let mut polls = Polls::get();
+		polls.insert(4, Ongoing(Tally::from_parts(0, 0, 0), 0));
+		Polls::set(polls);
+
+		assert_ok!(Club::do_add_member_to_rank(1, Rank::MAX, false));
+		assert_ok!(Club::vote(RuntimeOrigin::signed(1), 4, true));
+		assert_eq!(tally(4), Tally::from_parts(1, 2_147_516_416, 0));
+	});
+}
+
+#[test]
 fn cleanup_works() {
 	ExtBuilder::default().build_and_execute(|| {
 		assert_ok!(Club::add_member(RuntimeOrigin::root(), 1));


### PR DESCRIPTION
Closes #12915.

#### Problem

Rank is u16 and Votes is u32. Both converters add 1 before widening, so the addition happens in u16:

```rust
(r + 1) as Votes            // Linear
let v = (r + 1) as Votes;   // Geometric
v * (v + 1) / 2
```

At an excess rank of `Rank::MAX` this panics with overflow checks on and wraps to `v = 0` with them off, crediting the member 0 votes. That inverts the ordering the crate docs state: "higher ranks always have at least as much voting power in any given poll as lower ranks". The documented weights there are `65_536` and `2_147_516_416`, both inside Votes.

`Geometric` also needs the product widened, not just the addition: `65536 * 65537 = 4_295_032_832` exceeds `u32::MAX` while the halved result does not.

#### Change

```rust
Votes::from(r) + 1                          // Linear

let v = u64::from(r) + 1;                   // Geometric
(v * (v + 1) / 2).saturated_into()
```

`Linear` is fixed alongside `Geometric`: same expression, same root cause, and it is the collectives-westend Ambassador collective's `VoteWeight`.