### PR TITLE
`frame-support`: fix `CountedStorageMap` and `CountedStorageNMap` counter drift

### DIFF
--- a/prdoc/pr_13031.prdoc
+++ b/prdoc/pr_13031.prdoc
@@ -1,0 +1,11 @@
+title: 'frame-support: stop `CountedStorageMap::try_append` counting existing keys'
+doc:
+- audience: Runtime Dev
+  description: |-
+    `CountedStorageMap::try_append` incremented `CounterFor` on every append within the bound,
+    including appends to an existing key, which create no entry. `count()` drifted above the
+    number of stored keys. It now increments only when the key is absent, matching `insert` and
+    `append`.
+crates:
+- name: frame-support
+  bump: patch

--- a/prdoc/pr_13031.prdoc
+++ b/prdoc/pr_13031.prdoc
@@ -1,4 +1,4 @@
-title: 'frame-support: stop `CountedStorageMap::try_append` counting existing keys'
+title: 'frame-support: fix CountedStorageMap and CountedStorageNMap counter drift'
 doc:
 - audience: Runtime Dev
   description: |-
@@ -6,6 +6,10 @@ doc:
     including appends to an existing key, which create no entry. `count()` drifted above the
     number of stored keys. It now increments only when the key is absent, matching `insert` and
     `append`.
+
+    `CountedStorageNMap::set` decremented on every removal, including of an absent key, and never
+    incremented when it created an entry, so `count()` drifted below the number of stored keys.
+    It now delegates to `mutate_exists`, which counts the added/removed transition.
 crates:
 - name: frame-support
   bump: patch

--- a/substrate/frame/support/src/storage/types/counted_map.rs
+++ b/substrate/frame/support/src/storage/types/counted_map.rs
@@ -412,7 +412,9 @@ where
 		let bound = Value::bound();
 		let current = <Self as MapWrapper>::Map::decode_len(Ref::from(&key)).unwrap_or_default();
 		if current < bound {
-			CounterFor::<Prefix>::mutate(|value| value.saturating_inc());
+			if !<Self as MapWrapper>::Map::contains_key(Ref::from(&key)) {
+				CounterFor::<Prefix>::mutate(|value| value.saturating_inc());
+			}
 			let key = <Self as MapWrapper>::Map::hashed_key_for(key);
 			sp_io::storage::append(&key, item.encode());
 			Ok(())
@@ -1126,6 +1128,30 @@ mod test {
 			assert_eq!(B::decode_len(0), Some(3));
 			B::try_append(0, 3).err().unwrap();
 			assert_eq!(B::decode_len(0), Some(3));
+		})
+	}
+
+	#[test]
+	fn try_append_counts_keys_not_items() {
+		type B = CountedStorageMap<Prefix, Twox64Concat, u16, BoundedVec<u32, ConstU32<3u32>>>;
+
+		TestExternalities::default().execute_with(|| {
+			B::try_append(0, 3).unwrap();
+			assert_eq!(B::count(), 1);
+			B::try_append(0, 3).unwrap();
+			B::try_append(0, 3).unwrap();
+			assert_eq!(B::count(), 1);
+			B::try_append(0, 3).err().unwrap();
+			assert_eq!(B::count(), 1);
+			B::try_append(1, 3).unwrap();
+			assert_eq!(B::count(), 2);
+			B::insert(2, BoundedVec::default());
+			B::try_append(2, 3).unwrap();
+			assert_eq!(B::count(), 3);
+			B::remove(0);
+			B::remove(1);
+			B::remove(2);
+			assert_eq!(B::count(), 0);
 		})
 	}
 

--- a/substrate/frame/support/src/storage/types/counted_nmap.rs
+++ b/substrate/frame/support/src/storage/types/counted_nmap.rs
@@ -181,16 +181,14 @@ where
 	}
 
 	/// Store or remove the value to be associated with `key` so that `get` returns the `query`.
-	/// It decrements the counter when the value is removed.
+	/// It updates the counter when an entry is added or removed.
 	pub fn set<KArg: EncodeLikeTuple<Key::KArg> + TupleToEncodedIter>(
 		key: KArg,
 		query: QueryKind::Query,
 	) {
-		let option = QueryKind::from_query_to_optional_value(query);
-		if option.is_none() {
-			CounterFor::<Prefix>::mutate(|value| value.saturating_dec());
-		}
-		<Self as MapWrapper>::Map::set(key, QueryKind::from_optional_value_to_query(option))
+		Self::mutate_exists(key, |value| {
+			*value = QueryKind::from_query_to_optional_value(query);
+		})
 	}
 
 	/// Take a value from storage, removing it afterwards.
@@ -708,6 +706,31 @@ mod test {
 		fn get() -> u32 {
 			98
 		}
+	}
+
+	#[test]
+	fn set_counts_keys_not_writes() {
+		type A = CountedStorageNMap<Prefix, NMapKey<Blake2_128Concat, u16>, u32, OptionQuery>;
+
+		TestExternalities::default().execute_with(|| {
+			A::insert((1,), 10);
+			assert_eq!(A::count(), 1);
+
+			A::set((2,), None);
+			assert_eq!(A::count(), 1);
+
+			A::set((2,), Some(20));
+			assert_eq!(A::get((2,)), Some(20));
+			assert_eq!(A::count(), 2);
+
+			A::set((2,), Some(21));
+			assert_eq!(A::get((2,)), Some(21));
+			assert_eq!(A::count(), 2);
+
+			A::set((2,), None);
+			assert_eq!(A::get((2,)), None);
+			assert_eq!(A::count(), 1);
+		});
 	}
 
 	#[test]


### PR DESCRIPTION
Closes #12782.

### Problem

`try_append` increments the counter on every append that fits the bound:

```rust
if current < bound {
    CounterFor::<Prefix>::mutate(|value| value.saturating_inc());
```

Appending to an existing key creates no entry, so `count()` climbs above the number of stored keys. remove decrements once per key, so the drift never clears.

Every other method in the file already guards this: `insert`, `append` and `remove` check `contains_key`, and `try_mutate_exists` tracks the `existed/exist` transition.

### Change

```rust
if !<Self as MapWrapper>::Map::contains_key(Ref::from(&key)) {
    CounterFor::<Prefix>::mutate(|value| value.saturating_inc());
}
```

The same guard `append` uses. `contains_key` rather than `current == 0`, because `decode_len(..).unwrap_or_default()` returns 0 both for an absent key and for an existing empty value.

`try_append_decode_len_works` already appends twice to one key but asserts only on `decode_len`, which is why this went unnoticed. The new test asserts `count()`.

No pallet calls `try_append` on a `CountedStorageMap` today, so nothing on-chain changes. The cost is one extra storage read per call, the same read insert and append already pay.