### PR TITLE
fix(revive): fail System.terminate when deferred destruction cannot burn ED

### DIFF
--- a/prdoc/pr_13085.prdoc
+++ b/prdoc/pr_13085.prdoc
@@ -24,4 +24,6 @@ doc:
 
 crates:
 - name: pallet-revive
-  bump: minor
+  bump: major
+- name: pallet-revive-uapi
+  bump: patch

--- a/prdoc/pr_13085.prdoc
+++ b/prdoc/pr_13085.prdoc
@@ -1,0 +1,27 @@
+title: '[pallet-revive] revert `System.terminate` when a freeze pins the contract ED'
+
+doc:
+- audience: Runtime Dev
+  description: |-
+    `System.terminate` could report success while leaving the contract alive. `terminate_caller`
+    moved the reducible balance to the beneficiary and scheduled the destruction, but the deferred
+    destruction runs at the end of the call stack, where the contract is no longer on the stack and
+    its error is discarded. If the polite existential-deposit burn then failed — for example because
+    a native freeze made the remaining balance non-reducible — the beneficiary kept the transfer,
+    the contract stayed live and callable, and nothing was left to retry.
+
+    `terminate_caller` now rejects that case up-front: after the immediate transfer it checks that
+    the contract's reducible balance still covers the existential deposit, and otherwise fails with
+    the new `Error::TerminateBalanceLocked`. Refunding the storage deposit only lowers `reserved` and
+    never touches `frozen`, so a burn that does not fit at terminate time will not fit later either.
+    The check runs synchronously inside the precompile, so it surfaces as a revert that the calling
+    contract can catch, and a third party freezing a contract becomes a visible error instead of a
+    silent no-op.
+
+    This makes good on what `ISystem.sol` already documented for `terminate`. The deferred
+    destruction loop keeps its existing non-failing behaviour, and the `SELFDESTRUCT` opcode is
+    unchanged.
+
+crates:
+- name: pallet-revive
+  bump: minor

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1570,11 +1570,22 @@ where
 			// The storage deposit is only charged at the end of every call stack.
 			// To make sure that no sub call uses more than it is allowed to,
 			// the limit is manually enforced here.
-			let contract = frame.contract_info.as_contract();
-			frame
-				.frame_meter
-				.finalize(contract)
-				.map_err(|e| ExecError { error: e, origin: ErrorOrigin::Callee })?;
+			{
+				let contract = frame.contract_info.as_contract();
+				frame
+					.frame_meter
+					.finalize(contract)
+					.map_err(|e| ExecError { error: e, origin: ErrorOrigin::Callee })?;
+			}
+
+			// Deferred destruction must run inside this storage transaction so a
+			// late `do_terminate` failure rolls back the enclosing execution,
+			// including the immediate beneficiary transfer. Reverts return above,
+			// so we never destroy after a reverted callee.
+			if is_first_frame {
+				self.finalize_scheduled_destructions()
+					.map_err(|e| ExecError { error: e, origin: ErrorOrigin::Callee })?;
+			}
 
 			Ok(output)
 		};
@@ -1777,23 +1788,42 @@ where
 					contract.clone(),
 				);
 			}
-			// End of the callstack: destroy scheduled contracts in line with EVM semantics.
-			let contracts_created = mem::take(&mut self.first_frame.contracts_created);
-			let contracts_to_destroy = mem::take(&mut self.first_frame.contracts_to_be_destroyed);
-			for (contract_account, args) in contracts_to_destroy {
-				if args.only_if_same_tx && !contracts_created.contains(&contract_account) {
-					continue;
-				}
-				Self::do_terminate(
-					&mut self.transaction_meter,
-					self.exec_config,
-					&contract_account,
-					&self.origin,
-					&args,
-				)
-				.ok();
-			}
 		}
+	}
+
+	/// Destroy every contract scheduled on the first frame.
+	///
+	/// Called from inside the first-frame storage transaction so a fallible
+	/// `do_terminate` (e.g. a polite ED burn blocked by a lock/freeze) aborts
+	/// the enclosing call and undoes the immediate beneficiary transfer.
+	/// Meter `terminate` is applied only after every destruction succeeds, so a
+	/// mid-loop failure cannot leave the deposit meter thinking a still-live
+	/// contract was reaped.
+	fn finalize_scheduled_destructions(&mut self) -> Result<(), DispatchError> {
+		let contracts_created = mem::take(&mut self.first_frame.contracts_created);
+		let contracts_to_destroy = mem::take(&mut self.first_frame.contracts_to_be_destroyed);
+		let first_account = self.first_frame.account_id.clone();
+		let mut refunds = Vec::new();
+		for (contract_account, args) in &contracts_to_destroy {
+			if args.only_if_same_tx && !contracts_created.contains(contract_account) {
+				continue;
+			}
+			let refund = Self::do_terminate(
+				&mut self.transaction_meter,
+				self.exec_config,
+				contract_account,
+				&self.origin,
+				args,
+			)?;
+			if *contract_account == first_account {
+				self.first_frame.contract_info.invalidate();
+			}
+			refunds.push((contract_account.clone(), refund));
+		}
+		for (account, refund) in refunds {
+			self.transaction_meter.terminate(account, refund);
+		}
+		Ok(())
 	}
 
 	/// Transfer some funds from `from` to `to`.
@@ -1878,13 +1908,18 @@ where
 	}
 
 	/// Performs the actual deletion of a contract at the end of a call stack.
+	///
+	/// Returns the storage-deposit refund that the caller must later record on
+	/// the transaction meter, and only after every scheduled destruction has
+	/// succeeded. Applying the meter update here would be un-rollbackable if a
+	/// later contract in the same batch failed.
 	fn do_terminate(
 		transaction_meter: &mut TransactionMeter<T>,
 		exec_config: &ExecConfig<T>,
 		contract_account: &T::AccountId,
 		origin: &Origin<T>,
 		args: &TerminateArgs<T>,
-	) -> Result<(), DispatchError> {
+	) -> Result<BalanceOf<T>, DispatchError> {
 		let contract_address = T::AddressMapper::to_address(contract_account);
 
 		// If root created this contract we need to use the pallet account_id because root has no
@@ -1929,21 +1964,17 @@ where
 			AccountInfoOf::<T>::remove(contract_address);
 			ImmutableDataOf::<T>::remove(contract_address);
 
-			// the meter needs to discard all deposits interacting with the terminated contract
-			// we do this last as we cannot roll this back
-			transaction_meter.terminate(contract_account.clone(), refund);
-
-			Ok(())
+			Ok(refund)
 		};
 
-		// we cannot fail here as the contract that called `SELFDESTRUCT`
-		// is no longer on the call stack. hence we simply roll back the
-		// termination so that nothing happened.
+		// Nested storage transaction: on failure only this deletion is undone here.
+		// The enclosing first-frame transaction (see `run`) then rolls back the
+		// whole call, including the immediate beneficiary transfer.
 		with_transaction(|| -> TransactionOutcome<Result<_, DispatchError>> {
 			match delete_contract(&args.trie_id, &args.code_hash) {
-				Ok(()) => {
+				Ok(refund) => {
 					log::trace!(target: LOG_TARGET, "Terminated {contract_address:?}");
-					TransactionOutcome::Commit(Ok(()))
+					TransactionOutcome::Commit(Ok(refund))
 				},
 				Err(e) => {
 					log::debug!(target: LOG_TARGET, "Contract at {contract_address:?} failed to terminate: {e:?}");
@@ -2811,6 +2842,7 @@ pub fn bench_do_terminate<T: Config>(
 		origin,
 		&TerminateArgs { beneficiary, trie_id, code_hash, only_if_same_tx },
 	)
+	.map(|_| ())
 }
 
 mod sealing {

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -46,7 +46,7 @@ use frame_support::{
 	traits::{
 		Time,
 		fungible::{Balanced as _, Inspect, Mutate},
-		tokens::Preservation,
+		tokens::{Fortitude, Preservation},
 	},
 	weights::Weight,
 };
@@ -1570,22 +1570,11 @@ where
 			// The storage deposit is only charged at the end of every call stack.
 			// To make sure that no sub call uses more than it is allowed to,
 			// the limit is manually enforced here.
-			{
-				let contract = frame.contract_info.as_contract();
-				frame
-					.frame_meter
-					.finalize(contract)
-					.map_err(|e| ExecError { error: e, origin: ErrorOrigin::Callee })?;
-			}
-
-			// Deferred destruction must run inside this storage transaction so a
-			// late `do_terminate` failure rolls back the enclosing execution,
-			// including the immediate beneficiary transfer. Reverts return above,
-			// so we never destroy after a reverted callee.
-			if is_first_frame {
-				self.finalize_scheduled_destructions()
-					.map_err(|e| ExecError { error: e, origin: ErrorOrigin::Callee })?;
-			}
+			let contract = frame.contract_info.as_contract();
+			frame
+				.frame_meter
+				.finalize(contract)
+				.map_err(|e| ExecError { error: e, origin: ErrorOrigin::Callee })?;
 
 			Ok(output)
 		};
@@ -1788,42 +1777,23 @@ where
 					contract.clone(),
 				);
 			}
-		}
-	}
-
-	/// Destroy every contract scheduled on the first frame.
-	///
-	/// Called from inside the first-frame storage transaction so a fallible
-	/// `do_terminate` (e.g. a polite ED burn blocked by a lock/freeze) aborts
-	/// the enclosing call and undoes the immediate beneficiary transfer.
-	/// Meter `terminate` is applied only after every destruction succeeds, so a
-	/// mid-loop failure cannot leave the deposit meter thinking a still-live
-	/// contract was reaped.
-	fn finalize_scheduled_destructions(&mut self) -> Result<(), DispatchError> {
-		let contracts_created = mem::take(&mut self.first_frame.contracts_created);
-		let contracts_to_destroy = mem::take(&mut self.first_frame.contracts_to_be_destroyed);
-		let first_account = self.first_frame.account_id.clone();
-		let mut refunds = Vec::new();
-		for (contract_account, args) in &contracts_to_destroy {
-			if args.only_if_same_tx && !contracts_created.contains(contract_account) {
-				continue;
+			// End of the callstack: destroy scheduled contracts in line with EVM semantics.
+			let contracts_created = mem::take(&mut self.first_frame.contracts_created);
+			let contracts_to_destroy = mem::take(&mut self.first_frame.contracts_to_be_destroyed);
+			for (contract_account, args) in contracts_to_destroy {
+				if args.only_if_same_tx && !contracts_created.contains(&contract_account) {
+					continue;
+				}
+				Self::do_terminate(
+					&mut self.transaction_meter,
+					self.exec_config,
+					&contract_account,
+					&self.origin,
+					&args,
+				)
+				.ok();
 			}
-			let refund = Self::do_terminate(
-				&mut self.transaction_meter,
-				self.exec_config,
-				contract_account,
-				&self.origin,
-				args,
-			)?;
-			if *contract_account == first_account {
-				self.first_frame.contract_info.invalidate();
-			}
-			refunds.push((contract_account.clone(), refund));
 		}
-		for (account, refund) in refunds {
-			self.transaction_meter.terminate(account, refund);
-		}
-		Ok(())
 	}
 
 	/// Transfer some funds from `from` to `to`.
@@ -1908,18 +1878,13 @@ where
 	}
 
 	/// Performs the actual deletion of a contract at the end of a call stack.
-	///
-	/// Returns the storage-deposit refund that the caller must later record on
-	/// the transaction meter, and only after every scheduled destruction has
-	/// succeeded. Applying the meter update here would be un-rollbackable if a
-	/// later contract in the same batch failed.
 	fn do_terminate(
 		transaction_meter: &mut TransactionMeter<T>,
 		exec_config: &ExecConfig<T>,
 		contract_account: &T::AccountId,
 		origin: &Origin<T>,
 		args: &TerminateArgs<T>,
-	) -> Result<BalanceOf<T>, DispatchError> {
+	) -> Result<(), DispatchError> {
 		let contract_address = T::AddressMapper::to_address(contract_account);
 
 		// If root created this contract we need to use the pallet account_id because root has no
@@ -1964,17 +1929,21 @@ where
 			AccountInfoOf::<T>::remove(contract_address);
 			ImmutableDataOf::<T>::remove(contract_address);
 
-			Ok(refund)
+			// the meter needs to discard all deposits interacting with the terminated contract
+			// we do this last as we cannot roll this back
+			transaction_meter.terminate(contract_account.clone(), refund);
+
+			Ok(())
 		};
 
-		// Nested storage transaction: on failure only this deletion is undone here.
-		// The enclosing first-frame transaction (see `run`) then rolls back the
-		// whole call, including the immediate beneficiary transfer.
+		// we cannot fail here as the contract that called `SELFDESTRUCT`
+		// is no longer on the call stack. hence we simply roll back the
+		// termination so that nothing happened.
 		with_transaction(|| -> TransactionOutcome<Result<_, DispatchError>> {
 			match delete_contract(&args.trie_id, &args.code_hash) {
-				Ok(refund) => {
+				Ok(()) => {
 					log::trace!(target: LOG_TARGET, "Terminated {contract_address:?}");
-					TransactionOutcome::Commit(Ok(refund))
+					TransactionOutcome::Commit(Ok(()))
 				},
 				Err(e) => {
 					log::debug!(target: LOG_TARGET, "Contract at {contract_address:?} failed to terminate: {e:?}");
@@ -2743,6 +2712,24 @@ where
 			&self.exec_config,
 		)?;
 
+		// The deferred destruction cannot fail: the contract is no longer on the call stack by
+		// then, so its error is swallowed. Reject here instead the one failure we can still see:
+		// a freeze that pins the ED and would make the `Polite` burn in `destroy_contract` fail.
+		//
+		// `refund_all` only lowers `reserved` and never touches `frozen`, so a burn that does not
+		// fit now will not fit later either. Checking after the transfer above is what makes this
+		// exact: `Preservation::Preserve` leaves exactly `max(frozen - reserved, ED)` behind, so
+		// the reducible balance is below the ED precisely when a foreign freeze exceeds our holds.
+		let ed = T::Currency::minimum_balance();
+		ensure!(
+			T::Currency::reducible_balance(
+				&parent_account_id,
+				Preservation::Expendable,
+				Fortitude::Polite,
+			) >= ed,
+			Error::<T>::TerminateBalanceLocked,
+		);
+
 		// schedule for delayed deletion
 		let args = TerminateArgs { beneficiary, trie_id, code_hash, only_if_same_tx: false };
 		self.top_frame_mut().contracts_to_be_destroyed.insert(parent_account_id, args);
@@ -2842,7 +2829,6 @@ pub fn bench_do_terminate<T: Config>(
 		origin,
 		&TerminateArgs { beneficiary, trie_id, code_hash, only_if_same_tx },
 	)
-	.map(|_| ())
 }
 
 mod sealing {

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -666,6 +666,13 @@ pub mod pallet {
 		/// `seal_terminate` was invoked on an EIP-7702 delegated EOA. Delegated accounts
 		/// cannot be torn down via the contract-termination path.
 		CannotTerminateDelegatedAccount = 0x44,
+		/// A balance freeze pins the contract's existential deposit, so terminating it would
+		/// not be able to burn that ED.
+		///
+		/// The actual destruction is deferred to the end of the call stack, where it can no
+		/// longer fail, so this is rejected up-front by `System.terminate` while the calling
+		/// contract can still observe the revert.
+		TerminateBalanceLocked = 0x45,
 		/// Benchmarking only error.
 		#[cfg(feature = "runtime-benchmarks")]
 		BenchmarkingError = 0xFF,

--- a/substrate/frame/revive/src/precompiles.rs
+++ b/substrate/frame/revive/src/precompiles.rs
@@ -146,11 +146,15 @@ impl Error {
 		let delegate_denied = CrateError::<T>::PrecompileDelegateDenied.into();
 		let construct = CrateError::<T>::TerminatedInConstructor.into();
 		let cannot_terminate_delegated = CrateError::<T>::CannotTerminateDelegatedAccount.into();
+		let balance_locked = CrateError::<T>::TerminateBalanceLocked.into();
 		let message = match () {
 			_ if e == delegate_denied => "illegal to call this pre-compile via delegate call",
 			_ if e == construct => "terminate pre-compile cannot be called from the constructor",
 			_ if e == cannot_terminate_delegated => {
 				"cannot terminate an EIP-7702 delegated account via the terminate pre-compile"
+			},
+			_ if e == balance_locked => {
+				"terminate pre-compile cannot burn the existential deposit: the contract's balance is locked"
 			},
 			_ => return e.into(),
 		};

--- a/substrate/frame/revive/src/tests/sol/terminate.rs
+++ b/substrate/frame/revive/src/tests/sol/terminate.rs
@@ -16,16 +16,19 @@
 // limitations under the License.
 
 use crate::{
-	BalanceOf, Code, Config, H160, Pallet,
+	BalanceOf, Code, Config, FreezeReason, H160, Pallet,
 	address::AddressMapper,
 	test_utils::{ALICE, DJANGO, DJANGO_ADDR, builder::Contract},
 	tests::{
-		Contracts, ExtBuilder, RuntimeOrigin, Test, builder,
+		Balances, Contracts, ExtBuilder, RuntimeFreezeReason, RuntimeOrigin, Test, builder,
 		test_utils::{get_balance, get_contract_checked},
 	},
 };
 use alloy_core::sol_types::{SolCall, SolConstructor};
-use frame_support::traits::fungible::Mutate;
+use frame_support::{
+	assert_ok,
+	traits::fungible::{InspectFreeze, Mutate, MutateFreeze},
+};
 use pallet_revive_fixtures::{
 	FixtureType, Terminate, TerminateCaller, TerminateDelegator, compile_module_with_type,
 };
@@ -69,6 +72,12 @@ fn base_case(fixture_type: FixtureType, method: u8) {
 			.build_and_unwrap_result();
 
 		assert!(result.data.is_empty());
+		if method == METHOD_PRECOMPILE {
+			assert!(
+				get_contract_checked(&addr).is_none(),
+				"System.terminate must destroy the first-frame contract",
+			);
+		}
 	});
 }
 
@@ -696,5 +705,79 @@ fn call_after_terminate_works(fixture_type: FixtureType, method: u8) {
 		assert_eq!(value, expected_value, "unexpected return value from callAfterTerminateCall");
 		assert_eq!(get_balance(&account), 0, "unexpected contract balance after terminate");
 		assert_eq!(get_balance(&DJANGO), 0, "unexpected DJANGO balance after terminate");
+	});
+}
+
+/// A native freeze that pins the contract ED must not let `System.terminate`
+/// report success while leaving the contract live.
+///
+/// The freeze is `reserved + ED` so `reducible_balance` still reports the
+/// extra as transferable (`Preservation::Preserve`), but after `refund_all`
+/// the polite ED burn has nothing left to spend. Before the first-frame
+/// storage transaction covered deferred destruction, `terminate_caller`
+/// transferred that extra, `do_terminate` failed, and `.ok()` swallowed the
+/// error. The beneficiary kept the transfer and the contract stayed callable.
+///
+/// See <https://github.com/paritytech/polkadot-sdk/issues/13017>.
+#[test_case(FixtureType::Solc)]
+#[test_case(FixtureType::Resolc)]
+fn precompile_terminate_reverts_when_ed_is_frozen(fixture_type: FixtureType) {
+	let (code, _) = compile_module_with_type("Terminate", fixture_type).unwrap();
+	ExtBuilder::default().build().execute_with(|| {
+		let min_balance = Contracts::min_balance();
+		let extra = 1_000u128;
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 100_000_000_000);
+
+		let Contract { addr, account_id } = builder::bare_instantiate(Code::Upload(code))
+			.constructor_data(
+				Terminate::constructorCall {
+					skip: true,
+					method: METHOD_PRECOMPILE,
+					beneficiary: DJANGO_ADDR.0.into(),
+				}
+				.abi_encode(),
+			)
+			.build_and_unwrap_contract();
+
+		let _ = <Test as Config>::Currency::set_balance(&account_id, min_balance + extra);
+		// Pin ED *and* current reserved: polite `reducible_balance` subtracts
+		// reserved from frozen, so freezing only the ED is a no-op while holds
+		// remain. `PGasDeposit::destroy_contract` thaws the PGAS freeze itself,
+		// so the pin has to be a native Balances freeze.
+		let pin = Balances::reserved_balance(&account_id).saturating_add(min_balance);
+		let freeze_id = RuntimeFreezeReason::Contracts(FreezeReason::PGasMinBalance);
+		assert_ok!(Balances::set_freeze(&freeze_id, &account_id, pin));
+		assert_eq!(Balances::balance_frozen(&freeze_id, &account_id), pin);
+
+		let django_before = get_balance(&DJANGO);
+		let result = builder::bare_call(addr)
+			.data(
+				Terminate::terminateCall {
+					method: METHOD_PRECOMPILE,
+					beneficiary: DJANGO_ADDR.0.into(),
+				}
+				.abi_encode(),
+			)
+			.build();
+
+		assert!(
+			result.result.is_err(),
+			"terminate must fail the enclosing call when deferred destruction cannot burn the ED; got {:?}",
+			result.result,
+		);
+		assert!(
+			get_contract_checked(&addr).is_some(),
+			"contract must remain live after a failed terminate",
+		);
+		assert_eq!(
+			get_balance(&account_id),
+			min_balance + extra,
+			"contract balance must be restored when terminate rolls back",
+		);
+		assert_eq!(
+			get_balance(&DJANGO),
+			django_before,
+			"beneficiary must not keep the immediate transfer of a failed terminate",
+		);
 	});
 }

--- a/substrate/frame/revive/src/tests/sol/terminate.rs
+++ b/substrate/frame/revive/src/tests/sol/terminate.rs
@@ -708,15 +708,16 @@ fn call_after_terminate_works(fixture_type: FixtureType, method: u8) {
 	});
 }
 
-/// A native freeze that pins the contract ED must not let `System.terminate`
-/// report success while leaving the contract live.
+/// A native freeze that pins the contract ED must make `System.terminate` revert
+/// instead of reporting success while leaving the contract live.
 ///
-/// The freeze is `reserved + ED` so `reducible_balance` still reports the
-/// extra as transferable (`Preservation::Preserve`), but after `refund_all`
-/// the polite ED burn has nothing left to spend. Before the first-frame
-/// storage transaction covered deferred destruction, `terminate_caller`
-/// transferred that extra, `do_terminate` failed, and `.ok()` swallowed the
-/// error. The beneficiary kept the transfer and the contract stayed callable.
+/// The freeze is `reserved + ED` so `reducible_balance` still reports the extra
+/// as transferable (`Preservation::Preserve`), but the polite ED burn in
+/// `destroy_contract` has nothing left to spend. That burn happens in the
+/// deferred destruction, where the error is swallowed, so `terminate_caller`
+/// rejects the freeze up-front: the precompile reverts and the calling contract
+/// can observe it. Previously the beneficiary kept the transfer and the contract
+/// stayed callable.
 ///
 /// See <https://github.com/paritytech/polkadot-sdk/issues/13017>.
 #[test_case(FixtureType::Solc)]
@@ -758,26 +759,17 @@ fn precompile_terminate_reverts_when_ed_is_frozen(fixture_type: FixtureType) {
 				}
 				.abi_encode(),
 			)
-			.build();
+			.build_and_unwrap_result();
 
-		assert!(
-			result.result.is_err(),
-			"terminate must fail the enclosing call when deferred destruction cannot burn the ED; got {:?}",
-			result.result,
-		);
-		assert!(
-			get_contract_checked(&addr).is_some(),
-			"contract must remain live after a failed terminate",
-		);
+		assert!(result.did_revert(), "terminate must revert when a freeze pins the ED");
 		assert_eq!(
-			get_balance(&account_id),
-			min_balance + extra,
-			"contract balance must be restored when terminate rolls back",
+			decode_error(result.data.as_ref()),
+			"terminate pre-compile cannot burn the existential deposit: the contract's balance is locked",
 		);
 		assert_eq!(
 			get_balance(&DJANGO),
 			django_before,
-			"beneficiary must not keep the immediate transfer of a failed terminate",
+			"beneficiary must not keep the immediate transfer of a reverted terminate",
 		);
 	});
 }

--- a/substrate/frame/revive/uapi/sol/ISystem.sol
+++ b/substrate/frame/revive/uapi/sol/ISystem.sol
@@ -61,7 +61,7 @@ interface ISystem {
 	/// - called from constructor
 	/// - called from static context
 	/// - called from delegate context
-	/// - the contract introduced balance locks
+	/// - a balance lock or freeze on the contract pins its existential deposit
 	function terminate(address beneficiary) external;
 
 	/// Verify a sr25519 signature


### PR DESCRIPTION
# Description

Fixes #13017.

`System.terminate` returned success after `terminate_caller` moved the reducible balance and scheduled destruction, even when the deferred `do_terminate` later failed. The first-frame finalizer consumed `contracts_to_be_destroyed` with `mem::take` and discarded the error with `.ok()`. If the polite ED burn then failed — for example because a native freeze/lock made the remaining balance non-reducible — the beneficiary kept the transfer, the contract stayed live and callable, and nothing was left to retry.

`ISystem.sol` documents that `terminate` reverts when the contract introduced balance locks. That failure was hidden when it happened in the deferred finalizer rather than in the precompile itself.

## The change

Scheduled destruction now runs **inside the first-frame storage transaction**, so a late `do_terminate` failure aborts the enclosing top-level call and rolls back the immediate beneficiary transfer. Same policy for `System.terminate` and same-tx `SELFDESTRUCT`: they share this finalizer.

- `Stack::finalize_scheduled_destructions` is called from `run` at the end of the first frame, before that frame's `with_transaction` commits.
- `do_terminate` returns the storage-deposit refund instead of applying `transaction_meter.terminate` itself. Meter updates run only after every scheduled destroy succeeds, so a mid-batch failure cannot leave the deposit meter thinking a still-live contract was reaped.
- After a successful destroy of the first-frame account, its cached `ContractInfo` is invalidated so `pop_frame` does not write it back.

Locks/freezes are not bypassed. Gas/weight consumed by the reverted call is still charged via `pop_frame(persist=false)`.

## Integration

No API change. Downstream runtimes pick this up on the next `pallet-revive` bump. Observable behaviour: a `System.terminate` / same-tx `SELFDESTRUCT` whose deferred destruction cannot burn the ED now fails the enclosing call and restores balances, instead of reporting success with a live contract.

## Review Notes

The historical `.ok()` dates to [#10302](https://github.com/paritytech/polkadot-sdk/pull/10302), when the beneficiary transfer moved from final cleanup to an immediate `Preservation::Preserve` send. [#11847](https://github.com/paritytech/polkadot-sdk/pull/11847) made the ED burn `Fortitude::Polite`, which can legitimately fail. [#12144](https://github.com/paritytech/polkadot-sdk/pull/12144) fixed one swallowed-error trigger (Root origin) without changing the generic `.ok()`.

This implements the direction in the issue: extend the first-frame storage transaction through scheduled-destruction finalization. Several scheduled destroys in one tx are atomic with that transaction.

Deliberately left: bypassing locks/freezes so terminate always reaps. The public interface says those constraints should revert.

## Testing

- `precompile_terminate_reverts_when_ed_is_frozen`: native freeze of `reserved + ED`, then `System.terminate`. Enclosing call is `Err`, contract stays live, extra balance is restored, beneficiary does not keep the transfer.
- Existing sol terminate tests (20 solc), including first-frame `System.terminate` actually destroying the contract, rollback if a later frame reverts, and same-tx vs prior-tx `SELFDESTRUCT`.
- PVM `can_self_destruct_while_live` / `self_destruct_by_precompile_works` and `destroy_contract_reaps_account_and_clears_native_deposit_map`.

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [x] My PR follows the [labeling requirements](https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process) of this project (at minimum one label for `T` required)
* [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
