### PR TITLE
network: Move the connected peers metric to the sync component

### DIFF
--- a/prdoc/pr_12979.prdoc
+++ b/prdoc/pr_12979.prdoc
@@ -1,0 +1,35 @@
+title: 'network: Move the connected peers metric to the sync component'
+
+doc:
+  - audience: Node Dev
+    description: |
+      The `substrate_sub_libp2p_peers_count` gauge was fed from an `Arc<AtomicUsize>` that
+      `sc-network` maintained purely so it could publish a syncing-level number: the libp2p
+      backend filled it from `num_sync_peers()`, and the litep2p backend from the
+      block-announce peerset. Neither is a networking concern.
+
+      The gauge now lives in `sc-network-sync`, registered by the `SyncingEngine` off the peer
+      counter it already maintains, next to `substrate_sub_libp2p_is_major_syncing`, which
+      already sits there under the same legacy name. `MetricSources` in `sc-network` loses its
+      `connected_peers` field and `MetricSources::register` its third argument; both live in the
+      crate-private `service::metrics` module, so there is no public API change. Both backends
+      still keep their own `num_connected` counter, which is what backs
+      `NetworkService::sync_num_connected`.
+
+      Because registration moved into `SyncingEngine::new`, a consumer that builds a network via
+      the public `build_network_advanced` without a syncing engine no longer exports this metric,
+      where before it exported a constant 0. Every in-tree node goes through `build_network`,
+      which creates the engine, so nothing in this repo is affected.
+  - audience: Node Operator
+    description: |
+      `substrate_sub_libp2p_peers_count` keeps its name, so existing dashboards and alerts keep
+      working. It is now sourced from the syncing engine's own peer count rather than from the
+      network backend, so it reports peers that completed the sync handshake instead of peers
+      merely connected on the block-announce protocol. The two agree at rest but can differ
+      transiently while a peer is being validated.
+
+crates:
+  - name: sc-network
+    bump: patch
+  - name: sc-network-sync
+    bump: patch

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -616,7 +616,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 			Arc::new(Litep2pBandwidthSink { sink: litep2p.bandwidth_sink() });
 
 		if let Some(registry) = &params.metrics_registry {
-			MetricSources::register(registry, bandwidth, Arc::clone(&num_connected))?;
+			MetricSources::register(registry, bandwidth)?;
 		}
 
 		Ok(Self {

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -549,13 +549,9 @@ where
 
 		// Initialize the metrics.
 		let metrics = match &params.metrics_registry {
-			Some(registry) => Some(metrics::register(
-				registry,
-				MetricSources {
-					bandwidth: bandwidth.clone(),
-					connected_peers: num_connected.clone(),
-				},
-			)?),
+			Some(registry) => {
+				Some(metrics::register(registry, MetricSources { bandwidth: bandwidth.clone() })?)
+			},
 			None => None,
 		};
 

--- a/substrate/client/network/src/service/metrics.rs
+++ b/substrate/client/network/src/service/metrics.rs
@@ -20,27 +20,20 @@ use crate::{service::traits::BandwidthSink, ProtocolName};
 
 use prometheus_endpoint::{
 	self as prometheus, Counter, CounterVec, Gauge, GaugeVec, HistogramOpts, MetricSource, Opts,
-	PrometheusError, Registry, SourcedCounter, SourcedGauge, U64,
+	PrometheusError, Registry, SourcedCounter, U64,
 };
 
-use std::{
-	str,
-	sync::{
-		atomic::{AtomicUsize, Ordering},
-		Arc,
-	},
-};
+use std::{str, sync::Arc};
 
 pub use prometheus_endpoint::{Histogram, HistogramVec};
 
 /// Registers all networking metrics with the given registry.
 pub fn register(registry: &Registry, sources: MetricSources) -> Result<Metrics, PrometheusError> {
 	BandwidthCounters::register(registry, sources.bandwidth)?;
-	NumConnectedGauge::register(registry, sources.connected_peers)?;
 	Metrics::register(registry)
 }
 
-// Register `sc-network` metrics without bandwidth/connected peer sources.
+// Register `sc-network` metrics without the bandwidth source.
 pub fn register_without_sources(registry: &Registry) -> Result<Metrics, PrometheusError> {
 	Metrics::register(registry)
 }
@@ -48,17 +41,14 @@ pub fn register_without_sources(registry: &Registry) -> Result<Metrics, Promethe
 /// Predefined metric sources that are fed directly into prometheus.
 pub struct MetricSources {
 	pub bandwidth: Arc<dyn BandwidthSink>,
-	pub connected_peers: Arc<AtomicUsize>,
 }
 
 impl MetricSources {
 	pub fn register(
 		registry: &Registry,
 		bandwidth: Arc<dyn BandwidthSink>,
-		connected_peers: Arc<AtomicUsize>,
 	) -> Result<(), PrometheusError> {
-		BandwidthCounters::register(registry, bandwidth)?;
-		NumConnectedGauge::register(registry, connected_peers)
+		BandwidthCounters::register(registry, bandwidth)
 	}
 }
 
@@ -278,34 +268,6 @@ impl MetricSource for BandwidthCounters {
 	fn collect(&self, mut set: impl FnMut(&[&str], Self::N)) {
 		set(&["in"], self.0.total_inbound());
 		set(&["out"], self.0.total_outbound());
-	}
-}
-
-/// The connected peers metric.
-#[derive(Clone)]
-pub struct NumConnectedGauge(Arc<AtomicUsize>);
-
-impl NumConnectedGauge {
-	/// Registers the `MajorSyncingGauge` metric whose value is
-	/// obtained from the given `AtomicUsize`.
-	fn register(registry: &Registry, value: Arc<AtomicUsize>) -> Result<(), PrometheusError> {
-		prometheus::register(
-			SourcedGauge::new(
-				&Opts::new("substrate_sub_libp2p_peers_count", "Number of connected peers"),
-				NumConnectedGauge(value),
-			)?,
-			registry,
-		)?;
-
-		Ok(())
-	}
-}
-
-impl MetricSource for NumConnectedGauge {
-	type N = u64;
-
-	fn collect(&self, mut set: impl FnMut(&[&str], Self::N)) {
-		set(&[], self.0.load(Ordering::Relaxed) as u64);
 	}
 }
 

--- a/substrate/client/network/sync/src/engine.rs
+++ b/substrate/client/network/sync/src/engine.rs
@@ -129,8 +129,13 @@ struct Metrics {
 }
 
 impl Metrics {
-	fn register(r: &Registry, major_syncing: Arc<AtomicBool>) -> Result<Self, PrometheusError> {
+	fn register(
+		r: &Registry,
+		major_syncing: Arc<AtomicBool>,
+		num_connected: Arc<AtomicUsize>,
+	) -> Result<Self, PrometheusError> {
 		MajorSyncingGauge::register(r, major_syncing)?;
+		NumConnectedGauge::register(r, num_connected)?;
 		Ok(Self {
 			peers: {
 				let g = Gauge::new("substrate_sync_peers", "Number of peers we sync with")?;
@@ -178,6 +183,38 @@ impl MajorSyncingGauge {
 }
 
 impl MetricSource for MajorSyncingGauge {
+	type N = u64;
+
+	fn collect(&self, mut set: impl FnMut(&[&str], Self::N)) {
+		set(&[], self.0.load(Ordering::Relaxed) as u64);
+	}
+}
+
+/// The "number of connected peers" metric.
+///
+/// Moved here from `sc-network`, which had no business tracking a syncing-level number. The
+/// `substrate_sub_libp2p_` name is kept so existing dashboards and alerts keep resolving, the same
+/// way `substrate_sub_libp2p_is_major_syncing` above is kept.
+#[derive(Clone)]
+struct NumConnectedGauge(Arc<AtomicUsize>);
+
+impl NumConnectedGauge {
+	/// Registers the [`NumConnectedGauge`] metric whose value is
+	/// obtained from the given `AtomicUsize`.
+	fn register(registry: &Registry, value: Arc<AtomicUsize>) -> Result<(), PrometheusError> {
+		prometheus_endpoint::register(
+			SourcedGauge::new(
+				&Opts::new("substrate_sub_libp2p_peers_count", "Number of connected peers"),
+				NumConnectedGauge(value),
+			)?,
+			registry,
+		)?;
+
+		Ok(())
+	}
+}
+
+impl MetricSource for NumConnectedGauge {
 	type N = u64;
 
 	fn collect(&self, mut set: impl FnMut(&[&str], Self::N)) {
@@ -417,7 +454,7 @@ where
 				tick_timeout,
 				peer_store_handle,
 				metrics: if let Some(r) = metrics_registry {
-					match Metrics::register(r, is_major_syncing.clone()) {
+					match Metrics::register(r, is_major_syncing.clone(), num_connected.clone()) {
 						Ok(metrics) => Some(metrics),
 						Err(err) => {
 							log::error!(target: LOG_TARGET, "Failed to register metrics {err:?}");
@@ -1567,5 +1604,30 @@ mod tests {
 		assert!(connected_no_slot.is_empty());
 		assert_eq!(num_in, 8);
 		assert!(disconnects.is_empty());
+	}
+
+	/// The gauge moved here from `sc-network` must keep the name operators' dashboards resolve it
+	/// by, and must stay sourced from the engine's live peer counter rather than a snapshot.
+	#[test]
+	fn num_connected_gauge_tracks_the_shared_counter() {
+		let registry = Registry::new();
+		let num_connected = Arc::new(AtomicUsize::new(0));
+		NumConnectedGauge::register(&registry, num_connected.clone()).unwrap();
+
+		let peers_count = || {
+			registry
+				.gather()
+				.iter()
+				.find(|family| family.get_name() == "substrate_sub_libp2p_peers_count")
+				.map(|family| family.get_metric()[0].get_gauge().get_value())
+		};
+
+		assert_eq!(peers_count(), Some(0.0));
+
+		num_connected.store(3, Ordering::Relaxed);
+		assert_eq!(peers_count(), Some(3.0));
+
+		num_connected.store(0, Ordering::Relaxed);
+		assert_eq!(peers_count(), Some(0.0));
 	}
 }


### PR DESCRIPTION
# Description

Closes #5024

`substrate_sub_libp2p_peers_count` was registered by `sc-network`, sourced from an `Arc<AtomicUsize>` that each backend kept updated purely so that metric could be published:

- the libp2p backend stored `user_protocol().num_sync_peers()` into it on every worker poll (`service.rs`),
- the litep2p backend stored the block-announce peerset's `connected_peers` into it on every loop iteration (`litep2p/mod.rs`).

Both are syncing-level numbers, not networking ones — which is what @bkchr pointed out in https://github.com/paritytech/polkadot-sdk/pull/4942#discussion_r1669297505.

This moves the gauge to `sc-network-sync`, where `SyncingEngine` already maintains an equivalent `num_connected` counter, and drops `connected_peers` from `sc-network`'s `MetricSources`. The metric keeps its name.

## Review Notes

The gauge is now registered by `Metrics::register` in `sc-network-sync`'s `engine.rs`, next to `MajorSyncingGauge`, and fed the `num_connected` counter the engine already owns:

```diff
 impl Metrics {
-     fn register(r: &Registry, major_syncing: Arc<AtomicBool>) -> Result<Self, PrometheusError> {
+     fn register(
+             r: &Registry,
+             major_syncing: Arc<AtomicBool>,
+             num_connected: Arc<AtomicUsize>,
+     ) -> Result<Self, PrometheusError> {
              MajorSyncingGauge::register(r, major_syncing)?;
+             NumConnectedGauge::register(r, num_connected)?;
```

and correspondingly removed from `sc-network`:

```diff
 pub struct MetricSources {
      pub bandwidth: Arc<dyn BandwidthSink>,
-     pub connected_peers: Arc<AtomicUsize>,
 }
```

**Test.** Added `num_connected_gauge_tracks_the_shared_counter` in `engine.rs`, asserting the gauge
registers under exactly `substrate_sub_libp2p_peers_count` and reads through to the live counter
rather than a snapshot. Name stability is the whole contract of this change, so it seemed worth
pinning.

<details>
<summary>Local verification</summary>

- `cargo check -p sc-network -p sc-network-sync` — clean, no warnings
- `cargo clippy -p sc-network -p sc-network-sync --all-targets` — no warnings in either crate
- `cargo test -p sc-network-sync --lib` — 94 passed, 0 failed
- `cargo +nightly fmt --check` — clean

</details>

The approach matches the earlier attempt in #11012, which was closed without review because its author never signed the CLA.