### PR TITLE
Reject mismatched candidate backing vote counts

### DIFF
--- a/polkadot/primitives/src/v9/mod.rs
+++ b/polkadot/primitives/src/v9/mod.rs
@@ -628,11 +628,12 @@ pub fn check_candidate_backing<H: AsRef<[u8]> + Clone + Encode + core::fmt::Debu
 		return Err(());
 	}
 
-	if validity_votes.len() > group_len {
+	let signed_indices = validator_indices.count_ones();
+	if signed_indices != validity_votes.len() {
 		log::debug!(
 			target: LOG_TARGET,
-			"Check candidate backing: Too many votes, expected: {}, found: {}",
-			group_len,
+			"Check candidate backing: vote count mismatch: indices = {}, votes = {}",
+			signed_indices,
 			validity_votes.len(),
 		);
 		return Err(());
@@ -660,16 +661,6 @@ pub fn check_candidate_backing<H: AsRef<[u8]> + Clone + Encode + core::fmt::Debu
 			);
 			return Err(());
 		}
-	}
-
-	if signed != validity_votes.len() {
-		log::error!(
-			target: LOG_TARGET,
-			"Check candidate backing: Too many signatures, expected = {}, found = {}",
-			validity_votes.len(),
-			signed,
-		);
-		return Err(());
 	}
 
 	Ok(signed)
@@ -3335,6 +3326,25 @@ pub mod tests {
 		assert_eq!(supermajority_threshold(5), 4);
 		assert_eq!(supermajority_threshold(6), 5);
 		assert_eq!(supermajority_threshold(7), 5);
+	}
+
+	#[test]
+	fn check_candidate_backing_rejects_more_indices_than_votes() {
+		let validator_indices = bitvec![u8, Lsb0; 1, 1, 1];
+		let signing_context: SigningContext = SigningContext::default();
+
+		assert_eq!(
+			check_candidate_backing(
+				CandidateHash(Hash::repeat_byte(1)),
+				&[],
+				validator_indices.as_bitslice(),
+				&signing_context,
+				3,
+				|_| None,
+			),
+			Err(()),
+			"validator indices and validity votes must have matching cardinality",
+		);
 	}
 
 	#[test]

--- a/polkadot/runtime/parachains/src/builder.rs
+++ b/polkadot/runtime/parachains/src/builder.rs
@@ -785,11 +785,16 @@ impl<T: paras_inherent::Config> BenchBuilder<T> {
 								ValidityAttestation::Explicit(sig.clone())
 							})
 							.collect();
+						let validator_indices: BitVec<u8, BitOrderLsb0> = group_validators
+							.iter()
+							.enumerate()
+							.map(|(index, _)| index < validity_votes.len())
+							.collect();
 
 						BackedCandidate::<T::Hash>::new(
 							candidate,
 							validity_votes,
-							bitvec::bitvec![u8, bitvec::order::Lsb0; 1; group_validators.len()],
+							validator_indices,
 							core_idx,
 						)
 					})

--- a/prdoc/pr_12888.prdoc
+++ b/prdoc/pr_12888.prdoc
@@ -15,3 +15,7 @@ crates:
   bump: minor
 - name: sp-keystore
   bump: patch
+- name: sp-rpc
+  bump: patch
+- name: sc-storage-monitor
+  bump: patch

--- a/prdoc/pr_13004.prdoc
+++ b/prdoc/pr_13004.prdoc
@@ -7,3 +7,5 @@ doc:
 crates:
 - name: polkadot-primitives
   bump: patch
+- name: polkadot-runtime-parachains
+  bump: patch

--- a/prdoc/pr_13004.prdoc
+++ b/prdoc/pr_13004.prdoc
@@ -1,0 +1,9 @@
+title: Reject mismatched candidate backing vote counts
+doc:
+- audience: Runtime Dev
+  description: |-
+    Reject candidate backing when the validator bitfield and supplied validity
+    attestations contain different numbers of votes.
+crates:
+- name: polkadot-primitives
+  bump: patch


### PR DESCRIPTION
- reject candidate backing when the validator bitfield and validity attestations have different cardinalities
- validate the relationship before signature verification to prevent iterator truncation
- add a regression for bitfields claiming more validators than the supplied votes

Candidate backing previously zipped the set validator indices with the supplied attestations, allowing the shorter iterator to silently determine how many entries were checked.