### PR TITLE
`pallet-broker`: make storage changes made on revenue claim atomic on transfer

### DIFF
--- a/prdoc/pr_13040.prdoc
+++ b/prdoc/pr_13040.prdoc
@@ -1,0 +1,10 @@
+title: Propagate the revenue claim transfer error
+doc:
+- audience: Runtime Dev
+  description: |-
+    Return the error when the revenue payout to the payee fails, so the extrinsic reverts and
+    the claimant keeps the entitlement. The pallet previously discarded this error and removed
+    the entitlement without payment.
+crates:
+- name: pallet-broker
+  bump: patch

--- a/substrate/frame/broker/src/dispatchable_impls.rs
+++ b/substrate/frame/broker/src/dispatchable_impls.rs
@@ -20,7 +20,7 @@ use core::cmp;
 use super::*;
 use frame_support::{
 	pallet_prelude::*,
-	traits::{fungible::Mutate, tokens::Preservation::Expendable, DefensiveResult},
+	traits::{fungible::Mutate, tokens::Preservation::Expendable},
 };
 use sp_arithmetic::traits::{CheckedDiv, Saturating, Zero};
 use sp_runtime::traits::{BlockNumberProvider, Convert};
@@ -458,8 +458,10 @@ impl<T: Config> Pallet<T> {
 		if contribution.length > 0 {
 			InstaPoolContribution::<T>::insert(region, &contribution);
 		}
-		T::Currency::transfer(&Self::account_id(), &contribution.payee, payout, Expendable)
-			.defensive_ok();
+		// The steps above removed the contribution and reduced the stored payouts. If the
+		// transfer fails, the error must revert them. The storage changes and the payment
+		// must both happen, or neither.
+		T::Currency::transfer(&Self::account_id(), &contribution.payee, payout, Expendable)?;
 		let next = if last < region.begin + contribution.length { Some(region) } else { None };
 		Self::deposit_event(Event::RevenueClaimPaid {
 			who: contribution.payee,

--- a/substrate/frame/broker/src/tests.rs
+++ b/substrate/frame/broker/src/tests.rs
@@ -3144,3 +3144,54 @@ fn force_transfer_can_transfer_provisionally_assigned_region() {
 		);
 	});
 }
+
+/// A claim removes the contribution and reduces the stored payouts before it pays the payee.
+/// If the payment fails, all of these changes must revert. If they do not, the payee keeps no
+/// claim and receives no money, and a later attempt reports `UnknownContribution`.
+#[test]
+fn claim_revenue_reverts_when_pot_cannot_pay() {
+	TestExt::new().endow(1, 1000).execute_with(|| {
+		// Give account 2 a claim on pool revenue: reserve a pool core, sell a region to
+		// account 1, and pool that region with account 2 as the payee.
+		let item = ScheduleItem { assignment: Pool, mask: CoreMask::complete() };
+		assert_ok!(Broker::do_reserve(Schedule::truncate_from(vec![item])));
+		assert_ok!(Broker::do_start_sales(100, 2));
+		advance_to(2);
+		let region = Broker::do_purchase(1, u64::max_value()).unwrap();
+		assert_ok!(Broker::do_pool(region, None, 2, Final));
+
+		// Account 1 buys and spends credit. This sends revenue to the pot, where 4 units
+		// belong to account 2 and stay there until it claims them.
+		assert_ok!(Broker::do_purchase_credit(1, 20, 1));
+		advance_to(8);
+		assert_ok!(TestCoretimeProvider::spend_instantaneous(1, 10));
+		advance_to(11);
+		assert_eq!(pot(), 4);
+
+		// Empty the pot, so the payout to the payee cannot complete.
+		burn_from_pot(pot());
+		assert_eq!(pot(), 0);
+
+		// Call the extrinsic. It reverts the storage changes when the payout fails.
+		// A direct call to `do_claim_revenue` does not revert them.
+		let contribution_before = InstaPoolContribution::<Test>::get(region);
+		let history_before: Vec<_> = InstaPoolHistory::<Test>::iter().collect();
+
+		// The claim must fail, and it must leave the claim of account 2 in storage.
+		assert_err!(
+			Broker::claim_revenue(RuntimeOrigin::signed(2), region, 100),
+			TokenError::FundsUnavailable
+		);
+
+		assert_eq!(balance(2), 0);
+		assert_eq!(InstaPoolContribution::<Test>::get(region), contribution_before);
+		assert_eq!(InstaPoolHistory::<Test>::iter().collect::<Vec<_>>(), history_before);
+
+		// The claim stays valid. Account 2 receives the full amount after the pot holds
+		// funds again.
+		mint_to_pot(4);
+		assert_ok!(Broker::claim_revenue(RuntimeOrigin::signed(2), region, 100));
+		assert_eq!(balance(2), 4);
+		assert_eq!(pot(), 0);
+	});
+}


### PR DESCRIPTION
`do_claim_revenue` removes the contribution and reduces the stored payouts, then pays the payee. The payment used `defensive_ok`, which discards the error and returns `None`.

https://github.com/paritytech/polkadot-sdk/blob/90c177d163860c7836bdd118306f0459de9e7f28/substrate/frame/broker/src/dispatchable_impls.rs#L461-L462

Its `debug_assert!` does not run in a release build, so the function sent `RevenueClaimPaid` and returned `Ok`. If the payment failed, the payee lost the claim and received no money, and a second attempt gave `UnknownContribution`. An empty pot causes this failure, and the payee cannot control it.

https://github.com/paritytech/polkadot-sdk/blob/90c177d163860c7836bdd118306f0459de9e7f28/substrate/frame/broker/src/dispatchable_impls.rs#L424-L425

The payment now uses `?`. `claim_revenue` is the only caller. Dispatch thus reverts the storage changes when a call returns an error, so the claim stays in storage and the payee can try again.

The new test empties the pot, then confirms that the claim fails and stays in storage. It adds funds and confirms that the payee receives the full amount. The test calls the extrinsic and not the helper, because a direct call to the helper does not revert the changes.