### PR TITLE
Fix stale people ring positions after suspensions

### DIFF
--- a/prdoc/pr_12988.prdoc
+++ b/prdoc/pr_12988.prdoc
@@ -1,0 +1,9 @@
+title: Fix stale people ring positions after suspensions
+doc:
+- audience: Runtime Dev
+  description: |-
+    Keep pallet-people person records synchronized when suspension cleanup
+    compacts a ring, so later suspension sessions remove the intended keys.
+crates:
+- name: pallet-people
+  bump: patch

--- a/substrate/frame/people/src/lib.rs
+++ b/substrate/frame/people/src/lib.rs
@@ -1710,14 +1710,38 @@ pub mod pallet {
 			for (i, key) in keys.into_iter().enumerate() {
 				if j < suspended_indices.len() && i == suspended_indices[j] as usize {
 					j += 1;
-				} else if new_keys
-					.try_push(key)
-					.defensive_proof("cannot move more ring members than the max ring size; qed")
-					.is_err()
-				{
-					return T::WeightInfo::remove_suspended_people(
-						keys_len.try_into().unwrap_or(u32::MAX),
-					);
+				} else {
+					// Once a key is removed, all following keys shift to a lower index. Keep the
+					// corresponding person records in sync with the compacted ring.
+					if j > 0 {
+						if let Some(personal_id) = Keys::<T>::get(&key).defensive() {
+							People::<T>::mutate(personal_id, |maybe_record| {
+								let Some(record) = maybe_record else {
+									defensive!("No person record found for a ring key");
+									return;
+								};
+								let RingPosition::Included { ring_position, .. } =
+									&mut record.position
+								else {
+									defensive!("Ring key belongs to a person who is not included");
+									return;
+								};
+								*ring_position = new_keys.len().saturated_into();
+							});
+						}
+					}
+
+					if new_keys
+						.try_push(key)
+						.defensive_proof(
+							"cannot move more ring members than the max ring size; qed",
+						)
+						.is_err()
+					{
+						return T::WeightInfo::remove_suspended_people(
+							keys_len.try_into().unwrap_or(u32::MAX),
+						);
+					}
 				}
 			}
 

--- a/substrate/frame/people/src/tests.rs
+++ b/substrate/frame/people/src/tests.rs
@@ -1113,7 +1113,7 @@ mod suspensions {
 	}
 
 	#[test]
-	fn suspending_in_multiple_sessions() {
+	fn suspending_in_multiple_sessions_updates_ring_positions() {
 		TestExt::new().execute_with(|| {
 			let mut meter = WeightMeter::new();
 			// A ring with multiple people
@@ -1130,6 +1130,22 @@ mod suspensions {
 			// Those people are then removed
 			assert_eq!(suspended_indices_list(RI_ZERO).into_inner(), vec![1, 2]);
 			PeoplePallet::remove_suspended_keys(RI_ZERO);
+			assert_eq!(
+				People::<Test>::get(3).unwrap().position,
+				RingPosition::Included {
+					ring_index: RI_ZERO,
+					ring_position: 1,
+					scheduled_for_removal: false,
+				}
+			);
+			assert_eq!(
+				People::<Test>::get(4).unwrap().position,
+				RingPosition::Included {
+					ring_index: RI_ZERO,
+					ring_position: 2,
+					scheduled_for_removal: false,
+				}
+			);
 
 			// Second session: some more people become suspended
 			assert_ok!(PeoplePallet::start_people_set_mutation_session());
@@ -1138,13 +1154,17 @@ mod suspensions {
 			PeoplePallet::migrate_keys(&mut meter);
 
 			// Pending suspensions are tracked correctly
-			assert_eq!(suspended_indices_list(RI_ZERO).into_inner(), vec![3, 4]);
+			assert_eq!(suspended_indices_list(RI_ZERO).into_inner(), vec![1, 2]);
 
 			// Those extra people are removed too
 			PeoplePallet::remove_suspended_keys(RI_ZERO);
 
 			// Final ring state is correct
-			assert_eq!(RingKeys::<Test>::get(RI_ZERO).len(), 6);
+			let remaining_people = RingKeys::<Test>::get(RI_ZERO)
+				.iter()
+				.map(|key| Keys::<Test>::get(key).unwrap())
+				.collect::<Vec<_>>();
+			assert_eq!(remaining_people, vec![0, 5, 6, 7, 8, 9]);
 		});
 	}
 


### PR DESCRIPTION
- keep each surviving `PersonRecord.ring_position` synchronized when `RingKeys` is compacted
- ensure later suspension cycles enqueue the new ring indices and remove the intended keys
- strengthen multi-session coverage with exact remaining-member assertions

Ring compaction previously shifted keys without updating their stored positions, so later suspension sessions could remove unrelated keys and leave suspended keys behind.