### PR TITLE
cumulus-primitives-timestamp: saturate relay slot timestamp arithmetic

### DIFF
--- a/cumulus/primitives/timestamp/src/lib.rs
+++ b/cumulus/primitives/timestamp/src/lib.rs
@@ -61,10 +61,60 @@ impl InherentDataProvider {
 	pub fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
 		// As the parachain starts building at around `relay_chain_slot + 1` we use that slot to
 		// calculate the timestamp.
-		let data: InherentType = ((*self.relay_chain_slot + 1) *
-			self.relay_chain_slot_duration.as_millis() as u64)
+		//
+		// The arithmetic saturates instead of overflowing: an extreme relay chain slot would
+		// otherwise panic in debug and silently wrap to a nonsensical timestamp in release.
+		// `as_millis` returns a `u128`, so it is converted with a saturating `try_from` rather
+		// than a truncating `as` cast.
+		let slot_duration_ms =
+			u64::try_from(self.relay_chain_slot_duration.as_millis()).unwrap_or(u64::MAX);
+		let data: InherentType = (*self.relay_chain_slot)
+			.saturating_add(1)
+			.saturating_mul(slot_duration_ms)
 			.into();
 
 		inherent_data.put_data(INHERENT_IDENTIFIER, &data)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn timestamp_for(relay_chain_slot: u64, slot_duration: Duration) -> InherentType {
+		let inherent_data = InherentDataProvider::from_relay_chain_slot_and_duration(
+			relay_chain_slot.into(),
+			slot_duration,
+		)
+		.create_inherent_data()
+		.expect("creating inherent data works");
+
+		inherent_data
+			.get_data(&INHERENT_IDENTIFIER)
+			.expect("decoding the timestamp works")
+			.expect("the timestamp inherent is present")
+	}
+
+	#[test]
+	fn timestamp_is_derived_from_the_next_relay_chain_slot() {
+		// The parachain builds at `relay_chain_slot + 1`, so (5 + 1) * 6000 = 36_000.
+		assert_eq!(timestamp_for(5, Duration::from_millis(6_000)), InherentType::from(36_000u64));
+	}
+
+	#[test]
+	fn extreme_relay_chain_slot_saturates() {
+		// `relay_chain_slot + 1` used to overflow here, panicking in debug and wrapping in
+		// release. It must now clamp instead.
+		assert_eq!(
+			timestamp_for(u64::MAX, Duration::from_millis(6_000)),
+			InherentType::from(u64::MAX)
+		);
+	}
+
+	#[test]
+	fn extreme_slot_duration_saturates() {
+		// A slot duration whose milliseconds exceed `u64::MAX` must clamp rather than be
+		// truncated by an `as` cast.
+		assert_eq!(timestamp_for(1, Duration::from_secs(u64::MAX)), InherentType::from(u64::MAX));
 	}
 }

--- a/prdoc/pr_12996.prdoc
+++ b/prdoc/pr_12996.prdoc
@@ -1,0 +1,12 @@
+title: "cumulus-primitives-timestamp: saturate relay slot timestamp arithmetic"
+doc:
+  - audience: Node Dev
+    description: |
+      `InherentDataProvider::provide_inherent_data` now computes the timestamp with
+      saturating arithmetic, and converts the relay chain slot duration with a
+      saturating `try_from` instead of an `as` cast. An extreme relay chain slot or
+      slot duration now clamps to `u64::MAX` instead of overflowing, which previously
+      panicked in debug and silently wrapped in release.
+crates:
+  - name: cumulus-primitives-timestamp
+    bump: patch


### PR DESCRIPTION
Closes #12908

## Problem

`InherentDataProvider::provide_inherent_data` in
`cumulus/primitives/timestamp/src/lib.rs` computed the timestamp with unchecked
arithmetic:

```rust
let data: InherentType = ((*self.relay_chain_slot + 1) *
    self.relay_chain_slot_duration.as_millis() as u64)
    .into();
```

Two overflows are reachable here:

1. `*relay_chain_slot + 1` overflows at `u64::MAX` — a panic in debug, a silent wrap to a
   nonsensical timestamp in release.
2. The multiplication overflows for a large slot duration, and the `as u64` cast on the
   `u128` returned by `as_millis` truncates silently before that.

## Fix

Compute the value with saturating arithmetic, and convert the duration with a saturating
`try_from` rather than an `as` cast, so both cases clamp to `u64::MAX`:

```rust
let slot_duration_ms =
    u64::try_from(self.relay_chain_slot_duration.as_millis()).unwrap_or(u64::MAX);
let data: InherentType = (*self.relay_chain_slot)
    .saturating_add(1)
    .saturating_mul(slot_duration_ms)
    .into();
```

### Why saturating rather than returning an error

`provide_inherent_data` returns `Result<(), sp_inherents::Error>`, but `sp_inherents::Error`
has no `no_std`-constructible custom variant — `Application(Box<dyn std::error::Error…>)` is
gated behind `#[cfg(feature = "std")]`, and this crate is `no_std` and built for wasm.
Returning a clean `Err` would need a `cfg` split. Saturating compiles in both `std` and
`no_std`, never panics, and is deterministic. These slot values are not physically
reachable, so clamping is an acceptable outcome for an input that cannot occur in practice.

Happy to switch to a `std`-gated error path if maintainers would rather surface this as a
failure than clamp it.

## Testing

The crate had no tests. These are its first, and need no new dev-dependencies:

- `timestamp_is_derived_from_the_next_relay_chain_slot` — the normal case, `(5 + 1) * 6000`
- `extreme_relay_chain_slot_saturates` — the addition overflow
- `extreme_slot_duration_saturates` — the multiplication/truncation overflow

```
SKIP_WASM_BUILD=1 cargo test -p cumulus-primitives-timestamp
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Confirmed the tests are meaningful rather than vacuous — reverting to the original
arithmetic fails them with `attempt to add with overflow` and
`attempt to multiply with overflow` respectively, while the normal-case test still passes.

Also verified the fix still builds without `std`:

```
SKIP_WASM_BUILD=1 cargo build -p cumulus-primitives-timestamp --no-default-features
```

This is an RWF finding, from the same cluster as the merged #12769, #12771 and #12922.
