### PR TITLE
Add TransactionChargeApi to estimate fees in payment assets

### DIFF
--- a/prdoc/pr_13070.prdoc
+++ b/prdoc/pr_13070.prdoc
@@ -1,0 +1,27 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Add TransactionChargeApi to estimate fees in payment assets
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Adds an opt-in `TransactionChargeApi` to estimate which assets would be withdrawn from the
+      sender to pay for a transaction, and a `ChargeAssetTxPayment::quote_fee` to build it from.
+
+      **Breaking**: `pallet_asset_conversion_tx_payment::OnChargeAssetTransaction` now requires
+      `quote_asset_fee`. `SwapAssetAdapter` already implements it; only custom adapters need
+      work. The same-named trait in `pallet-asset-tx-payment` is unaffected.
+
+  - audience: Runtime User
+    description: |
+      Chains that implement `TransactionChargeApi` expose `estimate_charge`, which reports the
+      fee in the assets the sender pays with, including the tip. The call is read-only and
+      best-effort: it does not imply the sender can pay, and the amount later charged can
+      differ.
+
+crates:
+  - name: pallet-asset-conversion-tx-payment
+    bump: major
+  - name: pallet-transaction-payment-rpc-runtime-api
+    bump: minor

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3316,6 +3316,53 @@ mod mmr {
 	pub type Hashing = <Runtime as pallet_mmr::Config>::Hashing;
 }
 
+/// Helpers for [`pallet_transaction_payment_rpc_runtime_api::TransactionChargeApi`].
+mod transaction_charge {
+	use super::*;
+	use frame_support::dispatch::GetDispatchInfo;
+	use frame_system::RawOrigin;
+	use pallet_asset_conversion_tx_payment::{ChargeAssetTxPayment, FeeQuote};
+	use sp_runtime::{generic::Preamble, traits::StaticLookup};
+
+	/// Quotes [`ChargeAssetTxPayment`] only.
+	///
+	/// `AsScarcity` and `SkipCheckIfFeeless` are ignored, so the estimate can be non-zero
+	/// for a transaction that would not be charged.
+	///
+	/// General transactions are not quoted at all, since their origin is resolved by the
+	/// transaction extension pipeline, which this helper does not run.
+	pub fn estimate_charge(
+		uxt: &UncheckedExtrinsic,
+		len: u32,
+	) -> Option<Vec<(NativeOrWithId<u32>, Balance)>> {
+		let quote = match &uxt.0.preamble {
+			// Bare extrinsics carry no extension data and have no payer.
+			Preamble::Bare(_) => FeeQuote::Nothing,
+			Preamble::Signed(address, _, tx_ext) => {
+				let who =
+					<Runtime as frame_system::Config>::Lookup::lookup(address.clone()).ok()?;
+				tx_payment(tx_ext).quote_fee(
+					RawOrigin::Signed(who).into(),
+					&uxt.get_dispatch_info(),
+					len,
+				)?
+			},
+			Preamble::General(_) => return None,
+		};
+
+		Some(match quote {
+			FeeQuote::Nothing => vec![],
+			FeeQuote::Native(fee) => vec![(NativeOrWithId::Native, fee)],
+			FeeQuote::Asset((asset_id, fee)) => vec![(asset_id, fee)],
+		})
+	}
+
+	fn tx_payment(tx_ext: &TxExtension) -> &ChargeAssetTxPayment<Runtime> {
+		let (_, _, _, _, _, _, _, _, skip_feeless, _, _, _) = tx_ext;
+		&skip_feeless.0
+	}
+}
+
 #[cfg(feature = "runtime-benchmarks")]
 pub struct AssetConversionTxHelper;
 
@@ -3837,6 +3884,14 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 		}
 		fn query_length_to_fee(length: u32) -> Balance {
 			TransactionPayment::length_to_fee(length)
+		}
+	}
+
+	impl pallet_transaction_payment_rpc_runtime_api::TransactionChargeApi<Block, Balance, NativeOrWithId<u32>>
+		for Runtime
+	{
+		fn estimate_charge(uxt: <Block as BlockT>::Extrinsic, len: u32) -> Option<Vec<(NativeOrWithId<u32>, Balance)>> {
+			transaction_charge::estimate_charge(&uxt, len)
 		}
 	}
 

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
@@ -102,12 +102,10 @@ pub enum InitialPayment<T: Config> {
 	Asset((T::AssetId, AssetLiquidityInfoOf<T>)),
 }
 
-/// Estimated fee that would be charged for an extrinsic.
-///
-/// Returned by [`ChargeAssetTxPayment::quote_fee`].
+/// The fee that [`ChargeAssetTxPayment::quote_fee`] would request, if any.
 #[derive(DebugNoBound, PartialEqNoBound, EqNoBound)]
 pub enum FeeQuote<T: Config> {
-	/// No fee would be charged.
+	/// No payment would be requested.
 	Nothing,
 	/// Fee with no payment asset selected ([`ChargeAssetTxPayment::from`] with `None`).
 	Native(BalanceOf<T>),
@@ -203,10 +201,10 @@ where
 		Self { tip, asset_id }
 	}
 
-	/// Quote the fee that would be charged for this transaction.
+	/// Quote the fee this extension would request.
 	///
-	/// Does not withdraw funds or check the account balance. The quote uses the pre-dispatch fee
-	/// from `info` (including tip). It can differ from the amount later charged: unused weight is
+	/// Does not withdraw funds or check the account balance. The quote is the pre-dispatch fee for
+	/// `info`, with the tip added. It can differ from the amount later charged: unused weight is
 	/// refunded after dispatch, and the fee can change before inclusion.
 	///
 	/// Returns [`FeeQuote::Nothing`] if the origin is not a signer or the computed fee is zero, and

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
@@ -49,7 +49,7 @@ use frame_support::{
 	dispatch::{DispatchInfo, DispatchResult, PostDispatchInfo},
 	pallet_prelude::TransactionSource,
 	traits::IsType,
-	DefaultNoBound,
+	DebugNoBound, DefaultNoBound, EqNoBound, PartialEqNoBound,
 };
 use pallet_transaction_payment::{ChargeTransactionPayment, OnChargeTransaction};
 use scale_info::TypeInfo;
@@ -100,6 +100,19 @@ pub enum InitialPayment<T: Config> {
 	Native(NativeLiquidityInfoOf<T>),
 	/// The initial fee was paid in an asset.
 	Asset((T::AssetId, AssetLiquidityInfoOf<T>)),
+}
+
+/// Estimated fee that would be charged for an extrinsic.
+///
+/// Returned by [`ChargeAssetTxPayment::quote_fee`].
+#[derive(DebugNoBound, PartialEqNoBound, EqNoBound)]
+pub enum FeeQuote<T: Config> {
+	/// No fee would be charged.
+	Nothing,
+	/// Fee with no payment asset selected ([`ChargeAssetTxPayment::from`] with `None`).
+	Native(BalanceOf<T>),
+	/// Fee in the selected payment asset ([`ChargeAssetTxPayment::from`] with `Some`).
+	Asset((T::AssetId, BalanceOf<T>)),
 }
 
 pub use pallet::*;
@@ -188,6 +201,39 @@ where
 	/// Utility constructor. Used only in client/factory code.
 	pub fn from(tip: BalanceOf<T>, asset_id: Option<T::AssetId>) -> Self {
 		Self { tip, asset_id }
+	}
+
+	/// Quote the fee that would be charged for this transaction.
+	///
+	/// Does not withdraw funds or check the account balance. The quote uses the pre-dispatch fee
+	/// from `info` (including tip). It can differ from the amount later charged: unused weight is
+	/// refunded after dispatch, and the fee can change before inclusion.
+	///
+	/// Returns [`FeeQuote::Nothing`] if the origin is not a signer or the computed fee is zero, and
+	/// `None` if the fee cannot be converted into the chosen asset.
+	pub fn quote_fee(
+		&self,
+		origin: <T::RuntimeCall as Dispatchable>::RuntimeOrigin,
+		info: &DispatchInfoOf<T::RuntimeCall>,
+		len: u32,
+	) -> Option<FeeQuote<T>>
+	where
+		<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId>,
+	{
+		if origin.as_system_origin_signer().is_none() {
+			return Some(FeeQuote::Nothing);
+		}
+
+		let fee = pallet_transaction_payment::Pallet::<T>::compute_fee(len, info, self.tip);
+
+		if fee.is_zero() {
+			Some(FeeQuote::Nothing)
+		} else if let Some(asset_id) = &self.asset_id {
+			let asset_fee = T::OnChargeAssetTransaction::quote_asset_fee(asset_id.clone(), fee)?;
+			Some(FeeQuote::Asset((asset_id.clone(), asset_fee)))
+		} else {
+			Some(FeeQuote::Native(fee))
+		}
 	}
 
 	/// Fee withdrawal logic that dispatches to either [`Config::OnChargeAssetTransaction`] or

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/payment.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/payment.rs
@@ -38,7 +38,7 @@ use sp_runtime::{
 	Saturating,
 };
 
-/// Handle withdrawing, refunding and depositing of transaction fees.
+/// Handle quoting, withdrawing, refunding and depositing of transaction fees.
 pub trait OnChargeAssetTransaction<T: Config> {
 	/// The underlying integer type in which fees are calculated.
 	type Balance: Balance;
@@ -46,6 +46,13 @@ pub trait OnChargeAssetTransaction<T: Config> {
 	type AssetId: AssetId;
 	/// The type used to store the intermediate values between pre- and post-dispatch.
 	type LiquidityInfo;
+
+	/// Quote the amount of `asset_id` required to pay `fee`.
+	///
+	/// Note: The `fee` already includes the `tip`.
+	///
+	/// Returns `None` if `fee` cannot be converted into `asset_id`.
+	fn quote_asset_fee(asset_id: Self::AssetId, fee: Self::Balance) -> Option<Self::Balance>;
 
 	/// Secure the payment of the transaction fees before the transaction is executed.
 	///
@@ -85,7 +92,7 @@ pub trait OnChargeAssetTransaction<T: Config> {
 	) -> Result<BalanceOf<T>, TransactionValidityError>;
 }
 
-/// Means to withdraw, correct and deposit fees in the asset accepted by the system.
+/// Means to quote, withdraw, correct and deposit fees in the asset accepted by the system.
 ///
 /// The type uses the [`SwapCredit`] implementation to swap the asset used by a user for the fee
 /// payment for the asset accepted as a fee payment be the system.
@@ -116,6 +123,16 @@ where
 	type Balance = BalanceOf<T>;
 	type LiquidityInfo = (fungibles::Credit<T::AccountId, F>, BalanceOf<T>);
 
+	fn quote_asset_fee(asset_id: Self::AssetId, fee: Self::Balance) -> Option<Self::Balance> {
+		if asset_id == A::get() {
+			// The `asset_id` is the target asset, we do not need to swap.
+			return Some(fee);
+		}
+
+		S::quote_price_tokens_for_exact_tokens(asset_id, A::get(), fee, true)
+			.filter(|asset_fee| !asset_fee.is_zero())
+	}
+
 	fn withdraw_fee(
 		who: &T::AccountId,
 		_call: &T::RuntimeCall,
@@ -139,10 +156,8 @@ where
 			return Ok((fee_credit, fee));
 		}
 
-		// Quote the amount of the `asset_id` needed to pay the fee in the asset `A`.
 		let asset_fee =
-			S::quote_price_tokens_for_exact_tokens(asset_id.clone(), A::get(), fee, true)
-				.filter(|asset_fee| !asset_fee.is_zero())
+			<Self as OnChargeAssetTransaction<T>>::quote_asset_fee(asset_id.clone(), fee)
 				.ok_or(InvalidTransaction::Payment)?;
 
 		// Withdraw the `asset_id` credit for the swap.
@@ -194,8 +209,7 @@ where
 		}
 
 		let asset_fee =
-			S::quote_price_tokens_for_exact_tokens(asset_id.clone(), A::get(), fee, true)
-				.filter(|asset_fee| !asset_fee.is_zero())
+			<Self as OnChargeAssetTransaction<T>>::quote_asset_fee(asset_id.clone(), fee)
 				.ok_or(InvalidTransaction::Payment)?;
 
 		// Ensure we can withdraw enough `asset_id` for the swap.

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/tests.rs
@@ -169,6 +169,12 @@ fn transaction_payment_in_native_possible() {
 			let mut info = info_from_weight(WEIGHT_5);
 			let ext = ChargeAssetTxPayment::<Runtime>::from(0, None);
 			info.extension_weight = ext.weight(CALL);
+
+			assert_eq!(
+				ext.quote_fee(Some(1).into(), &info, len as u32),
+				Some(FeeQuote::Native(5 + 5 + 15 + 10))
+			);
+
 			let (pre, _) = ext.validate_and_prepare(Some(1).into(), CALL, &info, len, 0).unwrap();
 			let initial_balance = 10 * balance_factor;
 			assert_eq!(Balances::free_balance(1), initial_balance - 5 - 5 - 15 - 10);
@@ -255,15 +261,16 @@ fn transaction_payment_in_asset_possible() {
 			let fee_in_asset = input_quote.unwrap();
 			assert_eq!(Assets::balance(asset_id, caller), balance);
 
-			let (pre, _) = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()))
-				.validate_and_prepare(
-					Some(caller).into(),
-					CALL,
-					&info_from_weight(WEIGHT_5),
-					len,
-					0,
-				)
-				.unwrap();
+			let info = info_from_weight(WEIGHT_5);
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()));
+
+			assert_eq!(
+				ext.quote_fee(Some(caller).into(), &info, len as u32),
+				Some(FeeQuote::Asset((NativeOrWithId::WithId(asset_id), fee_in_asset)))
+			);
+
+			let (pre, _) =
+				ext.validate_and_prepare(Some(caller).into(), CALL, &info, len, 0).unwrap();
 			// assert that native balance is not used
 			assert_eq!(Balances::free_balance(caller), 10 * balance_factor);
 
@@ -278,8 +285,8 @@ fn transaction_payment_in_asset_possible() {
 
 			assert_ok!(ChargeAssetTxPayment::<Runtime>::post_dispatch_details(
 				pre,
-				&info_from_weight(WEIGHT_5), // estimated tx weight
-				&default_post_info(),        // weight actually used == estimated
+				&info,                // estimated tx weight
+				&default_post_info(), // weight actually used == estimated
 				len,
 				&Ok(()),
 			));
@@ -800,6 +807,12 @@ fn fee_with_native_asset_passed_with_id() {
 
 			let mut info = info_from_weight(WEIGHT_100);
 			info.extension_weight = extension_weight;
+
+			assert_eq!(
+				ext.quote_fee(Some(caller).into(), &info, len as u32),
+				Some(FeeQuote::Asset((NativeOrWithId::Native, initial_fee)))
+			);
+
 			let (pre, _) =
 				ext.validate_and_prepare(Some(caller).into(), CALL, &info, len, 0).unwrap();
 			assert_eq!(Balances::free_balance(caller), caller_balance - initial_fee);
@@ -1726,5 +1739,259 @@ fn validate_rejects_zero_asset_fee_but_accepts_small_nonzero() {
 				0,
 			);
 			assert!(result.is_ok(), "Small but non-zero fee should pass validation");
+		});
+}
+
+#[test]
+fn quote_fee_in_native_possible() {
+	let base_weight = 5;
+	let balance_factor = 100;
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			let len = 10;
+			let info = info_from_weight(WEIGHT_5);
+
+			let expected =
+				pallet_transaction_payment::Pallet::<Runtime>::compute_fee(len, &info, 0);
+			assert!(expected > 0);
+
+			let caller = 1;
+			let native_before = Balances::free_balance(caller);
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, None);
+			assert_eq!(
+				ext.quote_fee(Some(caller).into(), &info, len),
+				Some(FeeQuote::Native(expected))
+			);
+			// Quote must not withdraw funds.
+			assert_eq!(Balances::free_balance(caller), native_before);
+		});
+}
+
+#[test]
+fn quote_fee_in_asset_possible() {
+	let base_weight = 5;
+	let balance_factor = 100;
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			let asset_id = 1;
+			let min_balance = 2;
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				asset_id.into(),
+				42,
+				true,
+				min_balance,
+			));
+			setup_lp(asset_id, balance_factor);
+
+			let caller = 1;
+			let beneficiary = <Runtime as system::Config>::Lookup::unlookup(caller);
+			let balance = 1000;
+			assert_ok!(Assets::mint_into(asset_id.into(), &beneficiary, balance));
+
+			let len = 10;
+			let info = info_from_weight(WEIGHT_5);
+			let fee_in_native =
+				pallet_transaction_payment::Pallet::<Runtime>::compute_fee(len, &info, 0);
+			let expected_asset_fee = AssetConversion::quote_price_tokens_for_exact_tokens(
+				NativeOrWithId::WithId(asset_id),
+				NativeOrWithId::Native,
+				fee_in_native,
+				true,
+			)
+			.unwrap();
+
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()));
+			let native_before = Balances::free_balance(caller);
+			let asset_before = Assets::balance(asset_id, caller);
+
+			assert_eq!(
+				ext.quote_fee(Some(caller).into(), &info, len),
+				Some(FeeQuote::Asset((NativeOrWithId::WithId(asset_id), expected_asset_fee)))
+			);
+			assert_eq!(Balances::free_balance(caller), native_before);
+			assert_eq!(Assets::balance(asset_id, caller), asset_before);
+		});
+}
+
+#[test]
+fn quote_fee_in_asset_fails_if_no_pool_for_that_asset() {
+	let base_weight = 5;
+	let balance_factor = 100;
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			let asset_id = 1;
+			let min_balance = 2;
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				asset_id.into(),
+				42,
+				true,
+				min_balance,
+			));
+
+			let len = 10;
+			let info = info_from_weight(WEIGHT_5);
+			let fee = pallet_transaction_payment::Pallet::<Runtime>::compute_fee(len, &info, 0);
+			assert!(fee > 0);
+
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()));
+			assert!(ext.quote_fee(Some(1).into(), &info, len).is_none());
+		});
+}
+
+#[test]
+fn quote_fee_possible_when_validate_fails() {
+	let base_weight = 5;
+	let balance_factor = 100;
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			let asset_id = 1;
+			let min_balance = 2;
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				asset_id.into(),
+				42,
+				true,
+				min_balance,
+			));
+			setup_lp(asset_id, balance_factor);
+
+			let caller = 99;
+			assert_eq!(Balances::free_balance(caller), 0);
+			assert_eq!(Assets::balance(asset_id, caller), 0);
+
+			let len = 10;
+			let info = info_from_weight(WEIGHT_5);
+			let origin: RuntimeOrigin = Some(caller).into();
+			let ext_native = ChargeAssetTxPayment::<Runtime>::from(0, None);
+			let ext_asset = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()));
+
+			assert!(ext_native.quote_fee(origin.clone(), &info, len).is_some());
+			assert!(ext_asset.quote_fee(origin.clone(), &info, len).is_some());
+			assert!(ext_native
+				.validate_and_prepare(origin.clone(), CALL, &info, len as usize, 0)
+				.is_err());
+			assert!(ext_asset.validate_and_prepare(origin, CALL, &info, len as usize, 0).is_err());
+		});
+}
+
+#[test]
+fn quote_fee_with_tip() {
+	let base_weight = 5;
+	let balance_factor = 100;
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			let asset_id = 1;
+			let min_balance = 2;
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				asset_id.into(),
+				42,
+				true,
+				min_balance,
+			));
+			setup_lp(asset_id, balance_factor);
+
+			let len = 10;
+			let tip = 5;
+			let info = info_from_weight(WEIGHT_5);
+
+			let fee_with_tip =
+				pallet_transaction_payment::Pallet::<Runtime>::compute_fee(len, &info, tip);
+
+			// Native: tip is part of the quoted amount.
+			let ext_native = ChargeAssetTxPayment::<Runtime>::from(tip, None);
+			assert_eq!(
+				ext_native.quote_fee(Some(1).into(), &info, len),
+				Some(FeeQuote::Native(fee_with_tip))
+			);
+
+			// Asset: quoted amount follows conversion of the tipped native fee.
+			let expected_asset_fee = AssetConversion::quote_price_tokens_for_exact_tokens(
+				NativeOrWithId::WithId(asset_id),
+				NativeOrWithId::Native,
+				fee_with_tip,
+				true,
+			)
+			.unwrap();
+			let ext_asset = ChargeAssetTxPayment::<Runtime>::from(tip, Some(asset_id.into()));
+			assert_eq!(
+				ext_asset.quote_fee(Some(1).into(), &info, len),
+				Some(FeeQuote::Asset((NativeOrWithId::WithId(asset_id), expected_asset_fee)))
+			);
+		});
+}
+
+#[test]
+fn quote_fee_nothing_for_zero_fee() {
+	let balance_factor = 100;
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			let asset_id = 1;
+			let min_balance = 2;
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				asset_id.into(),
+				42,
+				true,
+				min_balance,
+			));
+
+			let len = 10;
+			let info = info_from_pays(Pays::No);
+
+			let fee = pallet_transaction_payment::Pallet::<Runtime>::compute_fee(len, &info, 0);
+			assert!(fee.is_zero());
+
+			let ext_native = ChargeAssetTxPayment::<Runtime>::from(0, None);
+			assert_eq!(ext_native.quote_fee(Some(1).into(), &info, len), Some(FeeQuote::Nothing));
+
+			let ext_asset = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()));
+			assert_eq!(ext_asset.quote_fee(Some(1).into(), &info, len), Some(FeeQuote::Nothing));
+		});
+}
+
+#[test]
+fn quote_fee_nothing_for_non_signer_origin() {
+	let base_weight = 5;
+	let balance_factor = 100;
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			let asset_id = 1;
+			let len = 10;
+			let info = info_from_weight(WEIGHT_5);
+			let fee = pallet_transaction_payment::Pallet::<Runtime>::compute_fee(len, &info, 0);
+			assert!(fee > 0);
+
+			let origin: <Runtime as frame_system::Config>::RuntimeOrigin =
+				frame_system::RawOrigin::Root.into();
+
+			let ext_native = ChargeAssetTxPayment::<Runtime>::from(0, None);
+			assert_eq!(ext_native.quote_fee(origin.clone(), &info, len), Some(FeeQuote::Nothing));
+
+			let ext_asset = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()));
+			assert_eq!(ext_asset.quote_fee(origin, &info, len), Some(FeeQuote::Nothing));
 		});
 }

--- a/substrate/frame/transaction-payment/rpc/runtime-api/src/lib.rs
+++ b/substrate/frame/transaction-payment/rpc/runtime-api/src/lib.rs
@@ -15,10 +15,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Runtime API definition for transaction payment pallet.
+//! Runtime API definition for the transaction payment pallet and related payment extensions.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
+use alloc::vec::Vec;
 use codec::Codec;
 use sp_runtime::traits::MaybeDisplay;
 
@@ -52,5 +55,27 @@ sp_api::decl_runtime_apis! {
 
 		/// Query the output of the current `LengthToFee` given some input.
 		fn query_length_to_fee(length: u32) -> Balance;
+	}
+
+	/// Estimate the assets that would be charged for an extrinsic.
+	///
+	/// Unlike [`TransactionPaymentApi`], this reports what would be charged to the sender
+	/// in the payment assets, rather than the protocol fee in native units.
+	///
+	/// The estimate is read-only: no funds are withdrawn. It may differ from the amount later
+	/// charged because the fee can change before inclusion, and unused weight is refunded after
+	/// dispatch. A successful estimate does not imply the sender can pay.
+	#[api_version(1)]
+	pub trait TransactionChargeApi<Balance, AssetId>
+	where
+		Balance: Codec,
+		AssetId: Codec,
+	{
+		/// Estimate the assets that would be charged for `uxt`.
+		///
+		/// Returns `None` if no estimate is available. An empty vector means nothing would be
+		/// charged. Otherwise each entry is the asset and amount that would be withdrawn from
+		/// the sender.
+		fn estimate_charge(uxt: Block::Extrinsic, len: u32) -> Option<Vec<(AssetId, Balance)>>;
 	}
 }

--- a/substrate/frame/transaction-payment/rpc/runtime-api/src/lib.rs
+++ b/substrate/frame/transaction-payment/rpc/runtime-api/src/lib.rs
@@ -57,14 +57,10 @@ sp_api::decl_runtime_apis! {
 		fn query_length_to_fee(length: u32) -> Balance;
 	}
 
-	/// Estimate the assets that would be charged for an extrinsic.
+	/// Estimate the assets that would be charged to the sender of an extrinsic.
 	///
-	/// Unlike [`TransactionPaymentApi`], this reports what would be charged to the sender
-	/// in the payment assets, rather than the protocol fee in native units.
-	///
-	/// The estimate is read-only: no funds are withdrawn. It may differ from the amount later
-	/// charged because the fee can change before inclusion, and unused weight is refunded after
-	/// dispatch. A successful estimate does not imply the sender can pay.
+	/// The estimate is read-only and best-effort: it does not imply the sender can pay, and the
+	/// amount finally charged can differ.
 	#[api_version(1)]
 	pub trait TransactionChargeApi<Balance, AssetId>
 	where
@@ -73,9 +69,8 @@ sp_api::decl_runtime_apis! {
 	{
 		/// Estimate the assets that would be charged for `uxt`.
 		///
-		/// Returns `None` if no estimate is available. An empty vector means nothing would be
-		/// charged. Otherwise each entry is the asset and amount that would be withdrawn from
-		/// the sender.
+		/// `None` means the runtime cannot produce an estimate, which says nothing about whether
+		/// the transaction is valid. An empty vector means nothing would be charged.
 		fn estimate_charge(uxt: Block::Extrinsic, len: u32) -> Option<Vec<(AssetId, Balance)>>;
 	}
 }


### PR DESCRIPTION
# Description

Adds `TransactionChargeApi`, a runtime API that estimates which assets would be withdrawn from
the sender to pay for a transaction, rather than the protocol fee in native units that
`TransactionPaymentApi::query_info` reports. A caller does not need to know the runtime's
`TxExtension` layout: the API reads the payment asset out of the extrinsic itself. For the same
reason the estimate includes the tip, which `query_info` always treats as zero.
To make that possible, `ChargeAssetTxPayment` gains `quote_fee`.

The API only reads state: it withdraws nothing and does not check that the sender can afford the
fee. The amount later charged can be lower, since unused weight is refunded after dispatch, or
different, since the fee multiplier can change before inclusion.

## Integration

**Breaking**: `pallet_asset_conversion_tx_payment::OnChargeAssetTransaction` now requires
`quote_asset_fee`. `SwapAssetAdapter` already implements it, so only custom adapters need work.
The same-named trait in `pallet-asset-tx-payment` is unaffected.

```rust
fn quote_asset_fee(asset_id: Self::AssetId, fee: Self::Balance) -> Option<Self::Balance>;
```

`TransactionChargeApi` is opt-in; kitchensink has a reference implementation.

The API is worth implementing on any runtime whose users can pay fees in assets. A runtime that
wraps its payment extension has to quote the wrapper rather than the extension inside it, since
the wrapper can decide whether the fee is taken at all and in which asset.

## Review Notes

Even though `ChargeAssetTxPayment` charges at most one asset,
`TransactionChargeApi::estimate_charge` returns `Vec<(AssetId, Balance)>`, so a chain that
charges several assets can return them all.

Kitchensink quotes only `ChargeAssetTxPayment`. `AsScarcity` and `SkipCheckIfFeeless` are
ignored, so the estimate can be non-zero for a transaction that would not actually be charged.

Only signed transactions are quoted. Bare extrinsics return `[]`, since they carry no extension
data and have no payer; general transactions return `None`, since their origin is resolved by the
transaction extension pipeline, which the helper does not run.

Existing payment tests now assert that the quote equals the amount actually withdrawn.
