### PR TITLE
pallet-derivatives: emit DerivativeMappingCreated when registering a mapping

### DIFF
--- a/prdoc/pr_12998.prdoc
+++ b/prdoc/pr_12998.prdoc
@@ -1,0 +1,11 @@
+title: "pallet-derivatives: emit DerivativeMappingCreated when registering a mapping"
+doc:
+  - audience: Runtime Dev
+    description: |
+      `try_register_derivative` now deposits `DerivativeMappingCreated`, carrying both the
+      original and the derivative id, instead of a second `DerivativeCreated`. Previously a
+      mapped `create_derivative` emitted `DerivativeCreated` twice and never emitted
+      `DerivativeMappingCreated`, which was declared but deposited nowhere.
+crates:
+  - name: pallet-derivatives
+    bump: patch

--- a/substrate/frame/derivatives/src/lib.rs
+++ b/substrate/frame/derivatives/src/lib.rs
@@ -283,7 +283,10 @@ impl<T: Config<I>, I: 'static> DerivativesRegistry<OriginalOf<T, I>, DerivativeO
 		<OriginalToDerivative<T, I>>::insert(original, derivative);
 		<DerivativeToOriginal<T, I>>::insert(derivative, original);
 
-		Self::deposit_event(Event::<T, I>::DerivativeCreated { original: original.clone() });
+		Self::deposit_event(Event::<T, I>::DerivativeMappingCreated {
+			original: original.clone(),
+			derivative_id: derivative.clone(),
+		});
 
 		Ok(())
 	}

--- a/substrate/frame/derivatives/src/tests.rs
+++ b/substrate/frame/derivatives/src/tests.rs
@@ -171,6 +171,59 @@ fn auto_id_collection() {
 }
 
 #[test]
+fn mapped_create_emits_mapping_event_exactly_once() {
+	new_test_ext().execute_with(|| {
+		// `frame_system` does not record events at genesis.
+		System::set_block_number(1);
+
+		let original =
+			AssetId(Location::new(1, [Parachain(4321), PalletInstance(42), GeneralIndex(1)]));
+
+		assert_ok!(AutoIdDerivativeCollections::create_derivative(
+			RuntimeOrigin::signed(1),
+			original.clone()
+		));
+
+		let derivative = AutoIdDerivativeCollections::get_derivative(&original).unwrap();
+
+		let events: Vec<_> = System::events().into_iter().map(|record| record.event).collect();
+
+		let mapping_created = events
+			.iter()
+			.filter(|event| {
+				matches!(
+					event,
+					RuntimeEvent::AutoIdDerivativeCollections(
+						pallet_derivatives::Event::DerivativeMappingCreated {
+							original: o,
+							derivative_id: d,
+						},
+					) if *o == original && *d == derivative
+				)
+			})
+			.count();
+
+		let created = events
+			.iter()
+			.filter(|event| {
+				matches!(
+					event,
+					RuntimeEvent::AutoIdDerivativeCollections(
+						pallet_derivatives::Event::DerivativeCreated { original: o },
+					) if *o == original
+				)
+			})
+			.count();
+
+		// Registering the mapping emits `DerivativeMappingCreated`, and the extrinsic emits a
+		// single `DerivativeCreated`. Previously the mapped path emitted `DerivativeCreated`
+		// twice and never emitted `DerivativeMappingCreated`.
+		assert_eq!(mapping_created, 1);
+		assert_eq!(created, 1);
+	});
+}
+
+#[test]
 fn local_nfts() {
 	new_test_ext().execute_with(|| {
 		let collection_owner = 1;


### PR DESCRIPTION
Closes #12914

## Problem

`substrate/frame/derivatives/src/lib.rs` declares a `DerivativeMappingCreated` event
(L205) that is **never deposited anywhere in the crate**.

`try_register_derivative` — the function that writes the bidirectional mapping into
`OriginalToDerivative` and `DerivativeToOriginal` — instead deposited `DerivativeCreated`:

```rust
<OriginalToDerivative<T, I>>::insert(original, derivative);
<DerivativeToOriginal<T, I>>::insert(derivative, original);

Self::deposit_event(Event::<T, I>::DerivativeCreated { original: original.clone() });
```

Since `create_derivative` already deposits `DerivativeCreated` unconditionally after
calling it, a mapped creation emitted **`DerivativeCreated` twice and
`DerivativeMappingCreated` never**. Off-chain consumers therefore see a duplicate
creation event and can never observe a mapping being registered.

## Fix

Deposit the intended event, with both ids — `derivative` is already in scope:

```rust
Self::deposit_event(Event::<T, I>::DerivativeMappingCreated {
    original: original.clone(),
    derivative_id: derivative.clone(),
});
```

`create_derivative`'s own `DerivativeCreated` is unchanged, so the mapped path now emits
exactly one of each.

## Testing

Added `mapped_create_emits_mapping_event_exactly_once` to
`substrate/frame/derivatives/src/tests.rs`, which counts both event kinds after a mapped
`create_derivative` and asserts exactly one of each.

Note the test calls `System::set_block_number(1)` first: `new_test_ext()` leaves the block
number at genesis, and `frame_system::deposit_event_indexed` deliberately drops events
when the block number is zero, so an event assertion would otherwise see an empty log.
This crate had no existing event-based tests.

```
SKIP_WASM_BUILD=1 cargo test -p pallet-derivatives --lib
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Confirmed the test is meaningful: restoring the original `DerivativeCreated` deposit makes
it fail on the `DerivativeMappingCreated` count.

This is an RWF finding, from the same cluster as the merged #12769, #12771 and #12922.
