### PR TITLE
sc-rpc-server: bound the cardinality of the RPC metrics `method` label

### DIFF
--- a/prdoc/pr_13045.prdoc
+++ b/prdoc/pr_13045.prdoc
@@ -1,17 +1,14 @@
-title: 'sc-rpc-server: bound the RPC metrics `method` label to registered methods'
+title: 'sc-rpc-server: bound the cardinality of the RPC metrics `method` label'
 doc:
   - audience: Node Operator
     description: |
-      The RPC metrics (`substrate_rpc_calls_*`) recorded the client-sent method name as a
-      Prometheus label before checking that the method exists, so an unauthenticated caller
-      reaching the RPC port could send unlimited distinct made-up names and grow the node's
-      memory without bound (one series per name, kept forever), leading to OOM. See
-      https://github.com/paritytech/eng_findings/issues/42.
+      The `substrate_rpc_calls_*` metrics used the requested method name as the `method`
+      label without restricting it to registered methods, so the label could take an
+      unbounded number of values. The label is now bounded to the registered method set;
+      any other name is recorded as `unknown`, keeping the series count finite.
 
-      The `method` label is now bounded to the registered method set; any other name is
-      recorded as `unknown`. Series count is capped at the number of registered methods
-      plus one. `RpcMetrics::with_known_methods` sets the allowlist and the RPC server
-      wires it at start; a metrics instance without it keeps the previous behaviour.
+      `RpcMetrics::with_known_methods` sets the allowlist and the RPC server wires it at
+      start; a metrics instance without it keeps the previous behaviour.
 crates:
   - name: sc-rpc-server
     bump: minor

--- a/prdoc/pr_13045.prdoc
+++ b/prdoc/pr_13045.prdoc
@@ -1,0 +1,17 @@
+title: 'sc-rpc-server: bound the RPC metrics `method` label to registered methods'
+doc:
+  - audience: Node Operator
+    description: |
+      The RPC metrics (`substrate_rpc_calls_*`) recorded the client-sent method name as a
+      Prometheus label before checking that the method exists, so an unauthenticated caller
+      reaching the RPC port could send unlimited distinct made-up names and grow the node's
+      memory without bound (one series per name, kept forever), leading to OOM. See
+      https://github.com/paritytech/eng_findings/issues/42.
+
+      The `method` label is now bounded to the registered method set; any other name is
+      recorded as `unknown`. Series count is capped at the number of registered methods
+      plus one. `RpcMetrics::with_known_methods` sets the allowlist and the RPC server
+      wires it at start; a metrics instance without it keeps the previous behaviour.
+crates:
+  - name: sc-rpc-server
+    bump: minor

--- a/substrate/client/rpc-servers/src/lib.rs
+++ b/substrate/client/rpc-servers/src/lib.rs
@@ -247,8 +247,16 @@ where
 	let rpc_handle = rpc_runtime.handle();
 
 	let (stop_handle, server_handle) = stop_channel();
+	let rpc_api = build_rpc_api(rpc_api);
+	// Bound the RPC metrics `method` label to the registered methods, so an
+	// unauthenticated caller cannot mint unbounded series with made-up names
+	// (see the `method_label` helper in `middleware::metrics`).
+	let metrics = metrics.map(|m| {
+		let known: Vec<&'static str> = rpc_api.method_names().collect();
+		m.with_known_methods(known)
+	});
 	let cfg = PerConnection {
-		methods: build_rpc_api(rpc_api).into(),
+		methods: rpc_api.into(),
 		metrics,
 		tokio_handle: rpc_handle.clone(),
 		stop_handle,

--- a/substrate/client/rpc-servers/src/lib.rs
+++ b/substrate/client/rpc-servers/src/lib.rs
@@ -248,9 +248,8 @@ where
 
 	let (stop_handle, server_handle) = stop_channel();
 	let rpc_api = build_rpc_api(rpc_api);
-	// Bound the RPC metrics `method` label to the registered methods, so an
-	// unauthenticated caller cannot mint unbounded series with made-up names
-	// (see the `method_label` helper in `middleware::metrics`).
+	// Bound the metrics `method` label to the registered methods; otherwise an
+	// unauthenticated caller can OOM the node via unbounded label cardinality.
 	let metrics = metrics.map(|m| {
 		let known: Vec<&'static str> = rpc_api.method_names().collect();
 		m.with_known_methods(known)

--- a/substrate/client/rpc-servers/src/lib.rs
+++ b/substrate/client/rpc-servers/src/lib.rs
@@ -248,8 +248,8 @@ where
 
 	let (stop_handle, server_handle) = stop_channel();
 	let rpc_api = build_rpc_api(rpc_api);
-	// Bound the metrics `method` label to the registered methods; otherwise an
-	// unauthenticated caller can OOM the node via unbounded label cardinality.
+	// Bound the metrics `method` label to the registered methods so its
+	// cardinality stays finite (unknown names collapse to `"unknown"`).
 	let metrics = metrics.map(|m| {
 		let known: Vec<&'static str> = rpc_api.method_names().collect();
 		m.with_known_methods(known)

--- a/substrate/client/rpc-servers/src/middleware/metrics.rs
+++ b/substrate/client/rpc-servers/src/middleware/metrics.rs
@@ -78,9 +78,8 @@ pub struct RpcMetrics {
 	ws_sessions_closed: Option<Counter<U64>>,
 	/// Histogram over RPC websocket sessions.
 	ws_sessions_time: HistogramVec,
-	/// Registered method names. The `method` label is bounded to this set so an
-	/// unauthenticated caller cannot mint unbounded series with made-up names.
-	/// Empty means "not configured": labels fall back to the raw name (old behaviour).
+	/// Bounds the `method` label so untrusted callers cannot mint unbounded series.
+	/// Empty = not configured: fall back to the raw name (old behaviour).
 	known_methods: Arc<HashSet<&'static str>>,
 }
 
@@ -178,15 +177,13 @@ impl RpcMetrics {
 		}
 	}
 
-	/// Bound the `method` label to `names`; any other method name is recorded as
-	/// `"unknown"`. Call once at server start with the registered method set.
+	/// Set the registered methods so unknown names collapse to `"unknown"`.
 	pub fn with_known_methods(mut self, names: impl IntoIterator<Item = &'static str>) -> Self {
 		self.known_methods = Arc::new(names.into_iter().collect());
 		self
 	}
 
-	/// Resolve the `method` label: the real name if registered, else `"unknown"`.
-	/// Falls back to the raw name when no set was configured (empty).
+	/// Registered name, else `"unknown"` (raw name if not configured).
 	fn method_label<'a>(&'a self, req: &'a Request) -> &'a str {
 		let name = req.method_name();
 		if self.known_methods.is_empty() || self.known_methods.contains(name) {

--- a/substrate/client/rpc-servers/src/middleware/metrics.rs
+++ b/substrate/client/rpc-servers/src/middleware/metrics.rs
@@ -18,7 +18,11 @@
 
 //! RPC middleware to collect prometheus metrics on RPC calls.
 
-use std::{sync::LazyLock, time::Instant};
+use std::{
+	collections::HashSet,
+	sync::{Arc, LazyLock},
+	time::Instant,
+};
 
 use jsonrpsee::{types::Request, MethodResponse};
 use prometheus::core::{GenericCounter, GenericGauge};
@@ -74,6 +78,10 @@ pub struct RpcMetrics {
 	ws_sessions_closed: Option<Counter<U64>>,
 	/// Histogram over RPC websocket sessions.
 	ws_sessions_time: HistogramVec,
+	/// Registered method names. The `method` label is bounded to this set so an
+	/// unauthenticated caller cannot mint unbounded series with made-up names.
+	/// Empty means "not configured": labels fall back to the raw name (old behaviour).
+	known_methods: Arc<HashSet<&'static str>>,
 }
 
 impl RpcMetrics {
@@ -163,9 +171,28 @@ impl RpcMetrics {
 					)?,
 					metrics_registry,
 				)?,
+				known_methods: Default::default(),
 			}))
 		} else {
 			Ok(None)
+		}
+	}
+
+	/// Bound the `method` label to `names`; any other method name is recorded as
+	/// `"unknown"`. Call once at server start with the registered method set.
+	pub fn with_known_methods(mut self, names: impl IntoIterator<Item = &'static str>) -> Self {
+		self.known_methods = Arc::new(names.into_iter().collect());
+		self
+	}
+
+	/// Resolve the `method` label: the real name if registered, else `"unknown"`.
+	/// Falls back to the raw name when no set was configured (empty).
+	fn method_label<'a>(&'a self, req: &'a Request) -> &'a str {
+		let name = req.method_name();
+		if self.known_methods.is_empty() || self.known_methods.contains(name) {
+			name
+		} else {
+			"unknown"
 		}
 	}
 
@@ -189,7 +216,7 @@ impl RpcMetrics {
 		);
 
 		self.calls_started
-			.with_label_values(&[transport_label, req.method_name()])
+			.with_label_values(&[transport_label, self.method_label(req)])
 			.inc();
 	}
 
@@ -200,7 +227,7 @@ impl RpcMetrics {
 			req.method_name(),
 		);
 		self.calls_rejected
-			.with_label_values(&[transport_label, req.method_name()])
+			.with_label_values(&[transport_label, self.method_label(req)])
 			.inc();
 	}
 
@@ -211,7 +238,7 @@ impl RpcMetrics {
 			req.method_name(),
 		);
 		self.calls_retried
-			.with_label_values(&[transport_label, req.method_name()])
+			.with_label_values(&[transport_label, self.method_label(req)])
 			.inc();
 	}
 
@@ -233,17 +260,18 @@ impl RpcMetrics {
 			req.method_name(),
 			micros,
 		);
+		let method = self.method_label(req);
 		self.calls_time
 			.with_label_values(&[
 				transport_label,
-				req.method_name(),
+				method,
 				if is_rate_limited { "true" } else { "false" },
 			])
 			.observe(micros as _);
 		self.calls_finished
 			.with_label_values(&[
 				transport_label,
-				req.method_name(),
+				method,
 				// the label "is_error", so `success` should be regarded as false
 				// and vice-versa to be registered correctly.
 				if rp.is_success() { "false" } else { "true" },
@@ -294,5 +322,66 @@ impl Metrics {
 		now: Instant,
 	) {
 		self.inner.on_response(req, rp, is_rate_limited, self.transport_label, now)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use jsonrpsee::types::Request;
+	use prometheus::core::Collector;
+	use prometheus_endpoint::Registry;
+	use std::borrow::Cow;
+
+	fn req(method: &'static str) -> Request<'static> {
+		Request {
+			jsonrpc: jsonrpsee::types::TwoPointZero,
+			id: jsonrpsee::types::Id::Number(1),
+			method: Cow::Borrowed(method),
+			params: None,
+			extensions: Default::default(),
+		}
+	}
+
+	fn metrics_with(known: &[&'static str]) -> RpcMetrics {
+		RpcMetrics::new(Some(&Registry::new()))
+			.unwrap()
+			.unwrap()
+			.with_known_methods(known.iter().copied())
+	}
+
+	#[test]
+	fn known_method_keeps_its_name() {
+		let m = metrics_with(&["state_getStorage", "chain_getBlock"]);
+		assert_eq!(m.method_label(&req("state_getStorage")), "state_getStorage");
+	}
+
+	#[test]
+	fn unknown_method_is_bucketed() {
+		let m = metrics_with(&["state_getStorage"]);
+		assert_eq!(m.method_label(&req("totally_made_up_9f3c")), "unknown");
+	}
+
+	#[test]
+	fn empty_set_preserves_raw_name() {
+		// Not configured: fall back to the raw name (backwards compatible).
+		let m = RpcMetrics::new(Some(&Registry::new())).unwrap().unwrap();
+		assert_eq!(m.method_label(&req("anything")), "anything");
+	}
+
+	#[test]
+	fn bounded_series_count_under_junk_flood() {
+		let m = metrics_with(&["state_getStorage", "chain_getBlock"]);
+		for i in 0..1000 {
+			// Leak so the &'static str requirement is satisfied; test-only.
+			let name: &'static str = Box::leak(format!("junk_{i}").into_boxed_str());
+			m.on_call(&req(name), "ws");
+		}
+		m.on_call(&req("state_getStorage"), "ws");
+		// 1000 distinct junk names collapse to a single `unknown` series; plus the
+		// one known method actually called = 2. Without the fix this would be 1001.
+		let families = m.calls_started.collect();
+		let series = families.iter().map(|f| f.get_metric().len()).sum::<usize>();
+		assert_eq!(series, 2);
 	}
 }

--- a/substrate/client/rpc-servers/src/middleware/metrics.rs
+++ b/substrate/client/rpc-servers/src/middleware/metrics.rs
@@ -78,7 +78,7 @@ pub struct RpcMetrics {
 	ws_sessions_closed: Option<Counter<U64>>,
 	/// Histogram over RPC websocket sessions.
 	ws_sessions_time: HistogramVec,
-	/// Bounds the `method` label so untrusted callers cannot mint unbounded series.
+	/// Bounds the `method` label to keep series cardinality finite.
 	/// Empty = not configured: fall back to the raw name (old behaviour).
 	known_methods: Arc<HashSet<&'static str>>,
 }
@@ -375,8 +375,8 @@ mod tests {
 			m.on_call(&req(name), "ws");
 		}
 		m.on_call(&req("state_getStorage"), "ws");
-		// 1000 distinct junk names collapse to a single `unknown` series; plus the
-		// one known method actually called = 2. Without the fix this would be 1001.
+		// 1000 distinct unregistered names collapse to a single `unknown` series,
+		// plus the one registered method actually called = 2.
 		let families = m.calls_started.collect();
 		let series = families.iter().map(|f| f.get_metric().len()).sum::<usize>();
 		assert_eq!(series, 2);


### PR DESCRIPTION
The `substrate_rpc_calls_*` metrics used the requested method name as the `method` label without restricting it to registered methods, so the label cardinality was unbounded.

Bound it to the registered method set and record everything else as `unknown`, so the series count stays finite. Additive and backwards compatible (an unconfigured `RpcMetrics` keeps the old behaviour), so `minor`.
