### PR TITLE
pallet-nfts: decrement attribute counter on cancel_item_attributes_approval

### DIFF
--- a/prdoc/pr_13034.prdoc
+++ b/prdoc/pr_13034.prdoc
@@ -1,0 +1,16 @@
+title: Decrement the nfts attribute counter when cancelling an attribute approval
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      cancel_item_attributes_approval removed a delegate's attributes from storage
+      but left CollectionDetails.attributes unchanged, so the counter grew above the
+      real number of stored attributes. The destroy witness is built from that
+      counter and destroy_collection requires it to match exactly, so a collection
+      that had a cancelled approval could no longer be destroyed with a correctly
+      computed witness. It now decrements the counter by the number of attributes it
+      drained, the same way clear_attribute does.
+
+crates:
+  - name: pallet-nfts
+    bump: patch

--- a/substrate/frame/nfts/src/features/attributes.rs
+++ b/substrate/frame/nfts/src/features/attributes.rs
@@ -443,6 +443,19 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				T::Currency::unreserve(&delegate, deposited);
 			}
 
+			// Keep `CollectionDetails.attributes` in sync with the attributes we
+			// just drained, mirroring `do_clear_attribute`. Without this the
+			// counter stays inflated and the derived destroy witness no longer
+			// matches `Attribute` storage, so the collection can't be destroyed
+			// with a correct witness (see the `BadWitness` check in
+			// `do_destroy_collection`).
+			if !attributes.is_zero() {
+				let mut collection_details =
+					Collection::<T, I>::get(&collection).ok_or(Error::<T, I>::UnknownCollection)?;
+				collection_details.attributes.saturating_reduce(attributes);
+				Collection::<T, I>::insert(collection, &collection_details);
+			}
+
 			Self::deposit_event(Event::ItemAttributesApprovalRemoved {
 				collection,
 				item,

--- a/substrate/frame/nfts/src/features/attributes.rs
+++ b/substrate/frame/nfts/src/features/attributes.rs
@@ -444,16 +444,16 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			}
 
 			// Keep `CollectionDetails.attributes` in sync with the attributes we
-			// just drained, mirroring `do_clear_attribute`. Without this the
-			// counter stays inflated and the derived destroy witness no longer
-			// matches `Attribute` storage, so the collection can't be destroyed
-			// with a correct witness (see the `BadWitness` check in
-			// `do_destroy_collection`).
+			// just drained. Without this the counter stays inflated and the
+			// derived destroy witness no longer matches `Attribute` storage, so
+			// the collection can't be destroyed with a correct witness (see the
+			// `BadWitness` check in `do_destroy_collection`).
 			if !attributes.is_zero() {
-				let mut collection_details =
-					Collection::<T, I>::get(&collection).ok_or(Error::<T, I>::UnknownCollection)?;
-				collection_details.attributes.saturating_reduce(attributes);
-				Collection::<T, I>::insert(collection, &collection_details);
+				Collection::<T, I>::try_mutate(collection, |maybe_details| -> DispatchResult {
+					let details = maybe_details.as_mut().ok_or(Error::<T, I>::UnknownCollection)?;
+					details.attributes.saturating_reduce(attributes);
+					Ok(())
+				})?;
 			}
 
 			Self::deposit_event(Event::ItemAttributesApprovalRemoved {

--- a/substrate/frame/nfts/src/tests.rs
+++ b/substrate/frame/nfts/src/tests.rs
@@ -1317,6 +1317,8 @@ fn set_external_account_attributes_should_work() {
 			]
 		);
 		assert_eq!(Balances::reserved_balance(account(2)), 6);
+		// the collection attribute counter tracks the two attributes just set
+		assert_eq!(Collection::<Test>::get(0).unwrap().attributes, 2);
 
 		// remove permission to set attributes
 		assert_ok!(Nfts::cancel_item_attributes_approval(
@@ -1327,6 +1329,10 @@ fn set_external_account_attributes_should_work() {
 			CancelAttributesApprovalWitness { account_attributes: 2 },
 		));
 		assert_eq!(attributes(0), vec![]);
+		// cancelling the approval must also decrement the collection counter,
+		// otherwise it drifts above the real `Attribute` storage count and the
+		// destroy witness no longer matches (regression test for #12775).
+		assert_eq!(Collection::<Test>::get(0).unwrap().attributes, 0);
 		assert_eq!(Balances::reserved_balance(account(2)), 0);
 		assert_noop!(
 			Nfts::set_attribute(


### PR DESCRIPTION
cancel_item_attributes_approval drains a delegate's attributes and unreserves their deposits, but it never decrements CollectionDetails.attributes or writes the collection back. set_attribute increments that counter and clear_attribute decrements it, so after a cancel the counter ends up higher than the number of attributes actually in storage.

That matters for destroying a collection: get_destroy_witness reads the counter, and do_destroy_collection requires collection_details.attributes == witness.attributes. So once an approval has been cancelled, a witness computed from the real storage is rejected as BadWitness, and you have to pass the inflated value instead.

The fix decrements the counter by the number of attributes drained (the loop already counts them) and writes the collection back, the same way clear_attribute does. I also extended the existing set_external_account_attributes_should_work test to check the counter before and after the cancel.

Found by the Runtime Whitebox Fuzzer, reported in #12775.

Closes #12775.
