### PR TITLE
feat(sc-consensus-babe): expose build_verifier like Aura

### DIFF
--- a/prdoc/pr_13061.prdoc
+++ b/prdoc/pr_13061.prdoc
@@ -1,0 +1,13 @@
+title: 'feat(sc-consensus-babe): expose build_verifier like Aura'
+doc:
+  - audience: Node Dev
+    description: |
+      BABE cannot be used with a custom import queue today, because `BabeVerifier` is only
+      constructed inside `import_queue` and immediately wrapped in `BasicQueue`.
+
+      This change adds `build_verifier` and `BuildVerifierParams`, matching Aura, so a node
+      can compose `BabeVerifier` into its own `ImportQueue`. Existing `import_queue` callers
+      are unchanged: it still builds a `BasicQueue` and still spawns the epoch-data worker.
+crates:
+  - name: sc-consensus-babe
+    bump: minor

--- a/substrate/client/consensus/babe/src/lib.rs
+++ b/substrate/client/consensus/babe/src/lib.rs
@@ -988,6 +988,18 @@ pub struct BabeVerifier<Block: BlockT, Client> {
 	telemetry: Option<TelemetryHandle>,
 }
 
+impl<Block: BlockT, Client> BabeVerifier<Block, Client> {
+	pub(crate) fn new(
+		client: Arc<Client>,
+		slot_duration: SlotDuration,
+		config: BabeConfiguration,
+		epoch_changes: SharedEpochChanges<Block, Epoch>,
+		telemetry: Option<TelemetryHandle>,
+	) -> Self {
+		Self { client, slot_duration, config, epoch_changes, telemetry }
+	}
+}
+
 #[async_trait::async_trait]
 impl<Block, Client> Verifier<Block> for BabeVerifier<Block, Client>
 where
@@ -1844,6 +1856,30 @@ where
 	Ok((import, link))
 }
 
+/// Parameters of [`build_verifier`].
+pub struct BuildVerifierParams<Block: BlockT, Client> {
+	/// The client to interact with the internals of the node.
+	pub client: Arc<Client>,
+	/// Slot duration.
+	pub slot_duration: SlotDuration,
+	/// BABE configuration for this chain.
+	pub config: BabeConfiguration,
+	/// Shared epoch-changes tree.
+	pub epoch_changes: SharedEpochChanges<Block, Epoch>,
+	/// Optional telemetry handle to report telemetry events.
+	pub telemetry: Option<TelemetryHandle>,
+}
+
+/// Build the [`BabeVerifier`]
+pub fn build_verifier<Block: BlockT, Client>(
+	BuildVerifierParams { client, slot_duration, config, epoch_changes, telemetry }: BuildVerifierParams<
+		Block,
+		Client,
+	>,
+) -> BabeVerifier<Block, Client> {
+	BabeVerifier::new(client, slot_duration, config, epoch_changes, telemetry)
+}
+
 /// Parameters passed to [`import_queue`].
 pub struct ImportQueueParams<'a, Block: BlockT, BI, Client, Spawn> {
 	/// The BABE link that is created by [`block_import`].
@@ -1899,13 +1935,13 @@ where
 {
 	const HANDLE_BUFFER_SIZE: usize = 1024;
 
-	let verifier = BabeVerifier {
+	let verifier = build_verifier(BuildVerifierParams {
+		client: client.clone(),
 		slot_duration,
 		config: babe_link.config.clone(),
 		epoch_changes: babe_link.epoch_changes.clone(),
 		telemetry,
-		client: client.clone(),
-	};
+	});
 
 	let (worker_tx, worker_rx) = channel(HANDLE_BUFFER_SIZE);
 


### PR DESCRIPTION
# Description

**Motivation:** BABE cannot be used with a custom import queue today, because `BabeVerifier` is only constructed inside `import_queue` and immediately wrapped in `BasicQueue`.

Aura already exposes `build_verifier` for that. This PR adds the same API for BABE (`build_verifier` + `BuildVerifierParams`) so a node can compose `BabeVerifier` into its own `ImportQueue`.

`import_queue` is unchanged for existing callers: it still builds a `BasicQueue` and still spawns the epoch-data worker.

# Integration

No change for callers of `import_queue`.

To compose BABE with a custom queue (same pattern as Aura):

```rust
let verifier = sc_consensus_babe::build_verifier(sc_consensus_babe::BuildVerifierParams {
    client: client.clone(),
    slot_duration,
    config: babe_link.config().clone(),
    epoch_changes: babe_link.epoch_changes().clone(),
    telemetry,
});
// pass `verifier` into BasicQueue::new or any ImportQueue
```

`BabeVerifier::new` stays `pub(crate)`. Epoch RPC still comes only from `import_queue` (`BabeWorkerHandle`).

# Review Notes

- `BuildVerifierParams` + `build_verifier` are the Aura equivalents (`sc_consensus_aura::{BuildVerifierParams, build_verifier}`).
- `import_queue` now calls `build_verifier` instead of constructing `BabeVerifier { ... }` inline. Worker spawn and `BasicQueue::new` are unchanged.
- No verification or import-path behavior change. No tests: API surface only.