### PR TITLE
statement gossip: allocate the validation queue lazily

### DIFF
--- a/prdoc/pr_12994.prdoc
+++ b/prdoc/pr_12994.prdoc
@@ -1,0 +1,9 @@
+title: 'statement gossip: allocate the validation queue lazily'
+doc:
+- audience: Node Operator
+  description: |-
+    The statement validation queue no longer pre-allocates its full capacity,
+    its memory tracks actual occupancy. The queue limit still holds.
+crates:
+- name: sc-network-statement
+  bump: patch

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -521,7 +521,8 @@ impl StatementHandlerPrototype {
 		statements_per_second: u32,
 	) -> error::Result<StatementHandler<N, S>> {
 		let sync_event_stream = sync.event_stream("statement-handler-sync");
-		let (queue_sender, queue_receiver) = async_channel::bounded(MAX_PENDING_STATEMENTS);
+		// Still bounded via the `MAX_PENDING_STATEMENTS` check in `on_statements`.
+		let (queue_sender, queue_receiver) = async_channel::unbounded();
 
 		if num_submission_workers == 0 {
 			log::warn!(
@@ -1040,6 +1041,7 @@ where
 				},
 				_ = self.propagate_timeout.next() => {
 					self.propagate_statements().await;
+					self.shrink_pending_statements_peers();
 					self.metrics.as_ref().map(|metrics| {
 						metrics.pending_statements.set(self.pending_statements.len() as u64);
 					});
@@ -1083,6 +1085,15 @@ where
 				self.drain_deferred_peers();
 				self.start_sync_recovery();
 			}
+		}
+	}
+
+	/// Release excess map capacity once the map is less than a quarter full.
+	fn shrink_pending_statements_peers(&mut self) {
+		const MIN_RETAINED_CAPACITY: usize = 1024;
+		let map = &mut self.pending_statements_peers;
+		if map.capacity() > MIN_RETAINED_CAPACITY && map.capacity() / 4 > map.len() {
+			map.shrink_to(MIN_RETAINED_CAPACITY);
 		}
 	}
 


### PR DESCRIPTION
# Description

StatementHandlerPrototype::build creates the validation queue with unbounded channel to not pre-allocate extra memory. The limit itself still holds: on_statements checks MAX_PENDING_STATEMENTS before every enqueue. Also shrink pending_statements_peers on the propagation tick — HashMap keeps its high-water capacity, so a burst would otherwise pin it permanently.