### PR TITLE
Fix ETH RPC Log Filtering Logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14241,6 +14241,7 @@ dependencies = [
  "sc-service",
  "serde",
  "serde_json",
+ "serde_with",
  "sp-arithmetic 23.0.0",
  "sp-core 28.0.0",
  "sp-crypto-hashing 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,6 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
- "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
@@ -386,7 +385,6 @@ dependencies = [
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ws",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -404,28 +402,6 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-pubsub"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
-dependencies = [
- "alloy-json-rpc",
- "alloy-primitives",
- "alloy-transport",
- "auto_impl",
- "bimap",
- "futures",
- "parking_lot 0.12.3",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower 0.5.3",
- "tracing",
  "wasmtimer",
 ]
 
@@ -459,10 +435,8 @@ checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ws",
  "futures",
  "pin-project",
  "reqwest 0.13.2",
@@ -715,25 +689,6 @@ dependencies = [
  "tower 0.5.3",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "alloy-transport-ws"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
-dependencies = [
- "alloy-pubsub",
- "alloy-transport",
- "futures",
- "http 1.1.0",
- "rustls 0.23.31",
- "serde_json",
- "tokio",
- "tokio-tungstenite 0.28.0",
- "tracing",
- "url",
- "ws_stream_wasm",
 ]
 
 [[package]]
@@ -2127,17 +2082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_io_stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
-dependencies = [
- "futures",
- "pharos",
- "rustc_version 0.4.0",
-]
-
-[[package]]
 name = "asynchronous-codec"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,12 +2279,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "binary-merkle-tree"
@@ -7931,7 +7869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
  "gloo-timers",
- "send_wrapper 0.4.0",
+ "send_wrapper",
 ]
 
 [[package]]
@@ -15919,16 +15857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pharos"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
-dependencies = [
- "futures",
- "rustc_version 0.4.0",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23273,12 +23201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28501,22 +28423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.23.31",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.0",
- "tungstenite 0.28.0",
- "webpki-roots 0.26.3",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28934,25 +28840,6 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.1.0",
- "httparse",
- "log",
- "rand 0.9.0",
- "rustls 0.23.31",
- "rustls-pki-types",
- "sha1",
- "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -30701,25 +30588,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "ws_stream_wasm"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
-dependencies = [
- "async_io_stream",
- "futures",
- "js-sys",
- "log",
- "pharos",
- "rustc_version 0.4.0",
- "send_wrapper 0.6.0",
- "thiserror 2.0.18",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "wyz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
+ "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
@@ -385,6 +386,7 @@ dependencies = [
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -402,6 +404,28 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "auto_impl",
+ "bimap",
+ "futures",
+ "parking_lot 0.12.3",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tracing",
  "wasmtimer",
 ]
 
@@ -435,8 +459,10 @@ checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
+ "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
  "futures",
  "pin-project",
  "reqwest 0.13.2",
@@ -689,6 +715,25 @@ dependencies = [
  "tower 0.5.3",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
+dependencies = [
+ "alloy-pubsub",
+ "alloy-transport",
+ "futures",
+ "http 1.1.0",
+ "rustls 0.23.31",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tracing",
+ "url",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -2082,6 +2127,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "asynchronous-codec"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,6 +2335,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "binary-merkle-tree"
@@ -7869,7 +7931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
  "gloo-timers",
- "send_wrapper",
+ "send_wrapper 0.4.0",
 ]
 
 [[package]]
@@ -15857,6 +15919,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23201,6 +23273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28423,6 +28501,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.31",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tungstenite 0.28.0",
+ "webpki-roots 0.26.3",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28840,6 +28934,25 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.9.0",
+ "rustls 0.23.31",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -30588,6 +30701,25 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version 0.4.0",
+ "send_wrapper 0.6.0",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wyz"

--- a/prdoc/pr_13002.prdoc
+++ b/prdoc/pr_13002.prdoc
@@ -1,0 +1,24 @@
+title: Fix ETH RPC Log Filtering Logic
+doc:
+- audience: Runtime Dev
+  description: |-
+    # Description
+
+    We have had a number of issues in the eth-rpc related to the log filtering logic and to its data representation such as:
+
+    - https://github.com/paritytech/polkadot-sdk/pull/12626
+    - https://github.com/paritytech/polkadot-sdk/pull/12483
+    - https://github.com/alloy-rs/alloy/pull/4153
+
+    Some of the issues that I link to here can't be fixed without changing the models we're using since there are certain things which alloy's `Filter` type can't represent (https://github.com/alloy-rs/alloy/pull/4153).
+
+    This PR does the following:
+    - Introduces our own `Filter` type which we use instead of alloy's filter type (due to the issues it has with what data it can't represent as seen in https://github.com/alloy-rs/alloy/pull/4153).
+    - Implement `Filter` matching logic on the `Filter` type itself as an authoritative implementation that can be used anywhere in the codebase.
+    - Removes the duplicated subscription filter type that we used to have in favor of this new `Filter` type.
+    - Updates the `ReceiptProvider::logs` implementation to match the filtering logic implemented on the `Filter` type.
+
+    This PR fixes all of the github issues/PRs linked to above and should close them once its merged.
+crates:
+- name: pallet-revive-eth-rpc
+  bump: minor

--- a/prdoc/pr_13002.prdoc
+++ b/prdoc/pr_13002.prdoc
@@ -2,23 +2,39 @@ title: Fix ETH RPC Log Filtering Logic
 doc:
 - audience: Runtime Dev
   description: |-
-    # Description
+    This PR fixes and consolidates all of the logic we had around log filtering
+    with the introduction of a new `Filter` type.
 
-    We have had a number of issues in the eth-rpc related to the log filtering logic and to its data representation such as:
+    The primary behavioral changes clients can observe now are as follows:
 
-    - https://github.com/paritytech/polkadot-sdk/pull/12626
-    - https://github.com/paritytech/polkadot-sdk/pull/12483
-    - https://github.com/alloy-rs/alloy/pull/4153
+    - Log subscriptions now accept block filtering options
+      - Block ranges are both inclusive.
+      - Block ranges are validated and an error is returned if they're invalid.
+      - Block ranges don't fetch logs from past blocks.
+      - Block hashes are not permitted for the block options and return an error
+        for invalid arguments.
+      - The `safe`, `finalized`, and `pending` tags are invalid options for
+        subscriptions but permitted for `eth_getLogs`.
+    - In block options, missing or `null` block range bounds now default to
+      the `latest` tag.
+    - On topic filtering:
+      - We now preserve wildcard positions at the end of the filter.
+      - A wildcard topic filter means "a topic must be present at this position
+        but it can be anything".
+    - Missing, `null`, or empty address and topic filters are treated as
+      wildcards. Filters accept up to 1,000 distinct addresses, four topic
+      positions, and 1,000 distinct topic alternatives per position.
+    - `eth_getLogs` now returns an error for an unknown `blockHash` instead of
+      returning `[]`. The `pending` tag is also rejected.
+      A block hash cannot be combined with a non-null `fromBlock` or `toBlock`,
+      and malformed block hashes are rejected instead of falling back to a
+      range filter.
+    - `eth_getLogs` results are now ordered by block number and log index before
+      the existing result limit is applied.
+    - The `data` field is now always included in log responses. Logs with no
+      data return `"0x"`, including older database entries where the data was
+      stored as `NULL`.
 
-    Some of the issues that I link to here can't be fixed without changing the models we're using since there are certain things which alloy's `Filter` type can't represent (https://github.com/alloy-rs/alloy/pull/4153).
-
-    This PR does the following:
-    - Introduces our own `Filter` type which we use instead of alloy's filter type (due to the issues it has with what data it can't represent as seen in https://github.com/alloy-rs/alloy/pull/4153).
-    - Implement `Filter` matching logic on the `Filter` type itself as an authoritative implementation that can be used anywhere in the codebase.
-    - Removes the duplicated subscription filter type that we used to have in favor of this new `Filter` type.
-    - Updates the `ReceiptProvider::logs` implementation to match the filtering logic implemented on the `Filter` type.
-
-    This PR fixes all of the github issues/PRs linked to above and should close them once its merged.
 crates:
 - name: pallet-revive-eth-rpc
   bump: minor

--- a/prdoc/pr_13002.prdoc
+++ b/prdoc/pr_13002.prdoc
@@ -37,4 +37,4 @@ doc:
 
 crates:
 - name: pallet-revive-eth-rpc
-  bump: minor
+  bump: major

--- a/substrate/frame/revive/rpc/Cargo.toml
+++ b/substrate/frame/revive/rpc/Cargo.toml
@@ -20,6 +20,7 @@ name = "eth-rpc"
 path = "src/main.rs"
 
 [dependencies]
+alloy-primitives = { workspace = true }
 alloy-rpc-types = { workspace = true, default-features = true, features = [
 	"trace",
 ] }
@@ -46,6 +47,7 @@ serde = { workspace = true, default-features = true, features = [
 	"derive",
 ] }
 serde_json = { workspace = true }
+serde_with = { workspace = true, default-features = true }
 sp-arithmetic = { workspace = true, default-features = true }
 sp-core = { workspace = true, default-features = true }
 sp-crypto-hashing = { workspace = true }
@@ -64,7 +66,6 @@ tokio-stream = { workspace = true }
 
 [dev-dependencies]
 alloy-network = { workspace = true, default-features = true }
-alloy-primitives = { workspace = true, default-features = true }
 alloy-provider = { workspace = true, default-features = true, features = [
 	"debug-api",
 	"reqwest",

--- a/substrate/frame/revive/rpc/Cargo.toml
+++ b/substrate/frame/revive/rpc/Cargo.toml
@@ -69,7 +69,6 @@ alloy-primitives = { workspace = true }
 alloy-provider = { workspace = true, default-features = true, features = [
 	"debug-api",
 	"reqwest",
-	"ws",
 ] }
 alloy-signer-local = { workspace = true, default-features = true }
 env_logger = { workspace = true }

--- a/substrate/frame/revive/rpc/Cargo.toml
+++ b/substrate/frame/revive/rpc/Cargo.toml
@@ -20,7 +20,6 @@ name = "eth-rpc"
 path = "src/main.rs"
 
 [dependencies]
-alloy-primitives = { workspace = true }
 alloy-rpc-types = { workspace = true, default-features = true, features = [
 	"trace",
 ] }
@@ -66,6 +65,7 @@ tokio-stream = { workspace = true }
 
 [dev-dependencies]
 alloy-network = { workspace = true, default-features = true }
+alloy-primitives = { workspace = true }
 alloy-provider = { workspace = true, default-features = true, features = [
 	"debug-api",
 	"reqwest",

--- a/substrate/frame/revive/rpc/Cargo.toml
+++ b/substrate/frame/revive/rpc/Cargo.toml
@@ -69,6 +69,7 @@ alloy-network = { workspace = true, default-features = true }
 alloy-provider = { workspace = true, default-features = true, features = [
 	"debug-api",
 	"reqwest",
+	"ws",
 ] }
 alloy-signer-local = { workspace = true, default-features = true }
 env_logger = { workspace = true }

--- a/substrate/frame/revive/rpc/src/client.rs
+++ b/substrate/frame/revive/rpc/src/client.rs
@@ -165,8 +165,8 @@ pub enum ClientError {
 	#[error("failed to recover eth address")]
 	RecoverEthAddressFailed,
 	/// Failed to filter logs.
-	#[error("Failed to filter logs")]
-	LogFilterFailed(#[from] anyhow::Error),
+	#[error("Failed to filter logs: {0}")]
+	LogFilterFailed(#[source] anyhow::Error),
 	/// Receipt storage was not found.
 	#[error("Receipt storage not found")]
 	ReceiptDataNotFound,

--- a/substrate/frame/revive/rpc/src/fee_history_provider.rs
+++ b/substrate/frame/revive/rpc/src/fee_history_provider.rs
@@ -105,7 +105,7 @@ impl FeeHistoryProvider {
 				(gas_used, effective_reward)
 			})
 			.collect::<Vec<_>>();
-		receipts.sort_by(|(_, a), (_, b)| a.cmp(b));
+		receipts.sort_by_key(|(_, a)| *a);
 
 		// Calculate percentile rewards.
 		result.rewards = reward_percentiles

--- a/substrate/frame/revive/rpc/src/lib.rs
+++ b/substrate/frame/revive/rpc/src/lib.rs
@@ -32,7 +32,7 @@ use pallet_revive_types::runtime_api::{
 };
 use sp_core::{H160, H256, U256};
 use sp_crypto_hashing::keccak_256;
-use std::pin::Pin;
+use std::{ops::ControlFlow, pin::Pin};
 use subxt::rpcs::methods::legacy::TransactionStatus;
 use thiserror::Error;
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
@@ -608,8 +608,20 @@ impl EthRpcServer for EthRpcServerImpl {
 			) as _,
 			SubscriptionParameters::Logs(filter) => Box::pin(
 				BroadcastStream::new(self.client.get_log_subscription_rx())
-					.try_filter(move |log| futures::future::ready(filter.matches(log)))
-					.map_ok(SubscriptionItem::Log),
+					.map_ok(move |log| match filter.block_option.window(log.block_number) {
+						LogWindow::Closed => ControlFlow::Break(()),
+						LogWindow::NotYetOpen => ControlFlow::Continue(None),
+						LogWindow::Open => {
+							ControlFlow::Continue(filter.matches(&log).then_some(log))
+						},
+					})
+					.try_take_while(|flow| futures::future::ready(Ok(flow.is_continue())))
+					.try_filter_map(|flow| {
+						futures::future::ready(Ok(match flow {
+							ControlFlow::Continue(log) => log.map(SubscriptionItem::Log),
+							ControlFlow::Break(()) => None,
+						}))
+					}),
 			) as _,
 		};
 		let _ = tokio::spawn(Self::handle_subscription_forwarding(sink, stream));

--- a/substrate/frame/revive/rpc/src/lib.rs
+++ b/substrate/frame/revive/rpc/src/lib.rs
@@ -17,7 +17,7 @@
 //! The [`EthRpcServer`] RPC server implementation
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-pub use alloy_rpc_types::{BlockId, BlockNumberOrTag, Filter, FilterBlockOption};
+pub use alloy_rpc_types::{BlockId, BlockNumberOrTag};
 use client::ClientError;
 use futures::{Stream, StreamExt, TryStreamExt};
 use jsonrpsee::{

--- a/substrate/frame/revive/rpc/src/receipt_extractor.rs
+++ b/substrate/frame/revive/rpc/src/receipt_extractor.rs
@@ -78,7 +78,7 @@ fn decode_revive_event(
 				return Some(ReviveEvent::Log(Log {
 					address: evt.contract,
 					topics: evt.topics,
-					data: Some(evt.data.into()),
+					data: evt.data.into(),
 					block_number,
 					transaction_hash,
 					transaction_index: transaction_index.into(),
@@ -864,7 +864,7 @@ mod tests {
 		let log = &logs[&5][0];
 		assert_eq!(log.address, contract);
 		assert_eq!(log.topics, topics);
-		assert_eq!(log.data.as_ref().unwrap().0, data);
+		assert_eq!(log.data.0, data);
 		assert_eq!(log.block_hash, eth_block_hash);
 		assert_eq!(log.block_number, eth_block_number);
 		assert_eq!(log.transaction_hash, tx_hash);

--- a/substrate/frame/revive/rpc/src/receipt_provider.rs
+++ b/substrate/frame/revive/rpc/src/receipt_provider.rs
@@ -56,7 +56,7 @@ fn parse_log_row(row: sqlx::sqlite::SqliteRow) -> Result<Log, sqlx::Error> {
 		address: Address::from_slice(&address),
 		block_hash: H256::from_slice(&block_hash),
 		block_number: U256::from(block_number as u64),
-		data: data.map(Bytes::from),
+		data: Some(Bytes::from(data.unwrap_or_default())),
 		log_index: U256::from(log_index as u64),
 		topics,
 		transaction_hash: H256::from_slice(&transaction_hash),
@@ -745,12 +745,22 @@ impl<B: BlockInfoProvider> ReceiptProvider<B> {
 					anyhow::bail!("pending logs are not supported");
 				}
 
-				let from_block = resolve_block_number(from_block).await?;
-				let to_block = resolve_block_number(to_block).await?;
-
-				// Read the latest block *after* resolving the tags.
+				// A single head snapshot resolves `latest` and validates the range,
+				// mirroring geth.
 				let latest_block = U256::from(self.block_provider.latest_block_number().await);
+				let from_block = match from_block {
+					BlockNumberOrTag::Latest => latest_block,
+					bound => resolve_block_number(bound).await?,
+				};
+				let to_block = match to_block {
+					BlockNumberOrTag::Latest => latest_block,
+					bound => resolve_block_number(bound).await?,
+				};
+				let earliest_block = resolve_block_number(BlockNumberOrTag::Earliest).await?;
 
+				if from_block < earliest_block {
+					anyhow::bail!("history below the earliest indexed block is not available");
+				}
 				if from_block > to_block {
 					anyhow::bail!("invalid block range params");
 				}
@@ -776,6 +786,9 @@ impl<B: BlockInfoProvider> ReceiptProvider<B> {
 
 		for (i, topic) in filter.topics.into_iter().enumerate() {
 			if topic.is_empty() {
+				// Geth requires the log to have a topic at every filter position, even a
+				// wildcard one.
+				qb.push(format_args!(" AND topic_{i} IS NOT NULL"));
 				continue;
 			}
 
@@ -1241,6 +1254,7 @@ mod tests {
 			block_number: block2.number.into(),
 			address: H160::from([2u8; 20]),
 			topics: vec![H256::from([2u8; 32]), H256::from([3u8; 32])],
+			data: Some(vec![1u8; 32].into()),
 			transaction_hash: H256::from([1u8; 32]),
 			transaction_index: U256::from(2),
 			log_index: U256::from(1),
@@ -1376,6 +1390,14 @@ mod tests {
 			)
 			.await?;
 		assert_eq!(logs, vec![log1.clone(), log2.clone()]);
+
+		// A trailing wildcard position still requires the log to have a topic there
+		let filter = serde_json::from_value::<Filter>(serde_json::json!({
+			"fromBlock": "earliest",
+			"topics": [H256::from([1u8; 32]), null, null],
+		}))?;
+		let logs = provider.logs(Some(filter), &resolve_block_number).await?;
+		assert_eq!(logs, Vec::<Log>::new());
 
 		// Altogether
 		let logs = provider

--- a/substrate/frame/revive/rpc/src/receipt_provider.rs
+++ b/substrate/frame/revive/rpc/src/receipt_provider.rs
@@ -21,7 +21,6 @@ use crate::{
 	block_sync::SyncCheckpoint,
 	client::{SubstrateBlock, SubstrateBlockNumber},
 };
-use futures::future::OptionFuture;
 use pallet_revive::evm::TransactionSigned;
 use sp_core::{H256, U256};
 use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool, query};
@@ -732,52 +731,45 @@ impl<B: BlockInfoProvider> ReceiptProvider<B> {
 		let filter = filter.unwrap_or_default();
 
 		match filter.block_option {
-			FilterBlockOption::AtBlockHash(hash) => {
-				qb.push(" AND block_hash = ").push_bind(hash.as_slice().to_vec());
+			FilterBlockOption::AtBlock { block_hash } => {
+				let block_hash = H256(block_hash.0);
+				if self.get_substrate_hash(&block_hash).await.is_none() {
+					anyhow::bail!("unknown block");
+				}
+				qb.push(" AND block_hash = ").push_bind(block_hash.as_bytes().to_vec());
 			},
 			FilterBlockOption::Range { from_block, to_block } => {
-				let from_block =
-					OptionFuture::from(from_block.map(&resolve_block_number)).await.transpose()?;
-				let to_block =
-					OptionFuture::from(to_block.map(&resolve_block_number)).await.transpose()?;
+				if matches!(from_block, BlockNumberOrTag::Pending) ||
+					matches!(to_block, BlockNumberOrTag::Pending)
+				{
+					anyhow::bail!("pending logs are not supported");
+				}
+
+				let from_block = resolve_block_number(from_block).await?;
+				let to_block = resolve_block_number(to_block).await?;
 
 				// Read the latest block *after* resolving the tags.
 				let latest_block = U256::from(self.block_provider.latest_block_number().await);
 
-				match (from_block, to_block) {
-					(Some(block), _) | (_, Some(block)) if block > latest_block => {
-						anyhow::bail!("block number exceeds latest block");
-					},
-					(Some(from_block), Some(to_block)) if from_block > to_block => {
-						anyhow::bail!("invalid block range params");
-					},
-					(Some(from_block), Some(to_block)) if from_block == to_block => {
-						qb.push(" AND block_number = ").push_bind(from_block.as_u64() as i64);
-					},
-					(Some(from_block), Some(to_block)) => {
-						qb.push(" AND block_number BETWEEN ")
-							.push_bind(from_block.as_u64() as i64)
-							.push(" AND ")
-							.push_bind(to_block.as_u64() as i64);
-					},
-					(Some(from_block), None) => {
-						qb.push(" AND block_number >= ").push_bind(from_block.as_u64() as i64);
-					},
-					(None, Some(to_block)) => {
-						qb.push(" AND block_number <= ").push_bind(to_block.as_u64() as i64);
-					},
-					(None, None) => {
-						qb.push(" AND block_number = ").push_bind(latest_block.as_u64() as i64);
-					},
+				if from_block > to_block {
+					anyhow::bail!("invalid block range params");
 				}
+				if to_block > latest_block {
+					anyhow::bail!("block range extends into the future");
+				}
+
+				qb.push(" AND block_number BETWEEN ")
+					.push_bind(from_block.as_u64() as i64)
+					.push(" AND ")
+					.push_bind(to_block.as_u64() as i64);
 			},
 		}
 
 		if !filter.address.is_empty() {
 			qb.push(" AND address IN (");
 			let mut separated = qb.separated(", ");
-			for addr in filter.address {
-				separated.push_bind(addr.as_slice().to_vec());
+			for address in filter.address {
+				separated.push_bind(address.as_bytes().to_vec());
 			}
 			separated.push_unseparated(")");
 		}
@@ -790,12 +782,13 @@ impl<B: BlockInfoProvider> ReceiptProvider<B> {
 			qb.push(format_args!(" AND topic_{i} IN ("));
 			let mut separated = qb.separated(", ");
 			for hash in topic {
-				separated.push_bind(hash.as_slice().to_vec());
+				separated.push_bind(hash.as_bytes().to_vec());
 			}
 			separated.push_unseparated(")");
 		}
 
-		qb.push(" LIMIT ").push_bind(MAX_LOG_RESULTS as i64);
+		qb.push(" ORDER BY block_number, log_index LIMIT ")
+			.push_bind(MAX_LOG_RESULTS as i64);
 
 		let logs = qb.build().try_map(parse_log_row).fetch_all(&self.db_ctx.pool).await?;
 
@@ -954,7 +947,6 @@ mod tests {
 		ReceiptInfo,
 		test::{MockBlockInfo, MockBlockInfoProvider},
 	};
-	use alloy_primitives::{Address as AlloyAddress, B256};
 	use pallet_revive::evm::TransactionSigned;
 	use pretty_assertions::assert_eq;
 	use sp_core::{H160, H256};
@@ -1304,29 +1296,29 @@ mod tests {
 			.await?;
 		assert_eq!(logs, vec![log2.clone()]);
 
-		// to_block filter
+		// to_block filter (a bare `to_block` in the past is `latest..to`, an invalid range)
 		let logs = provider
-			.logs(Some(Filter::new().to_block(log1.block_number.as_u64())), &resolve_block_number)
+			.logs(
+				Some(
+					Filter::new()
+						.from_block(BlockNumberOrTag::Earliest)
+						.to_block(log1.block_number.as_u64()),
+				),
+				&resolve_block_number,
+			)
 			.await?;
 		assert_eq!(logs, vec![log1.clone()]);
 
 		// block_hash filter
 		let logs = provider
-			.logs(
-				Some(Filter::new().at_block_hash(B256::from(log1.block_hash.0))),
-				&resolve_block_number,
-			)
+			.logs(Some(Filter::new().at_block_hash(log1.block_hash)), &resolve_block_number)
 			.await?;
 		assert_eq!(logs, vec![log1.clone()]);
 
 		// single address
 		let logs = provider
 			.logs(
-				Some(
-					Filter::new()
-						.from_block(BlockNumberOrTag::Earliest)
-						.address(AlloyAddress::from(log1.address.0)),
-				),
+				Some(Filter::new().from_block(BlockNumberOrTag::Earliest).address([log1.address])),
 				&resolve_block_number,
 			)
 			.await?;
@@ -1335,10 +1327,11 @@ mod tests {
 		// multiple addresses
 		let logs = provider
 			.logs(
-				Some(Filter::new().from_block(BlockNumberOrTag::Earliest).address(vec![
-					AlloyAddress::from(log1.address.0),
-					AlloyAddress::from(log2.address.0),
-				])),
+				Some(
+					Filter::new()
+						.from_block(BlockNumberOrTag::Earliest)
+						.address([log1.address, log2.address]),
+				),
 				&resolve_block_number,
 			)
 			.await?;
@@ -1350,7 +1343,7 @@ mod tests {
 				Some(
 					Filter::new()
 						.from_block(BlockNumberOrTag::Earliest)
-						.event_signature(B256::from(log1.topics[0].0)),
+						.event_signature([log1.topics[0]]),
 				),
 				&resolve_block_number,
 			)
@@ -1363,8 +1356,8 @@ mod tests {
 				Some(
 					Filter::new()
 						.from_block(BlockNumberOrTag::Earliest)
-						.event_signature(B256::from(log1.topics[0].0))
-						.topic1(B256::from(log1.topics[1].0)),
+						.event_signature([log1.topics[0]])
+						.topic1([log1.topics[1]]),
 				),
 				&resolve_block_number,
 			)
@@ -1374,10 +1367,11 @@ mod tests {
 		// multiple topic for topic_0
 		let logs = provider
 			.logs(
-				Some(Filter::new().from_block(BlockNumberOrTag::Earliest).event_signature(vec![
-					B256::from(log1.topics[0].0),
-					B256::from(log2.topics[0].0),
-				])),
+				Some(
+					Filter::new()
+						.from_block(BlockNumberOrTag::Earliest)
+						.event_signature([log1.topics[0], log2.topics[0]]),
+				),
 				&resolve_block_number,
 			)
 			.await?;
@@ -1390,26 +1384,15 @@ mod tests {
 					Filter::new()
 						.from_block(BlockNumberOrTag::Earliest)
 						.to_block(BlockNumberOrTag::Latest)
-						.address(vec![
-							AlloyAddress::from(log1.address.0),
-							AlloyAddress::from(log2.address.0),
-						])
-						.event_signature(vec![
-							B256::from(log1.topics[0].0),
-							B256::from(log2.topics[0].0),
-						]),
+						.address([log1.address, log2.address])
+						.event_signature([log1.topics[0], log2.topics[0]]),
 				),
 				&resolve_block_number,
 			)
 			.await?;
 		assert_eq!(logs, vec![log1.clone(), log2.clone()]);
 
-		for tag in [
-			BlockNumberOrTag::Latest,
-			BlockNumberOrTag::Finalized,
-			BlockNumberOrTag::Safe,
-			BlockNumberOrTag::Pending,
-		] {
+		for tag in [BlockNumberOrTag::Latest, BlockNumberOrTag::Finalized, BlockNumberOrTag::Safe] {
 			let logs = provider
 				.logs(Some(Filter::new().from_block(tag)), &resolve_block_number)
 				.await?;
@@ -1427,6 +1410,11 @@ mod tests {
 			)
 			.await?;
 		assert_eq!(logs, vec![log1.clone()], "from == to selects the single block");
+
+		let result = provider
+			.logs(Some(Filter::new().from_block(BlockNumberOrTag::Pending)), &resolve_block_number)
+			.await;
+		assert!(result.is_err(), "pending logs are unsupported");
 
 		let result = provider
 			.logs(
@@ -1573,7 +1561,7 @@ mod tests {
 		// Query logs using Ethereum block hash (should resolve to substrate hash)
 		let logs = provider
 			.logs(
-				Some(Filter::new().at_block_hash(B256::from(ethereum_hash.0))),
+				Some(Filter::new().at_block_hash(ethereum_hash)),
 				mock_resolve_block_number_with_latest(block.number.into()),
 			)
 			.await?;

--- a/substrate/frame/revive/rpc/src/receipt_provider.rs
+++ b/substrate/frame/revive/rpc/src/receipt_provider.rs
@@ -56,7 +56,7 @@ fn parse_log_row(row: sqlx::sqlite::SqliteRow) -> Result<Log, sqlx::Error> {
 		address: Address::from_slice(&address),
 		block_hash: H256::from_slice(&block_hash),
 		block_number: U256::from(block_number as u64),
-		data: Some(Bytes::from(data.unwrap_or_default())),
+		data: Bytes::from(data.unwrap_or_default()),
 		log_index: U256::from(log_index as u64),
 		topics,
 		transaction_hash: H256::from_slice(&transaction_hash),
@@ -702,7 +702,7 @@ impl<B: BlockInfoProvider> ReceiptProvider<B> {
 					.push_bind(log.topics.get(1).map(|v| &v[..]))
 					.push_bind(log.topics.get(2).map(|v| &v[..]))
 					.push_bind(log.topics.get(3).map(|v| &v[..]))
-					.push_bind(log.data.as_ref().map(|v| &v.0[..]));
+					.push_bind(&log.data.0[..]);
 			});
 			query_builder.build().execute(&mut *db_tx).await?;
 		}
@@ -1034,6 +1034,47 @@ mod tests {
 			.with_keep_latest(Some(10))
 	}
 
+	/// Preserve empty payloads across inserts and reads of legacy rows containing SQL NULL.
+	#[sqlx::test]
+	async fn empty_log_data_is_stored_as_bytes_and_legacy_null_reads_as_empty(
+		pool: SqlitePool,
+	) -> anyhow::Result<()> {
+		// Arrange
+		let provider = setup_sqlite_provider(pool).await;
+		let block = MockBlockInfo { hash: H256::repeat_byte(1), number: 1 };
+		let ethereum_hash = H256::repeat_byte(2);
+		let log = Log {
+			block_hash: ethereum_hash,
+			block_number: block.number.into(),
+			..Default::default()
+		};
+		let receipts = vec![(
+			TransactionSigned::default(),
+			ReceiptInfo { logs: vec![log.clone()], ..Default::default() },
+		)];
+
+		// Act
+		provider.insert(&block, &receipts, &ethereum_hash).await?;
+		let stored_data = sqlx::query_scalar::<_, Option<Vec<u8>>>("SELECT data FROM logs")
+			.fetch_one(&provider.db_ctx.pool)
+			.await?;
+		sqlx::query("UPDATE logs SET data = NULL")
+			.execute(&provider.db_ctx.pool)
+			.await?;
+		let logs = provider
+			.logs(
+				Some(Filter::new().at_block_hash(ethereum_hash)),
+				mock_resolve_block_number_with_latest(block.number),
+			)
+			.await?;
+
+		// Assert
+		assert_eq!(stored_data, Some(Vec::new()));
+		assert_eq!(logs, vec![log]);
+		assert_eq!(serde_json::to_value(&logs)?[0]["data"], "0x");
+		Ok(())
+	}
+
 	#[sqlx::test]
 	async fn test_insert_remove(pool: SqlitePool) -> anyhow::Result<()> {
 		let provider = setup_sqlite_provider(pool).await;
@@ -1243,7 +1284,7 @@ mod tests {
 			block_number: block1.number.into(),
 			address: H160::from([1u8; 20]),
 			topics: vec![H256::from([1u8; 32]), H256::from([2u8; 32])],
-			data: Some(vec![0u8; 32].into()),
+			data: vec![0u8; 32].into(),
 			transaction_hash: H256::default(),
 			transaction_index: U256::from(1),
 			log_index: U256::from(1),
@@ -1254,7 +1295,7 @@ mod tests {
 			block_number: block2.number.into(),
 			address: H160::from([2u8; 20]),
 			topics: vec![H256::from([2u8; 32]), H256::from([3u8; 32])],
-			data: Some(vec![1u8; 32].into()),
+			data: vec![1u8; 32].into(),
 			transaction_hash: H256::from([1u8; 32]),
 			transaction_index: U256::from(2),
 			log_index: U256::from(1),
@@ -1563,7 +1604,7 @@ mod tests {
 			transaction_hash: H256::from([3u8; 32]),
 			transaction_index: U256::from(0),
 			log_index: U256::from(0),
-			data: Some(vec![0u8; 32].into()),
+			data: vec![0u8; 32].into(),
 			..Default::default()
 		};
 

--- a/substrate/frame/revive/rpc/src/receipt_provider.rs
+++ b/substrate/frame/revive/rpc/src/receipt_provider.rs
@@ -758,9 +758,6 @@ impl<B: BlockInfoProvider> ReceiptProvider<B> {
 				};
 				let earliest_block = resolve_block_number(BlockNumberOrTag::Earliest).await?;
 
-				if from_block < earliest_block {
-					anyhow::bail!("history below the earliest indexed block is not available");
-				}
 				if from_block > to_block {
 					anyhow::bail!("invalid block range params");
 				}

--- a/substrate/frame/revive/rpc/src/receipt_provider.rs
+++ b/substrate/frame/revive/rpc/src/receipt_provider.rs
@@ -744,18 +744,12 @@ impl<B: BlockInfoProvider> ReceiptProvider<B> {
 					anyhow::bail!("pending logs are not supported");
 				}
 
-				// A single head snapshot resolves `latest` and validates the range,
-				// mirroring geth.
+				let from_block = resolve_block_number(from_block).await?;
+				let to_block = resolve_block_number(to_block).await?;
+
+				// Read the ceiling after resolving tags so advancing heads do not cause false
+				// future-block errors.
 				let latest_block = U256::from(self.block_provider.latest_block_number().await);
-				let from_block = match from_block {
-					BlockNumberOrTag::Latest => latest_block,
-					bound => resolve_block_number(bound).await?,
-				};
-				let to_block = match to_block {
-					BlockNumberOrTag::Latest => latest_block,
-					bound => resolve_block_number(bound).await?,
-				};
-				let earliest_block = resolve_block_number(BlockNumberOrTag::Earliest).await?;
 
 				if from_block > to_block {
 					anyhow::bail!("invalid block range params");

--- a/substrate/frame/revive/rpc/src/receipt_provider.rs
+++ b/substrate/frame/revive/rpc/src/receipt_provider.rs
@@ -1263,6 +1263,63 @@ mod tests {
 	}
 
 	#[sqlx::test]
+	async fn logs_are_ordered_by_block_and_log_index_before_truncation(
+		pool: SqlitePool,
+	) -> anyhow::Result<()> {
+		// Arrange
+		let provider = setup_sqlite_provider(pool).await;
+		let logs_per_block = MAX_LOG_RESULTS as u64 / 2 + 1;
+		let expected = (1..=2u64)
+			.flat_map(|block_number| {
+				(0..logs_per_block).map(move |log_index| Log {
+					block_hash: H256::from_low_u64_be(block_number),
+					block_number: block_number.into(),
+					transaction_hash: H256::from_low_u64_be(block_number + 2),
+					log_index: log_index.into(),
+					address: H160::from_low_u64_be(logs_per_block - log_index),
+					..Default::default()
+				})
+			})
+			.collect::<Vec<_>>();
+		for block_number in (1..=2u64).rev() {
+			let block = MockBlockInfo {
+				hash: H256::from_low_u64_be(block_number + 4),
+				number: block_number,
+			};
+			let receipt = ReceiptInfo {
+				transaction_hash: H256::from_low_u64_be(block_number + 2),
+				logs: expected
+					.iter()
+					.filter(|log| log.block_number == U256::from(block_number))
+					.rev()
+					.cloned()
+					.collect(),
+				..Default::default()
+			};
+			provider
+				.insert(
+					&block,
+					&[(TransactionSigned::default(), receipt)],
+					&H256::from_low_u64_be(block_number),
+				)
+				.await?;
+		}
+
+		// Act
+		let logs = provider
+			.logs(
+				Some(Filter::new().from_block(1u64).to_block(2u64)),
+				mock_resolve_block_number_with_latest(2),
+			)
+			.await?;
+
+		// Assert
+		assert_eq!(logs.len(), MAX_LOG_RESULTS);
+		assert_eq!(logs, expected.into_iter().take(MAX_LOG_RESULTS).collect::<Vec<_>>());
+		Ok(())
+	}
+
+	#[sqlx::test]
 	async fn test_query_logs(pool: SqlitePool) -> anyhow::Result<()> {
 		let provider = setup_sqlite_provider(pool).await;
 		let block1 = MockBlockInfo { hash: H256::from([1u8; 32]), number: 1 };

--- a/substrate/frame/revive/rpc/src/receipt_provider.rs
+++ b/substrate/frame/revive/rpc/src/receipt_provider.rs
@@ -775,10 +775,10 @@ impl<B: BlockInfoProvider> ReceiptProvider<B> {
 			},
 		}
 
-		if !filter.address.is_empty() {
+		if !filter.addresses.is_empty() {
 			qb.push(" AND address IN (");
 			let mut separated = qb.separated(", ");
-			for address in filter.address {
+			for address in filter.addresses {
 				separated.push_bind(address.as_bytes().to_vec());
 			}
 			separated.push_unseparated(")");

--- a/substrate/frame/revive/rpc/src/receipt_provider.rs
+++ b/substrate/frame/revive/rpc/src/receipt_provider.rs
@@ -732,7 +732,6 @@ impl<B: BlockInfoProvider> ReceiptProvider<B> {
 
 		match filter.block_option {
 			FilterBlockOption::AtBlock { block_hash } => {
-				let block_hash = H256(block_hash.0);
 				if self.get_substrate_hash(&block_hash).await.is_none() {
 					anyhow::bail!("unknown block");
 				}

--- a/substrate/frame/revive/rpc/src/tests.rs
+++ b/substrate/frame/revive/rpc/src/tests.rs
@@ -19,9 +19,9 @@
 //! [evm-test-suite](https://github.com/paritytech/evm-test-suite) repository.
 
 use crate::{
-	BlockHeader, BlockInfoProvider, BoundedOneOrMany, ChainMetadata, DbContext, DebugRpcClient,
-	EthRpcClient, FilterResults, Log, ReceiptExtractor, ReceiptProvider, SubscriptionItem,
-	SubscriptionKind, SubscriptionOptions, SubxtBlockInfoProvider, SyncLabel,
+	BlockHeader, BlockInfoProvider, ChainMetadata, DbContext, DebugRpcClient, EthRpcClient,
+	FilterResults, Log, ReceiptExtractor, ReceiptProvider, SubscriptionItem, SubscriptionKind,
+	SubscriptionOptions, SubxtBlockInfoProvider, SyncLabel,
 	cli::{self, CliCommand},
 	client::{
 		Client, GapFillRequest, SubscriptionGapQueue, connect,
@@ -29,6 +29,7 @@ use crate::{
 	},
 	example::TransactionBuilder,
 	subxt_client::{self, SrcChainConfig},
+	types,
 };
 use alloy_network::EthereumWallet;
 use alloy_primitives::{Address as AlloyAddress, B256, Bytes as AlloyBytes, U256 as AlloyU256};
@@ -60,7 +61,7 @@ use pallet_revive_types::runtime_api::{
 };
 use sp_runtime::BoundedVec;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use std::{sync::Arc, thread};
+use std::{collections::BTreeSet, sync::Arc, thread};
 use subxt::{
 	OnlineClient,
 	client::OnlineClientAtBlockImpl,
@@ -1410,10 +1411,10 @@ async fn test_subscribe_logs_with_address_filter() -> anyhow::Result<()> {
 	let contract_address = create1(&account.address(), nonce.try_into().unwrap());
 	assert_eq!(Some(contract_address), receipt.contract_address);
 
-	let options = SubscriptionOptions::LogsOptions {
-		address: Some(BoundedOneOrMany::One(contract_address)),
-		topics: None,
-	};
+	let options = SubscriptionOptions::LogsOptions(types::Filter {
+		address: BTreeSet::from([contract_address]),
+		..Default::default()
+	});
 	let mut sub = client.eth_subscribe(SubscriptionKind::Logs, Some(options)).await?;
 
 	// Act
@@ -1461,13 +1462,15 @@ async fn test_subscribe_logs_with_topic_filter() -> anyhow::Result<()> {
 	assert_eq!(Some(contract_address), receipt.contract_address);
 
 	let event_signature = H256(sp_io::hashing::keccak_256(b"Received(address,uint256)"));
-	let options = SubscriptionOptions::LogsOptions {
-		address: None,
-		topics: Some(
-			BoundedVec::try_from(vec![Some(BoundedOneOrMany::One(event_signature))])
-				.expect("Single topic filter is within bounds"),
-		),
-	};
+	let options = SubscriptionOptions::LogsOptions(types::Filter {
+		topics: BoundedVec::try_from(vec![
+			BTreeSet::from([event_signature])
+				.try_into()
+				.expect("Single topic set is within bounds"),
+		])
+		.expect("Single topic filter is within bounds"),
+		..Default::default()
+	});
 	let mut sub = client.eth_subscribe(SubscriptionKind::Logs, Some(options)).await?;
 
 	// Act
@@ -1593,10 +1596,10 @@ async fn test_subscribe_logs_address_filter_excludes_non_matching() -> anyhow::R
 	assert_eq!(Some(contract_b), receipt_b.contract_address);
 	assert_ne!(contract_a, contract_b, "The two contracts must have different addresses");
 
-	let options = SubscriptionOptions::LogsOptions {
-		address: Some(BoundedOneOrMany::One(contract_a)),
-		topics: None,
-	};
+	let options = SubscriptionOptions::LogsOptions(types::Filter {
+		address: BTreeSet::from([contract_a]),
+		..Default::default()
+	});
 	let mut sub = client.eth_subscribe(SubscriptionKind::Logs, Some(options)).await?;
 
 	// Act
@@ -1661,13 +1664,10 @@ async fn test_subscribe_logs_with_multiple_addresses_filter() -> anyhow::Result<
 	let contract_b = create1(&account.address(), nonce_b.try_into().unwrap());
 	assert_eq!(Some(contract_b), receipt_b.contract_address);
 
-	let options = SubscriptionOptions::LogsOptions {
-		address: Some(BoundedOneOrMany::Many(
-			BoundedVec::try_from(vec![contract_a, contract_b])
-				.expect("Two addresses is within bounds"),
-		)),
-		topics: None,
-	};
+	let options = SubscriptionOptions::LogsOptions(types::Filter {
+		address: BTreeSet::from([contract_a, contract_b]),
+		..Default::default()
+	});
 	let mut sub = client.eth_subscribe(SubscriptionKind::Logs, Some(options)).await?;
 
 	// Act
@@ -1786,10 +1786,10 @@ async fn test_subscribe_with_invalid_params_rejected() -> anyhow::Result<()> {
 	// Arrange
 	let client = Arc::new(SharedResources::client().await);
 
-	let options = SubscriptionOptions::LogsOptions {
-		address: Some(BoundedOneOrMany::One(Account::default().address())),
-		topics: None,
-	};
+	let options = SubscriptionOptions::LogsOptions(types::Filter {
+		address: BTreeSet::from([Account::default().address()]),
+		..Default::default()
+	});
 
 	// Act
 	let result = client.eth_subscribe(SubscriptionKind::NewBlockHeaders, Some(options)).await;

--- a/substrate/frame/revive/rpc/src/tests.rs
+++ b/substrate/frame/revive/rpc/src/tests.rs
@@ -19,7 +19,7 @@
 //! [evm-test-suite](https://github.com/paritytech/evm-test-suite) repository.
 
 use crate::{
-	BlockHeader, BlockInfoProvider, ChainMetadata, DbContext, DebugRpcClient, EthRpcClient,
+	BlockHeader, BlockInfoProvider, ChainMetadata, DbContext, DebugRpcClient, EthRpcClient, Filter,
 	FilterResults, Log, ReceiptExtractor, ReceiptProvider, SubscriptionItem, SubscriptionKind,
 	SubscriptionOptions, SubxtBlockInfoProvider, SyncLabel,
 	cli::{self, CliCommand},
@@ -29,13 +29,12 @@ use crate::{
 	},
 	example::TransactionBuilder,
 	subxt_client::{self, SrcChainConfig},
-	types,
 };
 use alloy_network::EthereumWallet;
 use alloy_primitives::{Address as AlloyAddress, B256, Bytes as AlloyBytes, U256 as AlloyU256};
 use alloy_provider::{Provider, ProviderBuilder, ext::DebugApi as _};
 use alloy_rpc_types::{
-	BlockId, BlockNumberOrTag, Filter, TransactionRequest,
+	BlockId, BlockNumberOrTag, TransactionRequest,
 	state::{AccountOverride, StateOverride},
 };
 use alloy_signer_local::PrivateKeySigner;
@@ -1026,23 +1025,34 @@ async fn test_get_logs_with_block_tags_works() -> anyhow::Result<()> {
 	};
 	let has_emitted_log = |logs: &[Log]| logs.iter().any(|log| log.block_number == emit_block);
 
-	// `<tag>..latest` range should span the emitted log.
+	// `<tag>..latest` range should span the emitted log, except `pending` which is rejected.
 	for from in BLOCK_TAGS {
+		let result = client
+			.get_logs(Some(Filter::new().from_block(from).to_block(BlockNumberOrTag::Latest)))
+			.await;
+		if matches!(from, BlockNumberOrTag::Pending) {
+			assert!(result.is_err(), "pending..latest should be rejected");
+			continue;
+		}
 		let logs = logs_of(
-			client
-				.get_logs(Some(Filter::new().from_block(from).to_block(BlockNumberOrTag::Latest)))
-				.await
+			result
 				.map_err(|err| anyhow::anyhow!("eth_getLogs {from:?}..latest failed: {err:?}"))?,
 		);
 		assert!(has_emitted_log(&logs), "{from:?}..latest should include the emitted log");
 	}
 
-	// `earliest..<tag>` range should span the emitted log for every tag except `earliest`.
+	// `earliest..<tag>` range should span the emitted log for every tag except `earliest`,
+	// while `pending` is rejected.
 	for to in BLOCK_TAGS {
+		let result = client
+			.get_logs(Some(Filter::new().from_block(BlockNumberOrTag::Earliest).to_block(to)))
+			.await;
+		if matches!(to, BlockNumberOrTag::Pending) {
+			assert!(result.is_err(), "earliest..pending should be rejected");
+			continue;
+		}
 		let logs = logs_of(
-			client
-				.get_logs(Some(Filter::new().from_block(BlockNumberOrTag::Earliest).to_block(to)))
-				.await
+			result
 				.map_err(|err| anyhow::anyhow!("eth_getLogs earliest..{to:?} failed: {err:?}"))?,
 		);
 		if matches!(to, BlockNumberOrTag::Earliest) {
@@ -1368,7 +1378,7 @@ async fn test_subscribe_logs() -> anyhow::Result<()> {
 		other => panic!("Expected Log, got: {other:?}"),
 	};
 
-	let filter = Filter::new().at_block_hash(B256::from(call_receipt.block_hash.0));
+	let filter = Filter::new().at_block_hash(call_receipt.block_hash);
 	let rpc_logs = client.get_logs(Some(filter)).await?;
 	let rpc_logs: Vec<Log> = match rpc_logs {
 		FilterResults::Logs(logs) => logs,
@@ -1411,7 +1421,7 @@ async fn test_subscribe_logs_with_address_filter() -> anyhow::Result<()> {
 	let contract_address = create1(&account.address(), nonce.try_into().unwrap());
 	assert_eq!(Some(contract_address), receipt.contract_address);
 
-	let options = SubscriptionOptions::LogsOptions(types::Filter {
+	let options = SubscriptionOptions::LogsOptions(Filter {
 		address: BTreeSet::from([contract_address]),
 		..Default::default()
 	});
@@ -1462,7 +1472,7 @@ async fn test_subscribe_logs_with_topic_filter() -> anyhow::Result<()> {
 	assert_eq!(Some(contract_address), receipt.contract_address);
 
 	let event_signature = H256(sp_io::hashing::keccak_256(b"Received(address,uint256)"));
-	let options = SubscriptionOptions::LogsOptions(types::Filter {
+	let options = SubscriptionOptions::LogsOptions(Filter {
 		topics: BoundedVec::try_from(vec![
 			BTreeSet::from([event_signature])
 				.try_into()
@@ -1596,7 +1606,7 @@ async fn test_subscribe_logs_address_filter_excludes_non_matching() -> anyhow::R
 	assert_eq!(Some(contract_b), receipt_b.contract_address);
 	assert_ne!(contract_a, contract_b, "The two contracts must have different addresses");
 
-	let options = SubscriptionOptions::LogsOptions(types::Filter {
+	let options = SubscriptionOptions::LogsOptions(Filter {
 		address: BTreeSet::from([contract_a]),
 		..Default::default()
 	});
@@ -1664,7 +1674,7 @@ async fn test_subscribe_logs_with_multiple_addresses_filter() -> anyhow::Result<
 	let contract_b = create1(&account.address(), nonce_b.try_into().unwrap());
 	assert_eq!(Some(contract_b), receipt_b.contract_address);
 
-	let options = SubscriptionOptions::LogsOptions(types::Filter {
+	let options = SubscriptionOptions::LogsOptions(Filter {
 		address: BTreeSet::from([contract_a, contract_b]),
 		..Default::default()
 	});
@@ -1786,7 +1796,7 @@ async fn test_subscribe_with_invalid_params_rejected() -> anyhow::Result<()> {
 	// Arrange
 	let client = Arc::new(SharedResources::client().await);
 
-	let options = SubscriptionOptions::LogsOptions(types::Filter {
+	let options = SubscriptionOptions::LogsOptions(Filter {
 		address: BTreeSet::from([Account::default().address()]),
 		..Default::default()
 	});

--- a/substrate/frame/revive/rpc/src/tests.rs
+++ b/substrate/frame/revive/rpc/src/tests.rs
@@ -387,6 +387,7 @@ async fn run_all_eth_rpc_tests_inner() -> anyhow::Result<()> {
 		test_block_hash_for_tag_with_block_tags_works,
 		test_earliest_block_tag,
 		test_get_logs_with_block_tags_works,
+		unknown_block_hash_returns_a_log_query_error,
 		test_multiple_transactions_in_block,
 		test_mixed_evm_substrate_transactions,
 		test_runtime_pallets_address_upload_code,
@@ -1066,6 +1067,36 @@ async fn test_get_logs_with_block_tags_works() -> anyhow::Result<()> {
 		}
 	}
 
+	Ok(())
+}
+
+async fn unknown_block_hash_returns_a_log_query_error() -> anyhow::Result<()> {
+	// Arrange
+	let client = Arc::new(SharedResources::client().await);
+	let ethan = Account::from(subxt_signer::eth::dev::ethan());
+	let receipt = TransactionBuilder::new(client.clone())
+		.to(ethan.address())
+		.value(U256::from(1))
+		.send()
+		.await?
+		.wait_for_receipt()
+		.await?;
+
+	// Act
+	let known_block_logs =
+		client.get_logs(Some(Filter::new().at_block_hash(receipt.block_hash))).await?;
+	let error = client
+		.get_logs(Some(Filter::new().at_block_hash(H256::repeat_byte(0xff))))
+		.await
+		.unwrap_err();
+
+	// Assert
+	assert_eq!(known_block_logs, FilterResults::default());
+	let ClientError::Call(error) = error else {
+		panic!("Expected a JSON-RPC error, got {error:?}");
+	};
+	assert_eq!(error.code(), jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE);
+	assert_eq!(error.message(), "Failed to filter logs: unknown block");
 	Ok(())
 }
 

--- a/substrate/frame/revive/rpc/src/tests.rs
+++ b/substrate/frame/revive/rpc/src/tests.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 use alloy_network::EthereumWallet;
 use alloy_primitives::{Address as AlloyAddress, B256, Bytes as AlloyBytes, U256 as AlloyU256};
-use alloy_provider::{Provider, ProviderBuilder, ext::DebugApi as _};
+use alloy_provider::{Provider, ProviderBuilder, WsConnect, ext::DebugApi as _};
 use alloy_rpc_types::{
 	BlockId, BlockNumberOrTag, TransactionRequest,
 	state::{AccountOverride, StateOverride},
@@ -390,7 +390,7 @@ async fn run_all_eth_rpc_tests_inner() -> anyhow::Result<()> {
 		test_multiple_transactions_in_block,
 		test_mixed_evm_substrate_transactions,
 		test_runtime_pallets_address_upload_code,
-		test_subscribe_new_heads,
+		test_new_heads_subscription_delivers_matching_header_via_alloy,
 		test_subscribe_new_heads_multiple_blocks,
 		test_subscribe_logs,
 		test_subscribe_logs_with_address_filter,
@@ -1288,16 +1288,17 @@ async fn test_runtime_pallets_address_upload_code() -> anyhow::Result<()> {
 	Ok(())
 }
 
-/// Verify that subscribing to `newHeads` delivers a block header matching the
-/// corresponding block fetched via `eth_getBlockByNumber` after a transaction
-/// triggers a new block.
-async fn test_subscribe_new_heads() -> anyhow::Result<()> {
+/// Verify that Alloy can subscribe to `newHeads` and receive the transaction's block header.
+async fn test_new_heads_subscription_delivers_matching_header_via_alloy() -> anyhow::Result<()> {
 	// Arrange
 	let client = Arc::new(SharedResources::client().await);
+	let provider = ProviderBuilder::new()
+		.connect_ws(WsConnect::new("ws://localhost:45788"))
+		.await?;
 	let ethan = Account::from(subxt_signer::eth::dev::ethan());
 	let value = U256::from(1_000_000_000_000u128);
 
-	let mut sub = client.eth_subscribe(SubscriptionKind::NewBlockHeaders, None).await?;
+	let mut sub = provider.subscribe_blocks().await?;
 
 	// Act
 	let tx = TransactionBuilder::new(client.clone())
@@ -1305,29 +1306,25 @@ async fn test_subscribe_new_heads() -> anyhow::Result<()> {
 		.to(ethan.address())
 		.send()
 		.await?;
-	tx.wait_for_receipt().await?;
+	let receipt = tx.wait_for_receipt().await?;
 
-	let notification = tokio::time::timeout(tokio::time::Duration::from_secs(10), sub.next())
+	let header = tokio::time::timeout(tokio::time::Duration::from_secs(10), sub.recv_result())
 		.await
 		.expect("Timed out waiting for newHeads notification")
 		.expect("Subscription stream ended unexpectedly")
-		.expect("Subscription returned an error");
-
-	let header = match notification {
-		SubscriptionItem::BlockHeader(header) => header,
-		other => panic!("Expected BlockHeader, got: {other:?}"),
-	};
+		.expect("Alloy should deserialize the newHeads notification");
 
 	let block = client
-		.get_block_by_number(BlockNumberOrTag::Number(header.number.as_u64()), false)
+		.get_block_by_number(BlockNumberOrTag::Number(header.number), false)
 		.await?
 		.expect("Block should exist");
 
 	// Assert
-	assert!(header.number > U256::zero(), "Block number should be > 0");
-	assert_ne!(header.hash, H256::zero(), "Block hash should not be zero");
-	assert_ne!(header.parent_hash, H256::zero(), "Parent hash should not be zero");
+	assert_eq!(U256::from(header.number), receipt.block_number);
+	assert_eq!(H256(header.hash.0), receipt.block_hash);
+	assert_ne!(header.parent_hash, B256::ZERO, "Parent hash should not be zero");
 
+	let header = serde_json::from_value::<BlockHeader>(serde_json::to_value(header)?)?;
 	let expected_header = BlockHeader::from(block);
 	assert_eq!(
 		header, expected_header,

--- a/substrate/frame/revive/rpc/src/tests.rs
+++ b/substrate/frame/revive/rpc/src/tests.rs
@@ -393,6 +393,7 @@ async fn run_all_eth_rpc_tests_inner() -> anyhow::Result<()> {
 		test_new_heads_subscription_delivers_matching_header_via_alloy,
 		test_subscribe_new_heads_multiple_blocks,
 		test_subscribe_logs,
+		test_log_subscription_respects_inclusive_block_bounds,
 		test_subscribe_logs_with_address_filter,
 		test_subscribe_logs_with_topic_filter,
 		test_subscribe_logs_address_filter_excludes_non_matching,
@@ -1398,6 +1399,74 @@ async fn test_subscribe_logs() -> anyhow::Result<()> {
 	assert!(rpc_logs.contains(&log), "Subscription log should match eth_getLogs result");
 
 	drop(sub);
+	Ok(())
+}
+
+async fn test_log_subscription_respects_inclusive_block_bounds() -> anyhow::Result<()> {
+	// Arrange
+	let client = Arc::new(SharedResources::client().await);
+	let (bytes, _) = pallet_revive_fixtures::compile_module_with_type(
+		"SimpleReceiver",
+		pallet_revive_fixtures::FixtureType::Solc,
+	)?;
+	let deployment = TransactionBuilder::new(client.clone()).input(bytes.to_vec()).send().await?;
+	let deployment_receipt = deployment.wait_for_receipt().await?;
+	let contract_address = deployment_receipt.contract_address.expect("Contract was deployed");
+	let from_block = deployment_receipt.block_number.as_u64() + 2;
+	let to_block = from_block + 1;
+	let filter = Filter::new()
+		.from_block(from_block)
+		.to_block(to_block)
+		.address([contract_address]);
+	let mut sub = client
+		.eth_subscribe(SubscriptionKind::Logs, Some(SubscriptionOptions::LogsOptions(filter)))
+		.await?;
+
+	// Act
+	let mut receipts = Vec::new();
+	for _ in 0..4 {
+		let tx = TransactionBuilder::new(client.clone())
+			.to(contract_address)
+			.value(U256::from(1_000_000_000_000u128))
+			.send()
+			.await?;
+		receipts.push(tx.wait_for_receipt().await?);
+	}
+	let logs = tokio::time::timeout(tokio::time::Duration::from_secs(10), async {
+		let mut logs = Vec::new();
+		for _ in 0..2 {
+			let notification = sub.next().await.expect("Subscription ended before both bounds")?;
+			match notification {
+				SubscriptionItem::Log(log) => logs.push(log),
+				other => panic!("Expected Log, got: {other:?}"),
+			}
+		}
+		anyhow::Ok(logs)
+	})
+	.await
+	.expect("Timed out waiting for logs at both window bounds")?;
+	let extra_notification =
+		tokio::time::timeout(tokio::time::Duration::from_secs(1), sub.next()).await;
+
+	// Assert
+	assert_eq!(
+		receipts.iter().map(|receipt| receipt.block_number).collect::<Vec<_>>(),
+		[from_block - 1, from_block, to_block, to_block + 1].map(U256::from),
+	);
+	for receipt in &receipts {
+		assert_eq!(receipt.logs.len(), 1, "Each transaction must emit a log to exercise its bound");
+	}
+	assert_eq!(
+		logs,
+		receipts[1..=2]
+			.iter()
+			.flat_map(|receipt| receipt.logs.iter().cloned())
+			.collect::<Vec<_>>(),
+	);
+	assert!(
+		matches!(extra_notification, Err(_) | Ok(None)),
+		"Unexpected notification outside the block window: {extra_notification:?}",
+	);
 	Ok(())
 }
 

--- a/substrate/frame/revive/rpc/src/tests.rs
+++ b/substrate/frame/revive/rpc/src/tests.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 use alloy_network::EthereumWallet;
 use alloy_primitives::{Address as AlloyAddress, B256, Bytes as AlloyBytes, U256 as AlloyU256};
-use alloy_provider::{Provider, ProviderBuilder, WsConnect, ext::DebugApi as _};
+use alloy_provider::{Provider, ProviderBuilder, ext::DebugApi as _};
 use alloy_rpc_types::{
 	BlockId, BlockNumberOrTag, TransactionRequest,
 	state::{AccountOverride, StateOverride},
@@ -390,7 +390,7 @@ async fn run_all_eth_rpc_tests_inner() -> anyhow::Result<()> {
 		test_multiple_transactions_in_block,
 		test_mixed_evm_substrate_transactions,
 		test_runtime_pallets_address_upload_code,
-		test_new_heads_subscription_delivers_matching_header_via_alloy,
+		test_subscribe_new_heads,
 		test_subscribe_new_heads_multiple_blocks,
 		test_subscribe_logs,
 		test_log_subscription_respects_inclusive_block_bounds,
@@ -1289,17 +1289,16 @@ async fn test_runtime_pallets_address_upload_code() -> anyhow::Result<()> {
 	Ok(())
 }
 
-/// Verify that Alloy can subscribe to `newHeads` and receive the transaction's block header.
-async fn test_new_heads_subscription_delivers_matching_header_via_alloy() -> anyhow::Result<()> {
+/// Verify that subscribing to `newHeads` delivers a block header matching the
+/// corresponding block fetched via `eth_getBlockByNumber` after a transaction
+/// triggers a new block.
+async fn test_subscribe_new_heads() -> anyhow::Result<()> {
 	// Arrange
 	let client = Arc::new(SharedResources::client().await);
-	let provider = ProviderBuilder::new()
-		.connect_ws(WsConnect::new("ws://localhost:45788"))
-		.await?;
 	let ethan = Account::from(subxt_signer::eth::dev::ethan());
 	let value = U256::from(1_000_000_000_000u128);
 
-	let mut sub = provider.subscribe_blocks().await?;
+	let mut sub = client.eth_subscribe(SubscriptionKind::NewBlockHeaders, None).await?;
 
 	// Act
 	let tx = TransactionBuilder::new(client.clone())
@@ -1307,25 +1306,29 @@ async fn test_new_heads_subscription_delivers_matching_header_via_alloy() -> any
 		.to(ethan.address())
 		.send()
 		.await?;
-	let receipt = tx.wait_for_receipt().await?;
+	tx.wait_for_receipt().await?;
 
-	let header = tokio::time::timeout(tokio::time::Duration::from_secs(10), sub.recv_result())
+	let notification = tokio::time::timeout(tokio::time::Duration::from_secs(10), sub.next())
 		.await
 		.expect("Timed out waiting for newHeads notification")
 		.expect("Subscription stream ended unexpectedly")
-		.expect("Alloy should deserialize the newHeads notification");
+		.expect("Subscription returned an error");
+
+	let header = match notification {
+		SubscriptionItem::BlockHeader(header) => header,
+		other => panic!("Expected BlockHeader, got: {other:?}"),
+	};
 
 	let block = client
-		.get_block_by_number(BlockNumberOrTag::Number(header.number), false)
+		.get_block_by_number(BlockNumberOrTag::Number(header.number.as_u64()), false)
 		.await?
 		.expect("Block should exist");
 
 	// Assert
-	assert_eq!(U256::from(header.number), receipt.block_number);
-	assert_eq!(H256(header.hash.0), receipt.block_hash);
-	assert_ne!(header.parent_hash, B256::ZERO, "Parent hash should not be zero");
+	assert!(header.number > U256::zero(), "Block number should be > 0");
+	assert_ne!(header.hash, H256::zero(), "Block hash should not be zero");
+	assert_ne!(header.parent_hash, H256::zero(), "Parent hash should not be zero");
 
-	let header = serde_json::from_value::<BlockHeader>(serde_json::to_value(header)?)?;
 	let expected_header = BlockHeader::from(block);
 	assert_eq!(
 		header, expected_header,

--- a/substrate/frame/revive/rpc/src/tests.rs
+++ b/substrate/frame/revive/rpc/src/tests.rs
@@ -646,8 +646,8 @@ async fn test_receipt_mixed_revert_and_logs_same_block() -> anyhow::Result<()> {
 	}
 
 	// Verify log data values
-	let ping_data = &emit_receipt.logs[0].data.as_ref().unwrap().0;
-	let pong_data = &emit_receipt.logs[1].data.as_ref().unwrap().0;
+	let ping_data = &emit_receipt.logs[0].data.0;
+	let pong_data = &emit_receipt.logs[1].data.0;
 	let ping = Ping::abi_decode_data(ping_data).expect("decode Ping data");
 	let pong = Pong::abi_decode_data(pong_data).expect("decode Pong data");
 	assert_eq!(ping.0, 1, "Ping value should be 1");

--- a/substrate/frame/revive/rpc/src/tests.rs
+++ b/substrate/frame/revive/rpc/src/tests.rs
@@ -1419,7 +1419,9 @@ async fn test_subscribe_logs_with_address_filter() -> anyhow::Result<()> {
 	assert_eq!(Some(contract_address), receipt.contract_address);
 
 	let options = SubscriptionOptions::LogsOptions(Filter {
-		address: BTreeSet::from([contract_address]),
+		addresses: BTreeSet::from([contract_address])
+			.try_into()
+			.expect("Single address is within bounds"),
 		..Default::default()
 	});
 	let mut sub = client.eth_subscribe(SubscriptionKind::Logs, Some(options)).await?;
@@ -1604,7 +1606,9 @@ async fn test_subscribe_logs_address_filter_excludes_non_matching() -> anyhow::R
 	assert_ne!(contract_a, contract_b, "The two contracts must have different addresses");
 
 	let options = SubscriptionOptions::LogsOptions(Filter {
-		address: BTreeSet::from([contract_a]),
+		addresses: BTreeSet::from([contract_a])
+			.try_into()
+			.expect("Single address is within bounds"),
 		..Default::default()
 	});
 	let mut sub = client.eth_subscribe(SubscriptionKind::Logs, Some(options)).await?;
@@ -1672,7 +1676,9 @@ async fn test_subscribe_logs_with_multiple_addresses_filter() -> anyhow::Result<
 	assert_eq!(Some(contract_b), receipt_b.contract_address);
 
 	let options = SubscriptionOptions::LogsOptions(Filter {
-		address: BTreeSet::from([contract_a, contract_b]),
+		addresses: BTreeSet::from([contract_a, contract_b])
+			.try_into()
+			.expect("Two addresses are within bounds"),
 		..Default::default()
 	});
 	let mut sub = client.eth_subscribe(SubscriptionKind::Logs, Some(options)).await?;
@@ -1794,7 +1800,9 @@ async fn test_subscribe_with_invalid_params_rejected() -> anyhow::Result<()> {
 	let client = Arc::new(SharedResources::client().await);
 
 	let options = SubscriptionOptions::LogsOptions(Filter {
-		address: BTreeSet::from([Account::default().address()]),
+		addresses: BTreeSet::from([Account::default().address()])
+			.try_into()
+			.expect("Single address is within bounds"),
 		..Default::default()
 	});
 

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -92,10 +92,60 @@ pub enum FilterBlockOption {
 	Range { from_block: BlockNumberOrTag, to_block: BlockNumberOrTag },
 }
 
+impl FilterBlockOption {
+	pub fn is_valid(&self) -> bool {
+		match self {
+			Self::AtBlock { .. } => true,
+			Self::Range {
+				from_block: BlockNumberOrTag::Latest,
+				to_block: BlockNumberOrTag::Latest,
+			} => true,
+			Self::Range { from_block, to_block: BlockNumberOrTag::Latest } => {
+				Self::concrete_bound(from_block).is_some()
+			},
+			Self::Range { from_block, to_block } => matches!(
+				(Self::concrete_bound(from_block), Self::concrete_bound(to_block)),
+				(Some(from), Some(to)) if from <= to
+			),
+		}
+	}
+
+	pub fn window(&self, block_number: U256) -> LogWindow {
+		match self {
+			Self::AtBlock { .. } => LogWindow::Open,
+			Self::Range { from_block, to_block } => {
+				match (Self::concrete_bound(from_block), Self::concrete_bound(to_block)) {
+					(_, Some(to)) if block_number > U256::from(to) => LogWindow::Closed,
+					(Some(from), _) if block_number < U256::from(from) => LogWindow::NotYetOpen,
+					_ => LogWindow::Open,
+				}
+			},
+		}
+	}
+
+	fn concrete_bound(bound: &BlockNumberOrTag) -> Option<u64> {
+		match bound {
+			BlockNumberOrTag::Earliest => Some(0),
+			BlockNumberOrTag::Number(number) => Some(*number),
+			BlockNumberOrTag::Latest |
+			BlockNumberOrTag::Finalized |
+			BlockNumberOrTag::Safe |
+			BlockNumberOrTag::Pending => None,
+		}
+	}
+}
+
 impl Default for FilterBlockOption {
 	fn default() -> Self {
 		Self::Range { from_block: BlockNumberOrTag::Latest, to_block: BlockNumberOrTag::Latest }
 	}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogWindow {
+	NotYetOpen,
+	Open,
+	Closed,
 }
 
 #[serde_as]
@@ -191,32 +241,28 @@ mod tests {
 	}
 
 	#[test]
-	fn null_alternate_block_selectors_deserialize_as_the_non_null_selector() {
+	fn block_hash_conflicts_only_with_non_null_range_bounds() {
 		// Arrange
 		let block_hash = BlockHash::repeat_byte(0xab);
-		let at_block = serde_json::json!({
+		let with_null_bounds = serde_json::json!({
 			"blockHash": block_hash,
 			"fromBlock": null,
 			"toBlock": null,
 		});
-		let range = serde_json::json!({
-			"blockHash": null,
-			"fromBlock": "earliest",
-			"toBlock": null,
+		let with_non_null_bound = serde_json::json!({
+			"blockHash": block_hash,
+			"fromBlock": "latest",
 		});
 
 		// Act
-		let at_block = serde_json::from_value::<Filter>(at_block).unwrap();
-		let range = serde_json::from_value::<Filter>(range).unwrap();
+		let with_null_bounds = serde_json::from_value::<Filter>(with_null_bounds).unwrap();
+		let error = serde_json::from_value::<Filter>(with_non_null_bound).unwrap_err();
 
 		// Assert
-		assert_eq!(at_block.block_option, FilterBlockOption::AtBlock { block_hash });
+		assert_eq!(with_null_bounds.block_option, FilterBlockOption::AtBlock { block_hash });
 		assert_eq!(
-			range.block_option,
-			FilterBlockOption::Range {
-				from_block: BlockNumberOrTag::Earliest,
-				to_block: BlockNumberOrTag::Latest,
-			},
+			error.to_string(),
+			"cannot specify both BlockHash and FromBlock/ToBlock, choose one or the other",
 		);
 	}
 
@@ -240,24 +286,6 @@ mod tests {
 	}
 
 	#[test]
-	fn non_null_block_hash_and_range_bound_are_rejected() {
-		// Arrange
-		let representation = serde_json::json!({
-			"blockHash": BlockHash::repeat_byte(0xab),
-			"fromBlock": "latest",
-		});
-
-		// Act
-		let error = serde_json::from_value::<Filter>(representation).unwrap_err();
-
-		// Assert
-		assert_eq!(
-			error.to_string(),
-			"cannot specify both BlockHash and FromBlock/ToBlock, choose one or the other",
-		);
-	}
-
-	#[test]
 	fn malformed_block_hash_cannot_fall_through_to_a_range_filter() {
 		// Arrange
 		let representation = serde_json::json!({ "blockHash": "invalid" });
@@ -267,27 +295,6 @@ mod tests {
 
 		// Assert
 		assert_eq!(error.to_string(), "odd number of digits");
-	}
-
-	#[test]
-	fn unrelated_fields_are_ignored_when_deserializing_a_block_range() {
-		// Arrange
-		let representation = serde_json::json!({
-			"fromBlock": "earliest",
-			"unrelated": true,
-		});
-
-		// Act
-		let filter = serde_json::from_value::<Filter>(representation).unwrap();
-
-		// Assert
-		assert_eq!(
-			filter.block_option,
-			FilterBlockOption::Range {
-				from_block: BlockNumberOrTag::Earliest,
-				to_block: BlockNumberOrTag::Latest,
-			},
-		);
 	}
 
 	#[test]
@@ -327,18 +334,6 @@ mod tests {
 	}
 
 	#[test]
-	fn null_address_elements_are_rejected() {
-		// Arrange
-		let representation = serde_json::json!({ "address": [H160::repeat_byte(0xab), null] });
-
-		// Act
-		let result = serde_json::from_value::<Filter>(representation);
-
-		// Assert
-		assert!(result.is_err());
-	}
-
-	#[test]
 	fn null_topic_alternative_makes_the_position_a_wildcard() {
 		// Arrange
 		let representation = serde_json::json!({
@@ -353,36 +348,13 @@ mod tests {
 	}
 
 	#[test]
-	fn trailing_wildcard_preserves_third_topic_position() {
-		// Arrange
-		let event_signature = H256::repeat_byte(0xab);
-		let first_set_topic = H256::repeat_byte(0xcd);
-		let second_set_topic = H256::repeat_byte(0xef);
-		let representation = serde_json::json!({
-			"topics": [event_signature, [first_set_topic, second_set_topic], null],
-		});
-
-		// Act
-		let filter = serde_json::from_value::<Filter>(representation).unwrap();
-
-		// Assert
-		assert_eq!(
-			filter.topics,
-			vec![
-				bounded_set([event_signature]),
-				bounded_set([first_set_topic, second_set_topic]),
-				BoundedBTreeSet::new(),
-			],
-		);
-	}
-
-	#[test]
 	fn trailing_empty_array_position_requires_the_log_to_have_a_third_topic() {
 		// Arrange
 		let event_signature = H256::repeat_byte(0xab);
 		let second_topic = H256::repeat_byte(0xcd);
+		let alternative_topic = H256::repeat_byte(0x11);
 		let filter = serde_json::from_value::<Filter>(serde_json::json!({
-			"topics": [event_signature, [second_topic], []],
+			"topics": [event_signature, [second_topic, alternative_topic], []],
 		}))
 		.unwrap();
 		let two_topic_log =
@@ -401,59 +373,11 @@ mod tests {
 			filter.topics,
 			vec![
 				bounded_set([event_signature]),
-				bounded_set([second_topic]),
+				bounded_set([second_topic, alternative_topic]),
 				BoundedBTreeSet::new(),
 			],
 		);
 		assert!(!two_topic_log_matches);
 		assert!(three_topic_log_matches);
-	}
-
-	#[test]
-	fn logs_with_fewer_topics_than_filter_positions_do_not_match() {
-		// Arrange
-		let event_signature = H256::repeat_byte(0xab);
-		let filter = serde_json::from_value::<Filter>(serde_json::json!({
-			"topics": [event_signature, null],
-		}))
-		.unwrap();
-		let short_log = Log { topics: vec![event_signature], ..Default::default() };
-		let matching_log =
-			Log { topics: vec![event_signature, H256::repeat_byte(0xcd)], ..Default::default() };
-
-		// Act
-		let short_log_matches = filter.matches(&short_log);
-		let matching_log_matches = filter.matches(&matching_log);
-
-		// Assert
-		assert!(!short_log_matches);
-		assert!(matching_log_matches);
-	}
-
-	#[test]
-	fn single_alternatives_serialize_as_scalars_and_wildcards_as_empty_arrays() {
-		// Arrange
-		let address = H160::repeat_byte(0xab);
-		let event_signature = H256::repeat_byte(0xcd);
-		let other_topic = H256::repeat_byte(0xef);
-		let filter = serde_json::from_value::<Filter>(serde_json::json!({
-			"address": [address],
-			"topics": [event_signature, null, [event_signature, other_topic]],
-		}))
-		.unwrap();
-
-		// Act
-		let serialized = serde_json::to_value(&filter).unwrap();
-
-		// Assert
-		assert_eq!(
-			serialized,
-			serde_json::json!({
-				"fromBlock": "latest",
-				"toBlock": "latest",
-				"address": address,
-				"topics": [event_signature, [], [event_signature, other_topic]],
-			}),
-		);
 	}
 }

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -16,7 +16,13 @@
 // limitations under the License.
 
 use crate::*;
+use alloy_primitives::BlockHash;
 use serde::{Deserialize, Serialize};
+use serde_with::{DefaultOnNull, OneOrMany, serde_as};
+use sp_core::ConstU32;
+use sp_runtime::{BoundedBTreeSet, BoundedVec};
+use std::collections::BTreeSet;
+use thiserror::Error;
 
 /// Filter results
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -59,4 +65,389 @@ pub struct Log {
 	pub transaction_hash: H256,
 	/// transaction index
 	pub transaction_index: U256,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "FilterRepr", into = "FilterRepr")]
+pub struct Filter {
+	pub block_option: FilterBlockOption,
+	pub address: BTreeSet<H160>,
+	pub topics: BoundedVec<BoundedBTreeSet<H256, ConstU32<1000>>, ConstU32<4>>,
+}
+
+impl Filter {
+	pub fn matches(&self, log: &Log) -> bool {
+		(self.address.is_empty() || self.address.contains(&log.address)) &&
+			self.topics.len() <= log.topics.len() &&
+			self.topics
+				.iter()
+				.zip(&log.topics)
+				.all(|(set, topic)| set.is_empty() || set.contains(topic))
+	}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilterBlockOption {
+	AtBlock { block_hash: BlockHash },
+	Range { from_block: BlockNumberOrTag, to_block: BlockNumberOrTag },
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FilterRepr {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	block_hash: Option<BlockHash>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	from_block: Option<BlockNumberOrTag>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	to_block: Option<BlockNumberOrTag>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde_as(as = "DefaultOnNull<OneOrMany<_>>")]
+	address: Vec<H160>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde_as(as = "DefaultOnNull<Vec<DefaultOnNull<OneOrMany<_>>>>")]
+	topics: Vec<Vec<Option<H256>>>,
+}
+
+impl TryFrom<FilterRepr> for Filter {
+	type Error = FilterError;
+
+	fn try_from(repr: FilterRepr) -> Result<Self, Self::Error> {
+		let FilterRepr { block_hash, from_block, to_block, address, topics } = repr;
+
+		let block_option = match (block_hash, from_block, to_block) {
+			(Some(block_hash), None, None) => FilterBlockOption::AtBlock { block_hash },
+			(Some(_), _, _) => return Err(FilterError::BlockHashCombinedWithRange),
+			(None, from_block, to_block) => FilterBlockOption::Range {
+				from_block: from_block.unwrap_or(BlockNumberOrTag::Latest),
+				to_block: to_block.unwrap_or(BlockNumberOrTag::Latest),
+			},
+		};
+
+		let topics = topics
+			.into_iter()
+			.map(|alternatives| {
+				// A `null` alternative makes the whole position a wildcard, mirroring geth.
+				alternatives
+					.into_iter()
+					.collect::<Option<BTreeSet<_>>>()
+					.unwrap_or_default()
+					.try_into()
+					.map_err(|_| FilterError::ExceedMaxTopics)
+			})
+			.collect::<Result<Vec<_>, _>>()?;
+		let topics = BoundedVec::try_from(topics).map_err(|_| FilterError::ExceedMaxTopics)?;
+
+		Ok(Self { block_option, address: address.into_iter().collect(), topics })
+	}
+}
+
+impl From<Filter> for FilterRepr {
+	fn from(filter: Filter) -> Self {
+		let (block_hash, from_block, to_block) = match filter.block_option {
+			FilterBlockOption::AtBlock { block_hash } => (Some(block_hash), None, None),
+			FilterBlockOption::Range { from_block, to_block } => {
+				(None, Some(from_block), Some(to_block))
+			},
+		};
+
+		Self {
+			block_hash,
+			from_block,
+			to_block,
+			address: filter.address.into_iter().collect(),
+			topics: filter
+				.topics
+				.into_iter()
+				.map(|position| position.into_iter().map(Some).collect())
+				.collect(),
+		}
+	}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum FilterError {
+	#[error("cannot specify both BlockHash and FromBlock/ToBlock, choose one or the other")]
+	BlockHashCombinedWithRange,
+	#[error("exceed max topics")]
+	ExceedMaxTopics,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn bounded_set(
+		topics: impl IntoIterator<Item = H256>,
+	) -> BoundedBTreeSet<H256, ConstU32<1000>> {
+		BoundedBTreeSet::try_from(topics.into_iter().collect::<BTreeSet<_>>()).unwrap()
+	}
+
+	#[test]
+	fn null_alternate_block_selectors_deserialize_as_the_non_null_selector() {
+		// Arrange
+		let block_hash = BlockHash::repeat_byte(0xab);
+		let at_block = serde_json::json!({
+			"blockHash": block_hash,
+			"fromBlock": null,
+			"toBlock": null,
+		});
+		let range = serde_json::json!({
+			"blockHash": null,
+			"fromBlock": "earliest",
+			"toBlock": null,
+		});
+
+		// Act
+		let at_block = serde_json::from_value::<Filter>(at_block).unwrap();
+		let range = serde_json::from_value::<Filter>(range).unwrap();
+
+		// Assert
+		assert_eq!(at_block.block_option, FilterBlockOption::AtBlock { block_hash });
+		assert_eq!(
+			range.block_option,
+			FilterBlockOption::Range {
+				from_block: BlockNumberOrTag::Earliest,
+				to_block: BlockNumberOrTag::Latest,
+			},
+		);
+	}
+
+	#[test]
+	fn missing_and_null_range_bounds_default_to_the_latest_block() {
+		// Arrange
+		let missing = serde_json::json!({});
+		let null = serde_json::json!({ "fromBlock": null, "toBlock": null });
+		let expected = FilterBlockOption::Range {
+			from_block: BlockNumberOrTag::Latest,
+			to_block: BlockNumberOrTag::Latest,
+		};
+
+		// Act
+		let missing = serde_json::from_value::<Filter>(missing).unwrap();
+		let null = serde_json::from_value::<Filter>(null).unwrap();
+
+		// Assert
+		assert_eq!(missing.block_option, expected);
+		assert_eq!(null.block_option, expected);
+	}
+
+	#[test]
+	fn non_null_block_hash_and_range_bound_are_rejected() {
+		// Arrange
+		let representation = serde_json::json!({
+			"blockHash": BlockHash::repeat_byte(0xab),
+			"fromBlock": "latest",
+		});
+
+		// Act
+		let error = serde_json::from_value::<Filter>(representation).unwrap_err();
+
+		// Assert
+		assert_eq!(
+			error.to_string(),
+			"cannot specify both BlockHash and FromBlock/ToBlock, choose one or the other",
+		);
+	}
+
+	#[test]
+	fn malformed_block_hash_cannot_fall_through_to_a_range_filter() {
+		// Arrange
+		let representation = serde_json::json!({ "blockHash": "invalid" });
+
+		// Act
+		let error = serde_json::from_value::<Filter>(representation).unwrap_err();
+
+		// Assert
+		assert_eq!(error.to_string(), "odd number of digits");
+	}
+
+	#[test]
+	fn unrelated_fields_are_ignored_when_deserializing_a_block_range() {
+		// Arrange
+		let representation = serde_json::json!({
+			"fromBlock": "earliest",
+			"unrelated": true,
+		});
+
+		// Act
+		let filter = serde_json::from_value::<Filter>(representation).unwrap();
+
+		// Assert
+		assert_eq!(
+			filter.block_option,
+			FilterBlockOption::Range {
+				from_block: BlockNumberOrTag::Earliest,
+				to_block: BlockNumberOrTag::Latest,
+			},
+		);
+	}
+
+	#[test]
+	fn missing_null_and_empty_address_and_topics_are_wildcards() {
+		// Arrange
+		let missing = serde_json::json!({});
+		let null = serde_json::json!({ "address": null, "topics": null });
+		let empty = serde_json::json!({ "address": [], "topics": [] });
+
+		// Act
+		let missing = serde_json::from_value::<Filter>(missing).unwrap();
+		let null = serde_json::from_value::<Filter>(null).unwrap();
+		let empty = serde_json::from_value::<Filter>(empty).unwrap();
+
+		// Assert
+		for filter in [missing, null, empty] {
+			assert!(filter.address.is_empty());
+			assert!(filter.topics.is_empty());
+		}
+	}
+
+	#[test]
+	fn scalar_and_array_addresses_deserialize_as_matching_sets() {
+		// Arrange
+		let first_address = H160::repeat_byte(0xab);
+		let second_address = H160::repeat_byte(0xcd);
+		let scalar = serde_json::json!({ "address": first_address });
+		let array = serde_json::json!({ "address": [first_address, second_address] });
+
+		// Act
+		let scalar = serde_json::from_value::<Filter>(scalar).unwrap();
+		let array = serde_json::from_value::<Filter>(array).unwrap();
+
+		// Assert
+		assert_eq!(scalar.address, BTreeSet::from([first_address]));
+		assert_eq!(array.address, BTreeSet::from([first_address, second_address]));
+	}
+
+	#[test]
+	fn null_address_elements_are_rejected() {
+		// Arrange
+		let representation = serde_json::json!({ "address": [H160::repeat_byte(0xab), null] });
+
+		// Act
+		let result = serde_json::from_value::<Filter>(representation);
+
+		// Assert
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn null_topic_alternative_makes_the_position_a_wildcard() {
+		// Arrange
+		let representation = serde_json::json!({
+			"topics": [[H256::repeat_byte(0xab), null, H256::repeat_byte(0xcd)]],
+		});
+
+		// Act
+		let filter = serde_json::from_value::<Filter>(representation).unwrap();
+
+		// Assert
+		assert_eq!(filter.topics, vec![BoundedBTreeSet::new()]);
+	}
+
+	#[test]
+	fn trailing_wildcard_preserves_third_topic_position() {
+		// Arrange
+		let event_signature = H256::repeat_byte(0xab);
+		let first_set_topic = H256::repeat_byte(0xcd);
+		let second_set_topic = H256::repeat_byte(0xef);
+		let representation = serde_json::json!({
+			"topics": [event_signature, [first_set_topic, second_set_topic], null],
+		});
+
+		// Act
+		let filter = serde_json::from_value::<Filter>(representation).unwrap();
+
+		// Assert
+		assert_eq!(
+			filter.topics,
+			vec![
+				bounded_set([event_signature]),
+				bounded_set([first_set_topic, second_set_topic]),
+				BoundedBTreeSet::new(),
+			],
+		);
+	}
+
+	#[test]
+	fn trailing_empty_array_position_requires_the_log_to_have_a_third_topic() {
+		// Arrange
+		let event_signature = H256::repeat_byte(0xab);
+		let second_topic = H256::repeat_byte(0xcd);
+		let filter = serde_json::from_value::<Filter>(serde_json::json!({
+			"topics": [event_signature, [second_topic], []],
+		}))
+		.unwrap();
+		let two_topic_log =
+			Log { topics: vec![event_signature, second_topic], ..Default::default() };
+		let three_topic_log = Log {
+			topics: vec![event_signature, second_topic, H256::repeat_byte(0xef)],
+			..Default::default()
+		};
+
+		// Act
+		let two_topic_log_matches = filter.matches(&two_topic_log);
+		let three_topic_log_matches = filter.matches(&three_topic_log);
+
+		// Assert
+		assert_eq!(
+			filter.topics,
+			vec![
+				bounded_set([event_signature]),
+				bounded_set([second_topic]),
+				BoundedBTreeSet::new(),
+			],
+		);
+		assert!(!two_topic_log_matches);
+		assert!(three_topic_log_matches);
+	}
+
+	#[test]
+	fn logs_with_fewer_topics_than_filter_positions_do_not_match() {
+		// Arrange
+		let event_signature = H256::repeat_byte(0xab);
+		let filter = serde_json::from_value::<Filter>(serde_json::json!({
+			"topics": [event_signature, null],
+		}))
+		.unwrap();
+		let short_log = Log { topics: vec![event_signature], ..Default::default() };
+		let matching_log =
+			Log { topics: vec![event_signature, H256::repeat_byte(0xcd)], ..Default::default() };
+
+		// Act
+		let short_log_matches = filter.matches(&short_log);
+		let matching_log_matches = filter.matches(&matching_log);
+
+		// Assert
+		assert!(!short_log_matches);
+		assert!(matching_log_matches);
+	}
+
+	#[test]
+	fn single_alternatives_serialize_as_scalars_and_wildcards_as_empty_arrays() {
+		// Arrange
+		let address = H160::repeat_byte(0xab);
+		let event_signature = H256::repeat_byte(0xcd);
+		let other_topic = H256::repeat_byte(0xef);
+		let filter = serde_json::from_value::<Filter>(serde_json::json!({
+			"address": [address],
+			"topics": [event_signature, null, [event_signature, other_topic]],
+		}))
+		.unwrap();
+
+		// Act
+		let serialized = serde_json::to_value(&filter).unwrap();
+
+		// Assert
+		assert_eq!(
+			serialized,
+			serde_json::json!({
+				"fromBlock": "latest",
+				"toBlock": "latest",
+				"address": address,
+				"topics": [event_signature, [], [event_signature, other_topic]],
+			}),
+		);
+	}
 }

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -67,7 +67,7 @@ pub struct Log {
 	pub transaction_index: U256,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "FilterRepr", into = "FilterRepr")]
 pub struct Filter {
 	pub block_option: FilterBlockOption,
@@ -90,6 +90,12 @@ impl Filter {
 pub enum FilterBlockOption {
 	AtBlock { block_hash: BlockHash },
 	Range { from_block: BlockNumberOrTag, to_block: BlockNumberOrTag },
+}
+
+impl Default for FilterBlockOption {
+	fn default() -> Self {
+		Self::Range { from_block: BlockNumberOrTag::Latest, to_block: BlockNumberOrTag::Latest }
+	}
 }
 
 #[serde_as]

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -86,6 +86,64 @@ impl Filter {
 	}
 }
 
+#[cfg(test)]
+impl Filter {
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	pub fn from_block(mut self, block: impl Into<BlockNumberOrTag>) -> Self {
+		let to_block = match self.block_option {
+			FilterBlockOption::Range { to_block, .. } => to_block,
+			FilterBlockOption::AtBlock { .. } => BlockNumberOrTag::Latest,
+		};
+		self.block_option = FilterBlockOption::Range { from_block: block.into(), to_block };
+		self
+	}
+
+	pub fn to_block(mut self, block: impl Into<BlockNumberOrTag>) -> Self {
+		let from_block = match self.block_option {
+			FilterBlockOption::Range { from_block, .. } => from_block,
+			FilterBlockOption::AtBlock { .. } => BlockNumberOrTag::Latest,
+		};
+		self.block_option = FilterBlockOption::Range { from_block, to_block: block.into() };
+		self
+	}
+
+	pub fn at_block_hash(mut self, block_hash: H256) -> Self {
+		self.block_option =
+			FilterBlockOption::AtBlock { block_hash: BlockHash::from(block_hash.0) };
+		self
+	}
+
+	pub fn address(mut self, addresses: impl IntoIterator<Item = H160>) -> Self {
+		self.address = addresses.into_iter().collect();
+		self
+	}
+
+	pub fn event_signature(self, topics: impl IntoIterator<Item = H256>) -> Self {
+		self.topic(0, topics)
+	}
+
+	pub fn topic1(self, topics: impl IntoIterator<Item = H256>) -> Self {
+		self.topic(1, topics)
+	}
+
+	fn topic(mut self, position: usize, topics: impl IntoIterator<Item = H256>) -> Self {
+		let mut positions = self.topics.into_inner();
+		if positions.len() <= position {
+			positions.resize(position + 1, BoundedBTreeSet::new());
+		}
+		positions[position] = topics
+			.into_iter()
+			.collect::<BTreeSet<_>>()
+			.try_into()
+			.expect("test topic alternatives are within bounds");
+		self.topics = positions.try_into().expect("test topic positions are within bounds");
+		self
+	}
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FilterBlockOption {
 	AtBlock { block_hash: BlockHash },
@@ -93,7 +151,7 @@ pub enum FilterBlockOption {
 }
 
 impl FilterBlockOption {
-	pub fn is_valid(&self) -> bool {
+	pub fn is_valid_for_subscription(&self) -> bool {
 		match self {
 			Self::AtBlock { .. } => true,
 			Self::Range {

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -154,7 +154,7 @@ pub enum FilterBlockOption {
 impl FilterBlockOption {
 	pub fn is_valid_for_subscription(&self) -> bool {
 		match self {
-			Self::AtBlock { .. } => true,
+			Self::AtBlock { .. } => false,
 			Self::Range {
 				from_block: BlockNumberOrTag::Latest,
 				to_block: BlockNumberOrTag::Latest,
@@ -171,7 +171,7 @@ impl FilterBlockOption {
 
 	pub fn window(&self, block_number: U256) -> LogWindow {
 		match self {
-			Self::AtBlock { .. } => LogWindow::Open,
+			Self::AtBlock { .. } => LogWindow::Closed,
 			Self::Range { from_block, to_block } => {
 				match (Self::concrete_bound(from_block), Self::concrete_bound(to_block)) {
 					(_, Some(to)) if block_number > U256::from(to) => LogWindow::Closed,

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -16,7 +16,6 @@
 // limitations under the License.
 
 use crate::*;
-use alloy_primitives::BlockHash;
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnNull, OneOrMany, serde_as};
 use sp_core::ConstU32;
@@ -110,8 +109,7 @@ impl Filter {
 	}
 
 	pub fn at_block_hash(mut self, block_hash: H256) -> Self {
-		self.block_option =
-			FilterBlockOption::AtBlock { block_hash: BlockHash::from(block_hash.0) };
+		self.block_option = FilterBlockOption::AtBlock { block_hash };
 		self
 	}
 
@@ -149,7 +147,7 @@ impl Filter {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FilterBlockOption {
-	AtBlock { block_hash: BlockHash },
+	AtBlock { block_hash: H256 },
 	Range { from_block: BlockNumberOrTag, to_block: BlockNumberOrTag },
 }
 
@@ -214,7 +212,7 @@ pub enum LogWindow {
 #[serde(rename_all = "camelCase")]
 struct FilterRepr {
 	#[serde(skip_serializing_if = "Option::is_none")]
-	block_hash: Option<BlockHash>,
+	block_hash: Option<H256>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	from_block: Option<BlockNumberOrTag>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -350,7 +348,7 @@ mod tests {
 	#[test]
 	fn block_hash_conflicts_only_with_non_null_range_bounds() {
 		// Arrange
-		let block_hash = BlockHash::repeat_byte(0xab);
+		let block_hash = H256::repeat_byte(0xab);
 		let with_null_bounds = serde_json::json!({
 			"blockHash": block_hash,
 			"fromBlock": null,
@@ -401,7 +399,10 @@ mod tests {
 		let error = serde_json::from_value::<Filter>(representation).unwrap_err();
 
 		// Assert
-		assert_eq!(error.to_string(), "odd number of digits");
+		assert_eq!(
+			error.to_string(),
+			"invalid length 7, expected a (both 0x-prefixed or not) hex string or byte array containing 32 bytes",
+		);
 	}
 
 	#[test]

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -301,27 +301,87 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn block_window_includes_both_bounds_and_excludes_blocks_outside_them() {
+	fn subscription_validity_rejects_invalid_ranges_and_unsupported_tags() {
+		use BlockNumberOrTag::{Earliest, Finalized, Latest, Number, Pending, Safe};
+
 		// Arrange
-		let range = FilterBlockOption::Range {
-			from_block: BlockNumberOrTag::Number(10),
-			to_block: BlockNumberOrTag::Number(20),
-		};
+		let range = |from_block, to_block| FilterBlockOption::Range { from_block, to_block };
+		let cases = [
+			(FilterBlockOption::AtBlock { block_hash: H256::repeat_byte(1) }, true),
+			(range(Latest, Latest), true),
+			(range(Earliest, Latest), true),
+			(range(Number(10), Latest), true),
+			(range(Latest, Number(20)), false),
+			(range(Earliest, Number(20)), true),
+			(range(Earliest, Earliest), true),
+			(range(Number(0), Earliest), true),
+			(range(Number(10), Earliest), false),
+			(range(Number(10), Number(10)), true),
+			(range(Number(10), Number(20)), true),
+			(range(Number(20), Number(10)), false),
+		];
+		let unsupported_bounds = [Safe, Finalized, Pending].into_iter().flat_map(|tag| {
+			[(range(tag, Latest), false), (range(Earliest, tag), false), (range(tag, tag), false)]
+		});
 
 		// Act
-		let windows = [9_u64, 10, 15, 20, 21].map(|block_number| range.window(block_number.into()));
+		let results = cases
+			.into_iter()
+			.chain(unsupported_bounds)
+			.map(|(option, expected)| (option, option.is_valid_for_subscription(), expected))
+			.collect::<Vec<_>>();
 
 		// Assert
-		assert_eq!(
-			windows,
-			[
-				LogWindow::NotYetOpen,
-				LogWindow::Open,
-				LogWindow::Open,
-				LogWindow::Open,
-				LogWindow::Closed,
-			],
-		);
+		for (option, actual, expected) in results {
+			assert_eq!(actual, expected, "Subscription validity for {option:?}");
+		}
+	}
+
+	#[test]
+	fn block_windows_handle_inclusive_and_open_ended_ranges() {
+		use BlockNumberOrTag::{Earliest, Latest, Number};
+		use LogWindow::{Closed, NotYetOpen, Open};
+
+		// Arrange
+		let range = |from_block, to_block| FilterBlockOption::Range { from_block, to_block };
+		let bounded = range(Number(10), Number(20));
+		let single_block = range(Number(10), Number(10));
+		let open_ended = range(Number(10), Latest);
+		let at_block = FilterBlockOption::AtBlock { block_hash: H256::repeat_byte(1) };
+		let cases = [
+			(bounded, 9, NotYetOpen),
+			(bounded, 10, Open),
+			(bounded, 15, Open),
+			(bounded, 20, Open),
+			(bounded, 21, Closed),
+			(single_block, 9, NotYetOpen),
+			(single_block, 10, Open),
+			(single_block, 11, Closed),
+			(open_ended, 9, NotYetOpen),
+			(open_ended, 10, Open),
+			(open_ended, u64::MAX, Open),
+			(range(Earliest, Number(20)), 0, Open),
+			(range(Earliest, Number(20)), 20, Open),
+			(range(Earliest, Number(20)), 21, Closed),
+			(range(Earliest, Earliest), 0, Open),
+			(range(Earliest, Earliest), 1, Closed),
+			(range(Earliest, Latest), 0, Open),
+			(range(Earliest, Latest), u64::MAX, Open),
+			(range(Latest, Latest), 0, Open),
+			(range(Latest, Latest), u64::MAX, Open),
+			(at_block, 0, Open),
+			(at_block, u64::MAX, Open),
+		];
+
+		// Act
+		let results = cases.map(|(option, block_number, expected)| {
+			(option, block_number, option.window(block_number.into()), expected)
+		});
+
+		// Assert
+		for (option, block_number, actual, expected) in results {
+			assert_eq!(actual, expected, "Window for {option:?} at block {block_number}");
+		}
 	}
 
 	/// Keep the data field present on the wire even when an event has no payload.

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -70,13 +70,13 @@ pub struct Log {
 #[serde(try_from = "FilterRepr", into = "FilterRepr")]
 pub struct Filter {
 	pub block_option: FilterBlockOption,
-	pub address: BTreeSet<H160>,
+	pub addresses: BoundedBTreeSet<H160, ConstU32<1000>>,
 	pub topics: BoundedVec<BoundedBTreeSet<H256, ConstU32<1000>>, ConstU32<4>>,
 }
 
 impl Filter {
 	pub fn matches(&self, log: &Log) -> bool {
-		(self.address.is_empty() || self.address.contains(&log.address)) &&
+		(self.addresses.is_empty() || self.addresses.contains(&log.address)) &&
 			self.topics.len() <= log.topics.len() &&
 			self.topics
 				.iter()
@@ -116,7 +116,11 @@ impl Filter {
 	}
 
 	pub fn address(mut self, addresses: impl IntoIterator<Item = H160>) -> Self {
-		self.address = addresses.into_iter().collect();
+		self.addresses = addresses
+			.into_iter()
+			.collect::<BTreeSet<_>>()
+			.try_into()
+			.expect("test addresses are within bounds");
 		self
 	}
 
@@ -215,9 +219,9 @@ struct FilterRepr {
 	from_block: Option<BlockNumberOrTag>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	to_block: Option<BlockNumberOrTag>,
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde(rename = "address", default, skip_serializing_if = "Vec::is_empty")]
 	#[serde_as(as = "DefaultOnNull<OneOrMany<_>>")]
-	address: Vec<H160>,
+	addresses: Vec<H160>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	#[serde_as(as = "DefaultOnNull<Vec<DefaultOnNull<OneOrMany<_>>>>")]
 	topics: Vec<Vec<Option<H256>>>,
@@ -227,7 +231,7 @@ impl TryFrom<FilterRepr> for Filter {
 	type Error = FilterError;
 
 	fn try_from(repr: FilterRepr) -> Result<Self, Self::Error> {
-		let FilterRepr { block_hash, from_block, to_block, address, topics } = repr;
+		let FilterRepr { block_hash, from_block, to_block, addresses, topics } = repr;
 
 		let block_option = match (block_hash, from_block, to_block) {
 			(Some(block_hash), None, None) => FilterBlockOption::AtBlock { block_hash },
@@ -238,6 +242,11 @@ impl TryFrom<FilterRepr> for Filter {
 			},
 		};
 
+		let addresses = addresses
+			.into_iter()
+			.collect::<BTreeSet<_>>()
+			.try_into()
+			.map_err(|_| FilterError::ExceedMaxAddresses)?;
 		let topics = topics
 			.into_iter()
 			.map(|alternatives| {
@@ -252,7 +261,7 @@ impl TryFrom<FilterRepr> for Filter {
 			.collect::<Result<Vec<_>, _>>()?;
 		let topics = BoundedVec::try_from(topics).map_err(|_| FilterError::ExceedMaxTopics)?;
 
-		Ok(Self { block_option, address: address.into_iter().collect(), topics })
+		Ok(Self { block_option, addresses, topics })
 	}
 }
 
@@ -269,7 +278,7 @@ impl From<Filter> for FilterRepr {
 			block_hash,
 			from_block,
 			to_block,
-			address: filter.address.into_iter().collect(),
+			addresses: filter.addresses.into_iter().collect(),
 			topics: filter
 				.topics
 				.into_iter()
@@ -283,6 +292,8 @@ impl From<Filter> for FilterRepr {
 pub enum FilterError {
 	#[error("cannot specify both BlockHash and FromBlock/ToBlock, choose one or the other")]
 	BlockHashCombinedWithRange,
+	#[error("exceed max addresses")]
+	ExceedMaxAddresses,
 	#[error("exceed max topics")]
 	ExceedMaxTopics,
 }
@@ -383,7 +394,7 @@ mod tests {
 
 		// Assert
 		for filter in [missing, null, empty] {
-			assert!(filter.address.is_empty());
+			assert!(filter.addresses.is_empty());
 			assert!(filter.topics.is_empty());
 		}
 	}
@@ -401,8 +412,8 @@ mod tests {
 		let array = serde_json::from_value::<Filter>(array).unwrap();
 
 		// Assert
-		assert_eq!(scalar.address, BTreeSet::from([first_address]));
-		assert_eq!(array.address, BTreeSet::from([first_address, second_address]));
+		assert_eq!(scalar.addresses, BTreeSet::from([first_address]));
+		assert_eq!(array.addresses, BTreeSet::from([first_address, second_address]));
 	}
 
 	#[test]

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -409,26 +409,37 @@ mod tests {
 	fn block_hash_conflicts_only_with_non_null_range_bounds() {
 		// Arrange
 		let block_hash = H256::repeat_byte(0xab);
-		let with_null_bounds = serde_json::json!({
-			"blockHash": block_hash,
-			"fromBlock": null,
-			"toBlock": null,
-		});
-		let with_non_null_bound = serde_json::json!({
-			"blockHash": block_hash,
-			"fromBlock": "latest",
-		});
+		let valid = [
+			serde_json::json!({ "blockHash": block_hash }),
+			serde_json::json!({
+				"blockHash": block_hash,
+				"fromBlock": null,
+				"toBlock": null,
+			}),
+		];
+		let conflicting = [
+			serde_json::json!({ "blockHash": block_hash, "fromBlock": "latest" }),
+			serde_json::json!({ "blockHash": block_hash, "toBlock": "0x0" }),
+			serde_json::json!({
+				"blockHash": block_hash,
+				"fromBlock": "0x0",
+				"toBlock": "latest",
+			}),
+		];
 
 		// Act
-		let with_null_bounds = serde_json::from_value::<Filter>(with_null_bounds).unwrap();
-		let error = serde_json::from_value::<Filter>(with_non_null_bound).unwrap_err();
+		let valid = valid
+			.map(|value| Filter::try_from(serde_json::from_value::<FilterRepr>(value).unwrap()));
+		let conflicting = conflicting
+			.map(|value| Filter::try_from(serde_json::from_value::<FilterRepr>(value).unwrap()));
 
 		// Assert
-		assert_eq!(with_null_bounds.block_option, FilterBlockOption::AtBlock { block_hash });
-		assert_eq!(
-			error.to_string(),
-			"cannot specify both BlockHash and FromBlock/ToBlock, choose one or the other",
-		);
+		for result in valid {
+			assert_eq!(result.unwrap().block_option, FilterBlockOption::AtBlock { block_hash });
+		}
+		for result in conflicting {
+			assert_eq!(result, Err(FilterError::BlockHashCombinedWithRange));
+		}
 	}
 
 	#[test]

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -302,6 +302,30 @@ pub enum FilterError {
 mod tests {
 	use super::*;
 
+	#[test]
+	fn block_window_includes_both_bounds_and_excludes_blocks_outside_them() {
+		// Arrange
+		let range = FilterBlockOption::Range {
+			from_block: BlockNumberOrTag::Number(10),
+			to_block: BlockNumberOrTag::Number(20),
+		};
+
+		// Act
+		let windows = [9_u64, 10, 15, 20, 21].map(|block_number| range.window(block_number.into()));
+
+		// Assert
+		assert_eq!(
+			windows,
+			[
+				LogWindow::NotYetOpen,
+				LogWindow::Open,
+				LogWindow::Open,
+				LogWindow::Open,
+				LogWindow::Closed,
+			],
+		);
+	}
+
 	/// Keep the data field present on the wire even when an event has no payload.
 	#[test]
 	fn empty_log_data_serializes_as_an_empty_hex_string() {

--- a/substrate/frame/revive/rpc/src/types/log.rs
+++ b/substrate/frame/revive/rpc/src/types/log.rs
@@ -50,9 +50,8 @@ pub struct Log {
 	pub block_hash: H256,
 	/// block number
 	pub block_number: U256,
-	/// data
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub data: Option<Bytes>,
+	/// Event payload, serialized as `0x` when the log contains no data.
+	pub data: Bytes,
 	/// log index
 	pub log_index: U256,
 	/// removed
@@ -291,6 +290,21 @@ pub enum FilterError {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// Keep the data field present on the wire even when an event has no payload.
+	#[test]
+	fn empty_log_data_serializes_as_an_empty_hex_string() {
+		// Arrange
+		let log = Log::default();
+
+		// Act
+		let serialized = serde_json::to_value(&log).unwrap();
+		let deserialized = serde_json::from_value::<Log>(serialized.clone()).unwrap();
+
+		// Assert
+		assert_eq!(serialized["data"], "0x");
+		assert_eq!(deserialized, log);
+	}
 
 	fn bounded_set(
 		topics: impl IntoIterator<Item = H256>,

--- a/substrate/frame/revive/rpc/src/types/subscription.rs
+++ b/substrate/frame/revive/rpc/src/types/subscription.rs
@@ -106,9 +106,12 @@ impl SubscriptionParameters {
 	) -> Option<Self> {
 		match (subscription_kind, subscription_options) {
 			(SubscriptionKind::Logs, None) => Some(Self::Logs(Filter::default())),
-			(SubscriptionKind::Logs, Some(SubscriptionOptions::LogsOptions(filter))) => {
+			(SubscriptionKind::Logs, Some(SubscriptionOptions::LogsOptions(filter)))
+				if filter.block_option.is_valid() =>
+			{
 				Some(Self::Logs(filter))
 			},
+			(SubscriptionKind::Logs, Some(SubscriptionOptions::LogsOptions(_))) => None,
 			(SubscriptionKind::NewBlockHeaders, None) => Some(Self::NewBlockHeaders),
 			(SubscriptionKind::NewBlockHeaders, Some(SubscriptionOptions::LogsOptions(_))) => None,
 		}

--- a/substrate/frame/revive/rpc/src/types/subscription.rs
+++ b/substrate/frame/revive/rpc/src/types/subscription.rs
@@ -15,11 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::Filter;
 use crate::*;
 use serde::{Deserialize, Serialize};
-use sp_core::ConstU32;
-use sp_runtime::BoundedVec;
-use std::collections::BTreeSet;
 
 /// Block header object returned by `newHeads` subscriptions.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -80,6 +78,7 @@ impl From<BlockV1> for BlockHeader {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum SubscriptionKind {
+	#[serde(rename = "newHeads")]
 	NewBlockHeaders,
 	Logs,
 }
@@ -89,92 +88,7 @@ pub enum SubscriptionKind {
 #[serde(untagged)]
 pub enum SubscriptionOptions {
 	/// Options passed when subscribing for logs.
-	LogsOptions {
-		/// An optional address to use to filter the logs.
-		///
-		/// If specified, then only logs where this address is the emitter will be returned in the
-		/// subscription. If not specified, then it means that there's no filtering based on the
-		/// address of the emitter.
-		///
-		/// If it's specified as a vector of addresses then all of the addresses specified in the
-		/// vector pass the filter.
-		#[serde(default, skip_serializing_if = "Option::is_none")]
-		address: Option<BoundedOneOrMany<Address, 1000>>,
-
-		/// An optional set of topics to filter the logs by.
-		///
-		/// If not specified, then logs with any topic would match the filter. If specified, then
-		/// only logs which match the specified topics pass the filter.
-		#[serde(default, skip_serializing_if = "Option::is_none")]
-		topics: Option<BoundedVec<Option<BoundedOneOrMany<H256, 1000>>, ConstU32<4>>>,
-	},
-}
-
-/// A type used as a filter for logs in subscriptions.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LogsSubscriptionFilter {
-	/// Defines if the filter is configured to make use of addresses or not.
-	addresses: Option<BTreeSet<H160>>,
-
-	/// Defines if the filter is configured to filter based on the topics.
-	topics: Option<[Option<BTreeSet<H256>>; 4]>,
-}
-
-impl LogsSubscriptionFilter {
-	/// Constructs a new logs filter.
-	pub fn new(
-		address: Option<BoundedOneOrMany<Address, 1000>>,
-		topics: Option<BoundedVec<Option<BoundedOneOrMany<H256, 1000>>, ConstU32<4>>>,
-	) -> Self {
-		Self {
-			addresses: address.map(|addresses| addresses.into_iter().collect()),
-			topics: topics.map(|topics| {
-				let mut resolved_topics = [None, None, None, None];
-				for (index, topic) in topics.into_iter().enumerate() {
-					resolved_topics[index] =
-						topic.map(|topic_filter| topic_filter.into_iter().collect());
-				}
-				resolved_topics
-			}),
-		}
-	}
-
-	/// Checks if a certain log matches this filter.
-	pub fn matches(&self, log: &Log) -> bool {
-		// Check the emitter address. If it doesn't match, then we return.
-		if let Some(ref address_filter) = self.addresses &&
-			!address_filter.contains(&log.address) &&
-			!address_filter.is_empty()
-		{
-			return false;
-		}
-
-		// Check the topics filter to ensure that the log matches the topics filter.
-		if let Some(ref topics_filters) = self.topics {
-			let mut event_topics = log.topics.iter();
-			for topics_filter in topics_filters {
-				let event_topic = event_topics.next();
-
-				match (topics_filter, event_topic) {
-					// Wildcard filters.
-					(None, _) => {},
-					(Some(topic_filters), _) if topic_filters.is_empty() => {},
-					// There's a filter but there's no topic at this index, return false at this
-					// point.
-					(Some(..), None) => return false,
-					// There's a filter and there's also a topic at this index. So filter based on
-					// it.
-					(Some(topics_filter), Some(topic)) => {
-						if !topics_filter.contains(topic) {
-							return false;
-						}
-					},
-				}
-			}
-		}
-
-		true
-	}
+	LogsOptions(Filter),
 }
 
 /// Resolved parameters for the subscription request which contains both the request type and the
@@ -182,7 +96,7 @@ impl LogsSubscriptionFilter {
 #[derive(Clone, Debug)]
 pub enum SubscriptionParameters {
 	NewBlockHeaders,
-	Logs(LogsSubscriptionFilter),
+	Logs(Filter),
 }
 
 impl SubscriptionParameters {
@@ -191,15 +105,12 @@ impl SubscriptionParameters {
 		subscription_options: Option<SubscriptionOptions>,
 	) -> Option<Self> {
 		match (subscription_kind, subscription_options) {
-			(SubscriptionKind::Logs, None) => {
-				Some(Self::Logs(LogsSubscriptionFilter::new(None, None)))
+			(SubscriptionKind::Logs, None) => Some(Self::Logs(Filter::default())),
+			(SubscriptionKind::Logs, Some(SubscriptionOptions::LogsOptions(filter))) => {
+				Some(Self::Logs(filter))
 			},
-			(
-				SubscriptionKind::Logs,
-				Some(SubscriptionOptions::LogsOptions { address, topics }),
-			) => Some(Self::Logs(LogsSubscriptionFilter::new(address, topics))),
 			(SubscriptionKind::NewBlockHeaders, None) => Some(Self::NewBlockHeaders),
-			_ => None,
+			(SubscriptionKind::NewBlockHeaders, Some(SubscriptionOptions::LogsOptions(_))) => None,
 		}
 	}
 }
@@ -209,25 +120,4 @@ impl SubscriptionParameters {
 pub enum SubscriptionItem {
 	BlockHeader(BlockHeader),
 	Log(Log),
-}
-
-/// A helper type used when a type can be serialized and deserialized as either being one or as an
-/// array.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-#[serde(untagged)]
-pub enum BoundedOneOrMany<T, const BOUND: u32> {
-	One(T),
-	Many(BoundedVec<T, ConstU32<BOUND>>),
-}
-
-impl<T: 'static, const BOUND: u32> IntoIterator for BoundedOneOrMany<T, BOUND> {
-	type IntoIter = Box<dyn Iterator<Item = T>>;
-	type Item = T;
-
-	fn into_iter(self) -> Self::IntoIter {
-		match self {
-			BoundedOneOrMany::One(item) => Box::new(core::iter::once(item)) as _,
-			BoundedOneOrMany::Many(bounded_vec) => Box::new(bounded_vec.into_iter()) as _,
-		}
-	}
 }

--- a/substrate/frame/revive/rpc/src/types/subscription.rs
+++ b/substrate/frame/revive/rpc/src/types/subscription.rs
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::Filter;
 use crate::*;
 use serde::{Deserialize, Serialize};
 
@@ -107,7 +106,7 @@ impl SubscriptionParameters {
 		match (subscription_kind, subscription_options) {
 			(SubscriptionKind::Logs, None) => Some(Self::Logs(Filter::default())),
 			(SubscriptionKind::Logs, Some(SubscriptionOptions::LogsOptions(filter)))
-				if filter.block_option.is_valid() =>
+				if filter.block_option.is_valid_for_subscription() =>
 			{
 				Some(Self::Logs(filter))
 			},

--- a/substrate/frame/revive/rpc/src/types/subscription.rs
+++ b/substrate/frame/revive/rpc/src/types/subscription.rs
@@ -30,10 +30,6 @@ pub struct BlockHeader {
 	pub parent_hash: H256,
 	/// Nonce
 	pub nonce: Bytes8,
-	/// Block difficulty required by Ethereum clients when decoding subscription headers.
-	pub difficulty: U256,
-	/// Block mix hash required by Ethereum clients when decoding subscription headers.
-	pub mix_hash: H256,
 	/// Ommers hash
 	pub sha_3_uncles: H256,
 	/// Bloom filter
@@ -63,8 +59,6 @@ impl From<BlockV1> for BlockHeader {
 			hash: block.hash,
 			parent_hash: block.parent_hash,
 			nonce: block.nonce,
-			difficulty: block.difficulty,
-			mix_hash: block.mix_hash,
 			sha_3_uncles: block.sha_3_uncles,
 			logs_bloom: block.logs_bloom,
 			transactions_root: block.transactions_root,
@@ -83,7 +77,6 @@ impl From<BlockV1> for BlockHeader {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum SubscriptionKind {
-	#[serde(rename = "newHeads")]
 	NewBlockHeaders,
 	Logs,
 }

--- a/substrate/frame/revive/rpc/src/types/subscription.rs
+++ b/substrate/frame/revive/rpc/src/types/subscription.rs
@@ -30,6 +30,10 @@ pub struct BlockHeader {
 	pub parent_hash: H256,
 	/// Nonce
 	pub nonce: Bytes8,
+	/// Block difficulty required by Ethereum clients when decoding subscription headers.
+	pub difficulty: U256,
+	/// Block mix hash required by Ethereum clients when decoding subscription headers.
+	pub mix_hash: H256,
 	/// Ommers hash
 	pub sha_3_uncles: H256,
 	/// Bloom filter
@@ -59,6 +63,8 @@ impl From<BlockV1> for BlockHeader {
 			hash: block.hash,
 			parent_hash: block.parent_hash,
 			nonce: block.nonce,
+			difficulty: block.difficulty,
+			mix_hash: block.mix_hash,
 			sha_3_uncles: block.sha_3_uncles,
 			logs_bloom: block.logs_bloom,
 			transactions_root: block.transactions_root,


### PR DESCRIPTION
# Description

We have had a number of issues in the eth-rpc related to the log filtering logic and to its data representation such as:

- https://github.com/paritytech/polkadot-sdk/pull/12626
- https://github.com/paritytech/polkadot-sdk/pull/12483
- https://github.com/alloy-rs/alloy/pull/4153

Some of the issues that I link to here can't be fixed without changing the models we're using since there are certain things which alloy's `Filter` type can't represent (https://github.com/alloy-rs/alloy/pull/4153).

This PR does the following:
- Introduces our own `Filter` type which we use instead of alloy's filter type (due to the issues it has with what data it can't represent as seen in https://github.com/alloy-rs/alloy/pull/4153).
- Implement `Filter` matching logic on the `Filter` type itself as an authoritative implementation that can be used anywhere in the codebase.
- Removes the duplicated subscription filter type that we used to have in favor of this new `Filter` type.
- Updates the `ReceiptProvider::logs` implementation to match the filtering logic implemented on the `Filter` type.

This PR fixes all of the github issues/PRs linked to above and should close them once its merged.