### PR TITLE
Reject duplicate derivative IDs

### DIFF
--- a/prdoc/pr_12888.prdoc
+++ b/prdoc/pr_12888.prdoc
@@ -15,7 +15,3 @@ crates:
   bump: minor
 - name: sp-keystore
   bump: patch
-- name: sp-rpc
-  bump: patch
-- name: sc-storage-monitor
-  bump: patch

--- a/prdoc/pr_12888.prdoc
+++ b/prdoc/pr_12888.prdoc
@@ -15,3 +15,7 @@ crates:
   bump: minor
 - name: sp-keystore
   bump: patch
+- name: sp-rpc
+  bump: patch
+- name: sc-storage-monitor
+  bump: patch

--- a/prdoc/pr_13006.prdoc
+++ b/prdoc/pr_13006.prdoc
@@ -1,0 +1,9 @@
+title: Reject duplicate derivative IDs
+doc:
+- audience: Runtime Dev
+  description: |-
+    Reject derivative registration when the derivative ID is already mapped to another original,
+    preserving the one-to-one relationship between registry indexes.
+crates:
+- name: pallet-derivatives
+  bump: patch

--- a/substrate/frame/derivatives/src/lib.rs
+++ b/substrate/frame/derivatives/src/lib.rs
@@ -279,6 +279,10 @@ impl<T: Config<I>, I: 'static> DerivativesRegistry<OriginalOf<T, I>, DerivativeO
 			Self::original_to_derivative(original).is_none(),
 			Error::<T, I>::DerivativeAlreadyExists,
 		);
+		ensure!(
+			Self::derivative_to_original(derivative).is_none(),
+			Error::<T, I>::DerivativeAlreadyExists,
+		);
 
 		<OriginalToDerivative<T, I>>::insert(original, derivative);
 		<DerivativeToOriginal<T, I>>::insert(derivative, original);

--- a/substrate/frame/derivatives/src/tests.rs
+++ b/substrate/frame/derivatives/src/tests.rs
@@ -171,6 +171,28 @@ fn auto_id_collection() {
 }
 
 #[test]
+fn duplicate_derivative_id_is_rejected() {
+	new_test_ext().execute_with(|| {
+		let id_a = AssetId(Location::new(1, [Parachain(1111)]));
+		let id_b = AssetId(Location::new(1, [Parachain(2222)]));
+		let derivative_id = 100;
+
+		assert_ok!(AutoIdDerivativeCollections::try_register_derivative(&id_a, &derivative_id));
+		assert_err!(
+			AutoIdDerivativeCollections::try_register_derivative(&id_b, &derivative_id),
+			pallet_derivatives::Error::<Test, AutoIdCollectionsInstance>::DerivativeAlreadyExists,
+		);
+
+		assert_eq!(AutoIdDerivativeCollections::get_derivative(&id_a), Ok(derivative_id));
+		assert_eq!(AutoIdDerivativeCollections::get_original(&derivative_id), Ok(id_a));
+		assert_err!(
+			AutoIdDerivativeCollections::get_derivative(&id_b),
+			pallet_derivatives::Error::<Test, AutoIdCollectionsInstance>::DerivativeNotFound,
+		);
+	});
+}
+
+#[test]
 fn local_nfts() {
 	new_test_ext().execute_with(|| {
 		let collection_owner = 1;


### PR DESCRIPTION
- reject derivative registration when the derivative ID is already mapped to another original
- preserve the one-to-one relationship between the forward and reverse registry indexes
- add a regression covering duplicate derivative IDs and the original mapping

`try_register_derivative` previously checked only the original-to-derivative index before writing both indexes. Reusing a derivative ID could therefore overwrite the reverse entry while leaving two forward entries pointing at the same derivative.
