### PR TITLE
`pallet-nfts`: decrement the attribute count when cancelling an attributes approval

### DIFF
--- a/prdoc/pr_13035.prdoc
+++ b/prdoc/pr_13035.prdoc
@@ -1,0 +1,16 @@
+title: 'pallet-nfts: decrement the attribute count when cancelling an attributes approval'
+doc:
+- audience: Runtime Dev
+  description: |-
+    `do_cancel_item_attributes_approval` drained the delegate's attributes and unreserved their
+    deposits without decrementing `CollectionDetails.attributes`, so the counter stayed above the
+    number of stored attributes and `DestroyWitness.attributes` reported the inflated value. It is
+    now reduced by the number of drained entries, matching `do_clear_attribute`.
+- audience: Runtime User
+  description: |-
+    A caller that derives the destroy witness from stored attributes rather than from
+    `get_destroy_witness` is no longer rejected with `BadWitness` after an attributes approval was
+    cancelled.
+crates:
+- name: pallet-nfts
+  bump: patch

--- a/substrate/frame/nfts/src/features/attributes.rs
+++ b/substrate/frame/nfts/src/features/attributes.rs
@@ -443,6 +443,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				T::Currency::unreserve(&delegate, deposited);
 			}
 
+			let mut collection_details =
+				Collection::<T, I>::get(&collection).ok_or(Error::<T, I>::UnknownCollection)?;
+			collection_details.attributes.saturating_reduce(attributes);
+			Collection::<T, I>::insert(collection, &collection_details);
+
 			Self::deposit_event(Event::ItemAttributesApprovalRemoved {
 				collection,
 				item,

--- a/substrate/frame/nfts/src/tests.rs
+++ b/substrate/frame/nfts/src/tests.rs
@@ -1343,6 +1343,61 @@ fn set_external_account_attributes_should_work() {
 }
 
 #[test]
+fn cancel_item_attributes_approval_updates_collection_attribute_count() {
+	new_test_ext().execute_with(|| {
+		Balances::make_free_balance_be(&account(1), 100);
+		Balances::make_free_balance_be(&account(2), 100);
+
+		assert_ok!(Nfts::force_create(
+			RuntimeOrigin::root(),
+			account(1),
+			collection_config_with_all_settings_enabled()
+		));
+		assert_ok!(Nfts::force_mint(
+			RuntimeOrigin::signed(account(1)),
+			0,
+			0,
+			account(1),
+			default_item_config()
+		));
+		assert_ok!(Nfts::approve_item_attributes(
+			RuntimeOrigin::signed(account(1)),
+			0,
+			0,
+			account(2)
+		));
+		assert_ok!(Nfts::set_attribute(
+			RuntimeOrigin::signed(account(2)),
+			0,
+			Some(0),
+			AttributeNamespace::Account(account(2)),
+			bvec![0],
+			bvec![0],
+		));
+		assert_ok!(Nfts::set_attribute(
+			RuntimeOrigin::signed(account(2)),
+			0,
+			Some(0),
+			AttributeNamespace::Account(account(2)),
+			bvec![1],
+			bvec![0],
+		));
+		assert_eq!(Collection::<Test>::get(0).unwrap().attributes, 2);
+
+		assert_ok!(Nfts::cancel_item_attributes_approval(
+			RuntimeOrigin::signed(account(1)),
+			0,
+			0,
+			account(2),
+			CancelAttributesApprovalWitness { account_attributes: 2 },
+		));
+		assert_eq!(attributes(0), vec![]);
+		assert_eq!(Collection::<Test>::get(0).unwrap().attributes, 0);
+		assert_eq!(Nfts::get_destroy_witness(&0).unwrap().attributes, 0);
+	});
+}
+
+#[test]
 fn validate_deposit_required_setting() {
 	new_test_ext().execute_with(|| {
 		Balances::make_free_balance_be(&account(1), 100);


### PR DESCRIPTION
Closes #12775.

### Problem

`do_cancel_item_attributes_approval` drains the delegate's attributes and counts them, but never writes the count back:

```rust
for (_, (_, deposit)) in Attribute::<T, I>::drain_prefix((
    &collection,
    Some(item),
    AttributeNamespace::Account(delegate.clone()),
)) {
    attributes.saturating_inc();
    deposited = deposited.saturating_add(deposit.amount);
}
```

`do_set_attribute` increments `CollectionDetails.attributes` for every namespace, `do_clear_attribute` decrements it. This path is the only one that removes attributes without touching the counter, so it stays above the number of stored entries.

### Change

```rust
let mut collection_details =
    Collection::<T, I>::get(&collection).ok_or(Error::<T, I>::UnknownCollection)?;
collection_details.attributes.saturating_reduce(attributes);
Collection::<T, I>::insert(collection, &collection_details);
```

The same get / modify / insert `do_clear_attribute` uses. The count is already computed by the drain loop.

`do_destroy_collection` compares the counter against `witness.attributes`, so a caller taking the witness from `get_destroy_witness` still passed. A caller deriving it from stored attributes got `BadWitness`.

`set_external_account_attributes_should_work` covers this path but asserts only on `attributes(0)` and reserved balance. The new test asserts the counter and the destroy witness.