### PR TITLE
fix(benchmarking): do not write 10^18 proof_size into weight files

### DIFF
--- a/prdoc/pr_13073.prdoc
+++ b/prdoc/pr_13073.prdoc
@@ -1,0 +1,21 @@
+title: 'fix(benchmarking): do not emit exabyte proof_size from rank-deficient OLS'
+
+doc:
+- audience: Runtime Dev
+  description: |-
+    `benchmark pallet` could write a `proof_size` in the 10^18 range into `weights.rs` when a
+    benchmark touched storage without `MaxEncodedLen` (`UNKNOWN KEY`). A storage prefix observed
+    at only one component value made `min_squares_iqr` rank-deficient; the pseudo-inverse then
+    emitted intercepts that silently poisoned block-weight accounting.
+
+    The analyzer now falls back to the constant (median) model when there is only one unique `x`,
+    proof-size arithmetic saturates instead of wrapping, and a `proof_size` that cannot fit in
+    `u32` fails the run instead of being written to a compiling weight file.
+
+    Re-run any benchmark whose generated weights contained an implausible `proof_size`.
+
+crates:
+- name: frame-benchmarking
+  bump: patch
+- name: frame-benchmarking-cli
+  bump: patch

--- a/substrate/frame/benchmarking/src/analysis.rs
+++ b/substrate/frame/benchmarking/src/analysis.rs
@@ -47,6 +47,22 @@ fn mul_1000_into_u128(value: f64) -> u128 {
 		.saturating_add((value.fract() * 1000.0) as u128)
 }
 
+/// Convert a regression coefficient to `u128`.
+///
+/// Negative, NaN and -inf collapse to 0 (weights cannot be negative). +inf saturates. Finite
+/// values that would overflow `u128` saturate as well. Without this, a rank-deficient OLS fit
+/// (every sample at the same x) can emit an intercept in the 10^18 range via `as u128`.
+fn f64_to_u128_saturating(value: f64, round_up: bool) -> u128 {
+	let v = if round_up { value + 0.5 } else { value };
+	if v.is_nan() || v == f64::NEG_INFINITY || v <= 0.0 {
+		0
+	} else if v == f64::INFINITY || v >= u128::MAX as f64 {
+		u128::MAX
+	} else {
+		v as u128
+	}
+}
+
 impl BenchmarkSelector {
 	fn scale_and_cast_weight(self, value: f64, round_up: bool) -> u128 {
 		if let BenchmarkSelector::ExtrinsicTime = self {
@@ -55,28 +71,16 @@ impl BenchmarkSelector {
 			// which we most certainly always want to round up instead of truncating.
 			mul_1000_into_u128(value + 0.000_000_005)
 		} else {
-			if round_up {
-				(value + 0.5) as u128
-			} else {
-				value as u128
-			}
+			f64_to_u128_saturating(value, round_up)
 		}
 	}
 
 	fn scale_weight(self, value: u128) -> u128 {
-		if let BenchmarkSelector::ExtrinsicTime = self {
-			value.saturating_mul(1000)
-		} else {
-			value
-		}
+		if let BenchmarkSelector::ExtrinsicTime = self { value.saturating_mul(1000) } else { value }
 	}
 
 	fn nanos_from_weight(self, value: u128) -> u128 {
-		if let BenchmarkSelector::ExtrinsicTime = self {
-			value / 1000
-		} else {
-			value
-		}
+		if let BenchmarkSelector::ExtrinsicTime = self { value / 1000 } else { value }
 	}
 
 	fn get_value(self, result: &BenchmarkResult) -> u128 {
@@ -381,6 +385,14 @@ impl Analysis {
 			*rs = rs[ql..rs.len() - ql].to_vec();
 		}
 
+		// OLS needs at least two distinct x-values. A single unique component combination
+		// (many repeats at one x) makes the design matrix rank-deficient; the pseudo-inverse
+		// then emits intercepts in the 10^18 range. Fall back to the constant (median) model.
+		// See https://github.com/paritytech/polkadot-sdk/issues/13066.
+		if results.len() <= 1 {
+			return Self::median_value(r, selector);
+		}
+
 		let names = r[0].components.iter().map(|x| format!("{:?}", x.0)).collect::<Vec<_>>();
 		let value_dists = results
 			.iter()
@@ -416,10 +428,10 @@ impl Analysis {
 			})?;
 
 		Ok(Self {
-			base: selector.scale_and_cast_weight(intercept, true),
+			base: selector.scale_and_cast_weight(intercept.max(0f64), true),
 			slopes: slopes
 				.into_iter()
-				.map(|value| selector.scale_and_cast_weight(value, true))
+				.map(|value| selector.scale_and_cast_weight(value.max(0f64), true))
 				.collect(),
 			names,
 			value_dists: Some(value_dists),
@@ -648,6 +660,71 @@ mod tests {
 			err.to_string().contains("only has 1 unique value"),
 			"expected 'only has 1 unique value' diagnostic, got: {err}",
 		);
+	}
+
+	fn benchmark_result_with_proof(
+		components: Vec<(BenchmarkParameter, u32)>,
+		proof_size: u32,
+	) -> BenchmarkResult {
+		BenchmarkResult {
+			components,
+			extrinsic_time: 0,
+			storage_root_time: 0,
+			reads: 0,
+			repeat_reads: 0,
+			writes: 0,
+			repeat_writes: 0,
+			proof_size,
+			keys: vec![],
+		}
+	}
+
+	// Regression for #13066: many repeats at a single component value make the OLS
+	// design matrix rank-deficient. The pseudo-inverse then emits intercepts in the
+	// 10^18 range. With more than two samples we must fall back to the constant
+	// (median) model instead of running OLS.
+	#[test]
+	fn min_squares_iqr_many_repeats_at_one_x_uses_median_proof_size() {
+		let data: Vec<_> = (0..20)
+			.map(|_| benchmark_result_with_proof(vec![(BenchmarkParameter::b, 8192)], 2560))
+			.collect();
+		let analysis = Analysis::min_squares_iqr(&data, BenchmarkSelector::ProofSize).unwrap();
+		assert_eq!(analysis.base, 2560);
+		assert!(
+			analysis.slopes.is_empty(),
+			"a constant model has no slope, got {:?}",
+			analysis.slopes
+		);
+		assert!(
+			analysis.base < u32::MAX as u128,
+			"proof_size intercept must fit in u32, got {}",
+			analysis.base
+		);
+	}
+
+	#[test]
+	fn min_squares_iqr_fifty_steps_constant_proof_size_stays_plausible() {
+		// Linear<0, 8192> with 50 steps and a constant y: intercept equals y, slope 0.
+		let mut data = Vec::new();
+		for step in 0..50u32 {
+			let x = step * 8192 / 49;
+			for _ in 0..20 {
+				data.push(benchmark_result_with_proof(vec![(BenchmarkParameter::b, x)], 123_835));
+			}
+		}
+		let analysis = Analysis::min_squares_iqr(&data, BenchmarkSelector::ProofSize).unwrap();
+		assert_eq!(analysis.base, 123_835);
+		assert_eq!(analysis.slopes, vec![0]);
+	}
+
+	#[test]
+	fn f64_to_u128_saturating_handles_non_finite_and_negative() {
+		assert_eq!(f64_to_u128_saturating(-1.0, true), 0);
+		assert_eq!(f64_to_u128_saturating(f64::NAN, true), 0);
+		assert_eq!(f64_to_u128_saturating(f64::NEG_INFINITY, true), 0);
+		assert_eq!(f64_to_u128_saturating(f64::INFINITY, true), u128::MAX);
+		assert_eq!(f64_to_u128_saturating(85.6, true), 86);
+		assert_eq!(f64_to_u128_saturating(85.2, false), 85);
 	}
 
 	#[test]

--- a/substrate/frame/benchmarking/src/analysis.rs
+++ b/substrate/frame/benchmarking/src/analysis.rs
@@ -76,11 +76,19 @@ impl BenchmarkSelector {
 	}
 
 	fn scale_weight(self, value: u128) -> u128 {
-		if let BenchmarkSelector::ExtrinsicTime = self { value.saturating_mul(1000) } else { value }
+		if let BenchmarkSelector::ExtrinsicTime = self {
+			value.saturating_mul(1000)
+		} else {
+			value
+		}
 	}
 
 	fn nanos_from_weight(self, value: u128) -> u128 {
-		if let BenchmarkSelector::ExtrinsicTime = self { value / 1000 } else { value }
+		if let BenchmarkSelector::ExtrinsicTime = self {
+			value / 1000
+		} else {
+			value
+		}
 	}
 
 	fn get_value(self, result: &BenchmarkResult) -> u128 {

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -29,12 +29,12 @@ use itertools::Itertools;
 use serde::Serialize;
 
 use crate::{
-	PalletCmd,
 	pallet::{
 		command::{PovEstimationMode, PovModesMap},
 		types::{ComponentRange, ComponentRangeMap},
 	},
 	shared::UnderscoreHelper,
+	PalletCmd,
 };
 use frame_benchmarking::{
 	Analysis, AnalysisChoice, BenchmarkBatchSplitResults, BenchmarkResult, BenchmarkSelector,

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -29,12 +29,12 @@ use itertools::Itertools;
 use serde::Serialize;
 
 use crate::{
+	PalletCmd,
 	pallet::{
 		command::{PovEstimationMode, PovModesMap},
 		types::{ComponentRange, ComponentRangeMap},
 	},
 	shared::UnderscoreHelper,
-	PalletCmd,
 };
 use frame_benchmarking::{
 	Analysis, AnalysisChoice, BenchmarkBatchSplitResults, BenchmarkResult, BenchmarkSelector,
@@ -174,6 +174,35 @@ fn map_results(
 		pallet_benchmarks.push(benchmark_data);
 	}
 	Ok(all_benchmarks)
+}
+
+/// Recorded proof sizes are `u32`. An analyzed intercept or slope at or above `u32::MAX` cannot
+/// come from real measurements; it is the signature of a rank-deficient PoV regression
+/// (see <https://github.com/paritytech/polkadot-sdk/issues/13066>).
+fn ensure_plausible_proof_size(
+	base: u128,
+	slopes: &[ComponentSlope],
+	pallet: &str,
+	benchmark: &str,
+) -> Result<(), sc_cli::Error> {
+	let max = u32::MAX as u128;
+	let implausible_slopes: Vec<_> = slopes
+		.iter()
+		.filter(|c| c.slope >= max)
+		.map(|c| (c.name.clone(), c.slope))
+		.collect();
+	if base < max && implausible_slopes.is_empty() {
+		return Ok(());
+	}
+	Err(format!(
+		"benchmark '{pallet}::{benchmark}' produced an implausible proof_size \
+		 (base={base}, slopes={implausible_slopes:?}). Values this large cannot come from \
+		 recorded proof sizes (u32) and typically indicate a rank-deficient PoV regression \
+		 — a storage prefix only observed at one component value, often an UNKNOWN KEY \
+		 without MaxEncodedLen. Implement MaxEncodedLen, set pov_mode = Measured or Ignored \
+		 for those keys, or reduce --steps."
+	)
+	.into())
 }
 
 // Get an iterator of errors.
@@ -346,6 +375,13 @@ fn get_benchmark_data(
 		}
 	}
 	used_calculated_proof_size.sort_by(|a, b| a.name.cmp(&b.name));
+
+	ensure_plausible_proof_size(
+		base_calculated_proof_size,
+		&used_calculated_proof_size,
+		&pallet,
+		&benchmark,
+	)?;
 
 	// This puts a marker on any component which is entirely unused in the weight formula.
 	let components = batch.time_results[0]
@@ -610,7 +646,9 @@ pub(crate) fn process_storage_results(
 			let is_all_ignored = pov_modes.get(&("ALL".to_string(), "ALL".to_string())) ==
 				Some(&PovEstimationMode::Ignored);
 			if is_all_ignored && override_pov_mode != Some(&PovEstimationMode::Ignored) {
-				panic!("The syntax currently does not allow to exclude single keys from a top-level `Ignored` pov-mode.");
+				panic!(
+					"The syntax currently does not allow to exclude single keys from a top-level `Ignored` pov-mode."
+				);
 			}
 
 			let pov_overhead = single_read_pov_overhead(
@@ -640,12 +678,15 @@ pub(crate) fn process_storage_results(
 				(None, None, PovEstimationMode::MaxEncodedLen) => {
 					// We add the overhead for a single read each time. In a more advanced version
 					// we could take node re-using into account and over-estimate a bit less.
-					prefix_result.proof_size += pov_overhead * *reads;
+					prefix_result.proof_size = prefix_result
+						.proof_size
+						.saturating_add(pov_overhead.saturating_mul(*reads));
 					PovEstimationMode::Measured
 				},
 				(Some(PovEstimationMode::MaxEncodedLen), Some(max_size), _) |
 				(None, Some(max_size), PovEstimationMode::MaxEncodedLen) => {
-					prefix_result.proof_size = (pov_overhead + max_size) * *reads;
+					prefix_result.proof_size =
+						pov_overhead.saturating_add(max_size).saturating_mul(*reads);
 					PovEstimationMode::MaxEncodedLen
 				},
 				(Some(PovEstimationMode::MaxEncodedLen), None, _) => {
@@ -654,7 +695,9 @@ pub(crate) fn process_storage_results(
 			};
 			// Add the additional trie layer overhead for every new prefix.
 			if *reads > 0 && !is_all_ignored {
-				prefix_result.proof_size += 15 * 33 * additional_trie_layers as u32;
+				prefix_result.proof_size = prefix_result.proof_size.saturating_add(
+					15u32.saturating_mul(33).saturating_mul(additional_trie_layers as u32),
+				);
 			}
 			storage_per_prefix.entry(prefix.clone()).or_default().push(prefix_result);
 
@@ -710,17 +753,17 @@ pub(crate) fn process_storage_results(
 							Some(new_pov) => {
 								let comment = format!(
 									"Proof: `{pallet_name}::{storage_name}` (`max_values`: {:?}, `max_size`: {:?}, added: {}, mode: `{:?}`)",
-									key_info.max_values,
-									key_info.max_size,
-									new_pov,
-									used_pov_mode,
+									key_info.max_values, key_info.max_size, new_pov, used_pov_mode,
 								);
 								comments.push(comment)
 							},
 							None => {
 								let comment = format!(
 									"Proof: `{}::{}` (`max_values`: {:?}, `max_size`: {:?}, mode: `{:?}`)",
-									pallet_name, storage_name, key_info.max_values, key_info.max_size,
+									pallet_name,
+									storage_name,
+									key_info.max_values,
+									key_info.max_size,
 									used_pov_mode,
 								);
 								comments.push(comment);
@@ -839,6 +882,7 @@ where
 mod test {
 	use super::*;
 	use frame_benchmarking::{BenchmarkBatchSplitResults, BenchmarkParameter, BenchmarkResult};
+	use std::collections::HashMap;
 
 	fn test_data(
 		pallet: &[u8],
@@ -1355,5 +1399,160 @@ mod test {
 		assert_eq!(easy_log_16(16u32.pow(7)), 7);
 		assert_eq!(easy_log_16(16u32.pow(7) + 1), 8);
 		assert_eq!(easy_log_16(u32::MAX), 8);
+	}
+
+	fn unknown_key_batch(
+		component_values: impl IntoIterator<Item = u32>,
+		repeats: usize,
+		reads: u32,
+		proof_size: u32,
+	) -> BenchmarkBatchSplitResults {
+		let prefix = vec![0xABu8; 32];
+		let mut results = Vec::new();
+		for b in component_values {
+			for _ in 0..repeats {
+				results.push(BenchmarkResult {
+					components: vec![(BenchmarkParameter::b, b)],
+					extrinsic_time: 1_000,
+					storage_root_time: 0,
+					reads,
+					repeat_reads: 0,
+					writes: 0,
+					repeat_writes: 0,
+					proof_size,
+					keys: vec![(prefix.clone(), reads, 0, false)],
+				});
+			}
+		}
+		BenchmarkBatchSplitResults {
+			pallet: b"my_pallet".to_vec(),
+			instance: b"instance".to_vec(),
+			benchmark: b"dispatch_post".to_vec(),
+			time_results: results.clone(),
+			db_results: results,
+		}
+	}
+
+	fn map_unknown(batch: BenchmarkBatchSplitResults) -> BenchmarkData {
+		let mapped = map_results(
+			&[batch],
+			&[],
+			&Default::default(),
+			Default::default(),
+			PovEstimationMode::MaxEncodedLen,
+			&AnalysisChoice::default(),
+			&AnalysisChoice::MedianSlopes,
+			1_000_000,
+			0,
+		)
+		.unwrap();
+		mapped.get(&("my_pallet".to_string(), "instance".to_string())).unwrap()[0].clone()
+	}
+
+	/// #13066: a prefix observed only at the high end of Linear<0, 8192> (20 repeats
+	/// at b=8192, absent elsewhere) used to feed rank-deficient OLS and emit an
+	/// exabyte-scale intercept. Trie overhead for an unbounded 1e6-key map is
+	/// 5 layers × 15 × 33; plus the measured 85 and 50 reads.
+	#[test]
+	fn unknown_key_single_component_value_does_not_explode_proof_size() {
+		let prefix = vec![0xABu8; 32];
+		let mut results = Vec::new();
+		for step in 0..50u32 {
+			let b = step * 8192 / 49;
+			for _ in 0..20 {
+				let (keys, reads) = if b == 8192 {
+					(vec![(prefix.clone(), 50, 0, false)], 50)
+				} else {
+					(vec![], 0)
+				};
+				results.push(BenchmarkResult {
+					components: vec![(BenchmarkParameter::b, b)],
+					extrinsic_time: 1_000,
+					storage_root_time: 0,
+					reads,
+					repeat_reads: 0,
+					writes: 0,
+					repeat_writes: 0,
+					proof_size: 85,
+					keys,
+				});
+			}
+		}
+		let result = map_unknown(BenchmarkBatchSplitResults {
+			pallet: b"my_pallet".to_vec(),
+			instance: b"instance".to_vec(),
+			benchmark: b"dispatch_post".to_vec(),
+			time_results: results.clone(),
+			db_results: results,
+		});
+		let expected = 85u128 + (5 * 15 * 33 * 50);
+		assert_eq!(result.base_calculated_proof_size, expected);
+		assert!(result.base_calculated_proof_size < u32::MAX as u128);
+		assert!(
+			result.component_calculated_proof_size.is_empty(),
+			"constant model has no slope, got {:?}",
+			result.component_calculated_proof_size
+		);
+	}
+
+	/// #13066: 50 steps of Linear<0, 8192> with a constant unknown-key proof must stay
+	/// on the measured+overhead intercept, not jump into the 10^18 range.
+	#[test]
+	fn unknown_keys_across_fifty_steps_stay_plausible() {
+		let steps: Vec<u32> = (0..50u32).map(|s| s * 8192 / 49).collect();
+		let result = map_unknown(unknown_key_batch(steps, 20, 50, 85));
+		let expected = 85u128 + (5 * 15 * 33 * 50);
+		assert_eq!(result.base_calculated_proof_size, expected);
+		assert!(
+			result.component_calculated_proof_size.is_empty() ||
+				result.component_calculated_proof_size.iter().all(|c| c.slope == 0),
+			"constant y must not produce a non-zero slope, got {:?}",
+			result.component_calculated_proof_size
+		);
+		assert!(result.base_calculated_proof_size < 1_000_000);
+	}
+
+	/// `pov_overhead * reads` used to wrap in u32 (2475 × 2_000_000). Saturating keeps
+	/// the estimate at `u32::MAX` instead of a wrapped small number feeding OLS garbage.
+	#[test]
+	fn proof_size_overhead_does_not_wrap() {
+		let mut storage_per_prefix = HashMap::new();
+		let prefix = vec![0xABu8; 32];
+		let results = vec![BenchmarkResult {
+			components: vec![(BenchmarkParameter::b, 1)],
+			extrinsic_time: 0,
+			storage_root_time: 0,
+			reads: 2_000_000,
+			repeat_reads: 0,
+			writes: 0,
+			repeat_writes: 0,
+			proof_size: 85,
+			keys: vec![(prefix.clone(), 2_000_000, 0, false)],
+		}];
+		process_storage_results(
+			&mut storage_per_prefix,
+			&results,
+			&[],
+			&Default::default(),
+			PovEstimationMode::MaxEncodedLen,
+			1_000_000,
+			0,
+		);
+		let stored = &storage_per_prefix.get(&prefix).unwrap()[0];
+		assert_eq!(stored.proof_size, u32::MAX);
+	}
+
+	#[test]
+	fn ensure_plausible_proof_size_rejects_exabyte_intercept() {
+		let err = ensure_plausible_proof_size(
+			8_126_544_059_662_763_008,
+			&[],
+			"my_pallet",
+			"dispatch_post",
+		)
+		.unwrap_err();
+		let msg = err.to_string();
+		assert!(msg.contains("implausible proof_size"), "{msg}");
+		assert!(msg.contains("UNKNOWN KEY"), "{msg}");
 	}
 }


### PR DESCRIPTION
# Description

Fixes #13066.

`benchmark pallet` can write a `proof_size` in the 10^18 range into `weights.rs` when the benchmark touches storage without `MaxEncodedLen` (`UNKNOWN KEY` in the storage summary). The same command with `--steps 3` produces a plausible number; `--steps 50` produces non-deterministic garbage. A weight that large silently poisons block-weight accounting: one extrinsic claims more PoV than any block can hold.

The number that lands in the file is the **calculated** PoV, from `min_squares_iqr` run **per storage prefix**. A prefix that is only observed at a single component value (many repeats at one `x` — typical when an unbounded map is only hit at the high end of a `Linear` range) makes the OLS design matrix rank-deficient. `linregress`'s pseudo-inverse then emits intercepts such as `8126544059662763008`. `--steps 3` often happens to see the prefix at more than one `x`, which is why it looks fine.

## The change

1. **Root cause.** `Analysis::min_squares_iqr` falls back to the constant (median) model when there is only one unique component combination. Two-sample / two-distinct-`x` behaviour is unchanged.
2. **Arithmetic.** `process_storage_results` uses saturating `u32` math for `pov_overhead * reads`, so wrap-around cannot feed OLS a sawtooth.
3. **Safety net.** After analysis, an intercept or slope `>= u32::MAX` fails the run. Recorded proof sizes are `u32`; anything at or above that cannot be a real measurement. The diagnostic points at UNKNOWN KEY / missing MEL instead of writing a compiling weight file.

`median_slopes` already clamped negative coefficients; `min_squares_iqr` now does the same. Non-time `scale_and_cast_weight` saturates non-finite floats instead of relying on `as u128`.

## Integration

No runtime or API change. Downstream picks this up on the next `frame-benchmarking` / `frame-benchmarking-cli` bump.

Re-run any benchmark whose generated weights contained an implausible `proof_size`. If a run still produces a value that cannot fit in `u32`, the CLI now errors instead of writing the file — implement `MaxEncodedLen`, set `pov_mode = Measured` or `Ignored` for those keys, or reduce `--steps`.

## Review Notes

The calculated-PoV path is `writer.rs::get_benchmark_data` → `process_storage_results` (per-prefix `proof_size`) → `analysis_function` (default `min_squares_iqr`). The "Measured:" comment in the weight file uses `--output-pov-analysis` (`median-slopes`) on the raw samples, which is why #13066 showed `Measured: 85` next to `Estimated: 8126544059662763008`.

Deliberately left:

- Using `median-slopes` for the calculated PoV as well. That would change existing weight files even in the well-posed case.
- Summing per-prefix estimates instead of taking the max. Pre-existing, not this bug.

## Testing

- many repeats at one `x` → median `proof_size`, no 10^18 intercept
- 50 steps of `Linear<0, 8192>` with constant unknown-key `y` stays on the measured+overhead intercept
- prefix only present at `b=8192` (the #13066 shape) does not explode
- `pov_overhead * reads` saturates instead of wrapping
- implausible intercept is rejected with an UNKNOWN KEY diagnostic

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [x] My PR follows the [labeling requirements](https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process) of this project (at minimum one label for `T` required)
* [x] I have added tests that prove my fix is effective or that my feature works (if applicable)