### PR TITLE
Raise max_code_size in the schedule_code_upgrade benchmark

### DIFF
--- a/polkadot/runtime/common/src/paras_registrar/benchmarking.rs
+++ b/polkadot/runtime/common/src/paras_registrar/benchmarking.rs
@@ -22,7 +22,7 @@ use crate::traits::Registrar as RegistrarT;
 use frame_support::assert_ok;
 use frame_system::RawOrigin;
 use polkadot_primitives::{MAX_CODE_SIZE, MAX_HEAD_DATA_SIZE, MIN_CODE_SIZE};
-use polkadot_runtime_parachains::{paras, shared, Origin as ParaOrigin};
+use polkadot_runtime_parachains::{configuration, paras, shared, Origin as ParaOrigin};
 use sp_runtime::traits::Bounded;
 
 use frame_benchmarking::v2::*;
@@ -186,6 +186,11 @@ mod benchmarks {
 	fn schedule_code_upgrade(
 		b: Linear<MIN_CODE_SIZE, MAX_CODE_SIZE>,
 	) -> Result<(), BenchmarkError> {
+		// The extrinsic validates the code length against the on-chain `max_code_size`, which a
+		// runtime may configure below `MAX_CODE_SIZE`. Raise it so that the largest sampled `b`
+		// is accepted, otherwise the benchmark fails with `InvalidCode` on those runtimes.
+		configuration::ActiveConfig::<T>::mutate(|config| config.max_code_size = MAX_CODE_SIZE);
+
 		let new_code = ValidationCode(vec![0; b as usize]);
 		let para_id = ParaId::from(1000);
 

--- a/prdoc/pr_13026.prdoc
+++ b/prdoc/pr_13026.prdoc
@@ -1,0 +1,14 @@
+title: Raise `max_code_size` in the `schedule_code_upgrade` benchmark
+doc:
+- audience: Runtime Dev
+  description: |-
+    The `paras_registrar::schedule_code_upgrade` benchmark sampled `b` up to the global
+    `MAX_CODE_SIZE` constant, while the extrinsic validates the code length against the
+    on-chain `max_code_size` host configuration. Runtimes that configure `max_code_size`
+    below `MAX_CODE_SIZE` failed the benchmark with `InvalidCode`.
+    The benchmark now raises the configured `max_code_size` during setup, so the worst case
+    it measures is accepted. `ActiveConfig` is whitelisted storage, so the recorded weight
+    is unchanged.
+crates:
+- name: polkadot-runtime-common
+  bump: patch


### PR DESCRIPTION
# Description

Fixes #12968.

`paras_registrar::schedule_code_upgrade` samples its parameter from the global constant:

```rust
fn schedule_code_upgrade(b: Linear<MIN_CODE_SIZE, MAX_CODE_SIZE>)
```

but the extrinsic validates the code length against the **on-chain host configuration**:

```rust
ensure!(new_code.0.len() <= config.max_code_size as usize, Error::<T>::InvalidCode);
```

So on any runtime whose `max_code_size` is below `MAX_CODE_SIZE`, the largest sampled `b` is rejected and the benchmark fails with `InvalidCode`.

Runtimes do cap it. A `max_code_size`-sized upgrade has to fit inside a single block, so `polkadot-fellows/runtimes` keeps `max_code_size` at 3 MiB while the constant is now 5 MiB. SDK runtimes use 10 MiB blocks, which is why SDK CI never hits this — it showed up integrating `stable2606-1` into the fellowship runtimes.

`Linear` bounds have to be const, so the sampled range cannot be read from the configuration. Instead the benchmark now raises the configured `max_code_size` to `MAX_CODE_SIZE` during setup, so the worst case it intends to measure is actually accepted:

```rust
configuration::ActiveConfig::<T>::mutate(|config| config.max_code_size = MAX_CODE_SIZE);
```

`ActiveConfig` is `#[pallet::whitelist_storage]`, so the extra write does not enter the recorded weight, and the mutation happens before `#[extrinsic_call]` so it is not timed either.

## Sibling audit

The issue asks that other extrinsics checking code length against `ActiveConfig::max_code_size` while sampling `MAX_CODE_SIZE` be audited. Two neighbours came up and neither needs the same change:

- `paras::force_schedule_code_upgrade` samples the same range but calls `schedule_code_upgrade` directly, which only logs a warning on oversized code — no `ensure!`, so it passes today.
- `paras_registrar::set_current_head` samples `MAX_HEAD_DATA_SIZE`, but its extrinsic calls the infallible `set_current_head` and performs no size check.

#12969 covers `paras_inherent::enter_backed_candidate_code_upgrade`, which fails for a different reason (block length rather than the config check) and is left alone here.

# Checklist

- [x] My PR includes a detailed description as outlined in "Description" and its two subsections above.
- [x] My PR follows the [labeling requirements](https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process) of this project (at minimum one label for `T` required)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
  - The benchmark is the test here; it fails with `InvalidCode` before this change on a runtime configuring `max_code_size < MAX_CODE_SIZE`.

Verified locally with `cargo check -p polkadot-runtime-common --features runtime-benchmarks` (clean) and `cargo fmt --check` (no diff in the touched file).
