### PR TITLE
pallet-conviction-voting: migrate from Currency locks to fungible freezes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13222,6 +13222,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/governance/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/governance/mod.rs
@@ -46,6 +46,7 @@ parameter_types! {
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = weights::pallet_conviction_voting::WeightInfo<Self>;
 	type RuntimeEvent = RuntimeEvent;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type Currency = Balances;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1863,6 +1863,8 @@ pub type Migrations = (
 	// incentive formula applies; pending pre-cutoff eras keep the legacy
 	// stake-only share, avoiding a `HistoryDepth × MaxValidatorSet` backfill.
 	pallet_staking_async::migrations::SetWeightedPointsFormulaStartEra<Runtime>,
+	// unreleased: conviction-voting lock -> freeze
+	pallet_conviction_voting::migrations::MigrateV0ToV1<Runtime, Balances>,
 );
 
 /// Executive: handles dispatch to the various modules.

--- a/polkadot/runtime/rococo/src/governance/mod.rs
+++ b/polkadot/runtime/rococo/src/governance/mod.rs
@@ -41,6 +41,7 @@ parameter_types! {
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = weights::pallet_conviction_voting::WeightInfo<Self>;
 	type RuntimeEvent = RuntimeEvent;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type Currency = Balances;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -415,10 +415,10 @@ impl pallet_balances::Config for Runtime {
 	type MaxReserves = MaxReserves;
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = weights::pallet_balances_balances::WeightInfo<Runtime>;
-	type FreezeIdentifier = ();
+	type FreezeIdentifier = RuntimeFreezeReason;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeFreezeReason = RuntimeFreezeReason;
-	type MaxFreezes = ConstU32<1>;
+	type MaxFreezes = frame_support::traits::VariantCountOf<RuntimeFreezeReason>;
 	type DoneSlashHandler = ();
 }
 
@@ -1732,6 +1732,7 @@ pub mod migrations {
 
 	/// Unreleased migrations. Add new ones here:
 	pub type Unreleased = (
+        pallet_conviction_voting::migrations::MigrateV0ToV1<Runtime, Balances>,
         pallet_society::migrations::MigrateToV2<Runtime, (), ()>,
         parachains_configuration::migration::v7::MigrateToV7<Runtime>,
         assigned_slots::migration::v1::MigrateToV1<Runtime>,

--- a/prdoc/pr_conviction_voting_fungible_freezes.prdoc
+++ b/prdoc/pr_conviction_voting_fungible_freezes.prdoc
@@ -1,0 +1,35 @@
+title: 'pallet-conviction-voting: migrate from Currency locks to fungible freezes'
+doc:
+- audience: Runtime Dev
+  description: |-
+    pallet-conviction-voting no longer uses the deprecated `Currency`/`LockableCurrency`
+    traits (see https://github.com/paritytech/polkadot-sdk/issues/226). The `Config::Currency`
+    associated type keeps its name but now requires
+    `fungible::Inspect + fungible::Mutate + fungible::MutateFreeze`, and voting balances are
+    frozen under the new typed `FreezeReason::Vote` (aggregated via the new
+    `Config::RuntimeFreezeReason` associated type) instead of being locked under the untyped
+    `*b"pyconvot"` lock id. Behavior is unchanged: locks and freezes both floor the account's
+    `frozen` balance by `max`, holds keep composing (`untouchable = frozen - reserved`), and
+    voting power remains gated by `total_balance`.
+
+    Integration steps for runtimes:
+    - add `type RuntimeFreezeReason = RuntimeFreezeReason;` to the pallet's `Config` impl;
+    - make sure `pallet_balances::Config::FreezeIdentifier` is `RuntimeFreezeReason` and
+      `MaxFreezes` accounts for the new variant (e.g. `VariantCountOf<RuntimeFreezeReason>`);
+    - schedule `pallet_conviction_voting::migrations::MigrateV0ToV1<Runtime, Balances>` to move
+      existing `pyconvot` locks over to freezes. The migration iterates all voters in a single
+      block; chains with large voter counts must convert it to a multi-block/stepped migration
+      before adopting this release.
+crates:
+- name: pallet-conviction-voting
+  bump: major
+- name: rococo-runtime
+  bump: major
+- name: asset-hub-westend-runtime
+  bump: major
+- name: kitchensink-runtime
+  bump: patch
+- name: pallet-staking-async-rc-runtime
+  bump: patch
+- name: pallet-staking-async-parachain-runtime
+  bump: patch

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1072,6 +1072,7 @@ parameter_types! {
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = pallet_conviction_voting::weights::SubstrateWeight<Self>;
 	type RuntimeEvent = RuntimeEvent;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type Currency = Balances;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;
@@ -3165,6 +3166,7 @@ const IDENTITY_MIGRATION_KEY_LIMIT: u64 = u64::MAX;
 // `OnRuntimeUpgrade`. Note: These are examples and do not need to be run directly
 // after the genesis block.
 type Migrations = (
+	pallet_conviction_voting::migrations::MigrateV0ToV1<Runtime, Balances>,
 	pallet_nomination_pools::migration::versioned::V6ToV7<Runtime>,
 	pallet_alliance::migration::Migration<Runtime>,
 	pallet_contracts::Migration<Runtime>,

--- a/substrate/frame/conviction-voting/Cargo.toml
+++ b/substrate/frame/conviction-voting/Cargo.toml
@@ -21,6 +21,7 @@ codec = { features = ["derive", "max-encoded-len"], workspace = true }
 frame-benchmarking = { optional = true, workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde = { features = ["derive"], optional = true, workspace = true, default-features = true }
 sp-io = { workspace = true }
@@ -37,6 +38,7 @@ std = [
 	"frame-benchmarking?/std",
 	"frame-support/std",
 	"frame-system/std",
+	"log/std",
 	"pallet-balances/std",
 	"scale-info/std",
 	"serde",

--- a/substrate/frame/conviction-voting/src/benchmarking.rs
+++ b/substrate/frame/conviction-voting/src/benchmarking.rs
@@ -27,7 +27,7 @@ use frame_support::{
 	traits::{
 		fungible,
 		tokens::{Fortitude::Polite, Preservation::Expendable},
-		Currency, Get,
+		Get,
 	},
 };
 use sp_runtime::traits::Bounded;
@@ -55,7 +55,13 @@ fn fill_voting<T: Config<I>, I: 'static>(
 
 fn funded_account<T: Config<I>, I: 'static>(name: &'static str, index: u32) -> T::AccountId {
 	let caller: T::AccountId = account(name, index, SEED);
-	T::Currency::make_free_balance_be(&caller, BalanceOf::<T, I>::max_value());
+	// `set_balance` mints the difference into `TotalIssuance`, so `max_value()` would
+	// overflow issuance (unlike the old `make_free_balance_be`, which saturated). A tenth is
+	// still far beyond any vote amount while leaving room for several funded accounts.
+	let _ = <T::Currency as fungible::Mutate<T::AccountId>>::set_balance(
+		&caller,
+		BalanceOf::<T, I>::max_value() / 10u32.into(),
+	);
 	caller
 }
 
@@ -256,8 +262,9 @@ benchmarks_instance_pallet! {
 		let caller = funded_account::<T, I>("caller", 0);
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
 		whitelist_account!(caller);
-		let normal_account_vote = account_vote::<T, I>(T::Currency::free_balance(&caller) - 100u32.into());
-		let big_account_vote = account_vote::<T, I>(T::Currency::free_balance(&caller));
+		let free_balance = <T::Currency as fungible::Inspect<T::AccountId>>::balance(&caller);
+		let normal_account_vote = account_vote::<T, I>(free_balance - 100u32.into());
+		let big_account_vote = account_vote::<T, I>(free_balance);
 
 		// Fill everything up to the max by filling all classes with votes and voting on them all.
 		let (class, all_polls) = fill_voting::<T, I>();

--- a/substrate/frame/conviction-voting/src/lib.rs
+++ b/substrate/frame/conviction-voting/src/lib.rs
@@ -43,6 +43,7 @@ use sp_runtime::{
 };
 
 mod conviction;
+pub mod migrations;
 mod traits;
 mod types;
 mod vote;

--- a/substrate/frame/conviction-voting/src/lib.rs
+++ b/substrate/frame/conviction-voting/src/lib.rs
@@ -33,8 +33,8 @@ use frame_support::{
 	dispatch::DispatchResult,
 	ensure,
 	traits::{
-		fungible, Currency, Get, LockIdentifier, LockableCurrency, PollStatus, Polling,
-		ReservableCurrency, WithdrawReasons,
+		fungible::{Inspect as FunInspect, Mutate as FunMutate, MutateFreeze as FunMutateFreeze},
+		Get, PollStatus, Polling,
 	},
 };
 use sp_runtime::{
@@ -64,14 +64,12 @@ mod tests;
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 
-const CONVICTION_VOTING_ID: LockIdentifier = *b"pyconvot";
-
 pub type BlockNumberFor<T, I> =
 	<<T as Config<I>>::BlockNumberProvider as BlockNumberProvider>::BlockNumber;
 
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
 pub type BalanceOf<T, I = ()> =
-	<<T as Config<I>>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+	<<T as Config<I>>::Currency as FunInspect<<T as frame_system::Config>::AccountId>>::Balance;
 pub type VotingOf<T, I = ()> = Voting<
 	BalanceOf<T, I>,
 	<T as frame_system::Config>::AccountId,
@@ -94,7 +92,8 @@ pub mod pallet {
 	use super::*;
 	use frame_support::{
 		pallet_prelude::{
-			DispatchResultWithPostInfo, IsType, StorageDoubleMap, StorageMap, ValueQuery,
+			DispatchResultWithPostInfo, IsType, StorageDoubleMap, StorageMap, StorageVersion,
+			ValueQuery,
 		},
 		traits::ClassCountOf,
 		Twox64Concat,
@@ -102,8 +101,22 @@ pub mod pallet {
 	use frame_system::pallet_prelude::{ensure_signed, OriginFor};
 	use sp_runtime::BoundedVec;
 
+	/// The in-code storage version. Version 1 replaces the `LockableCurrency` lock
+	/// (`*b"pyconvot"`) with a `fungible::MutateFreeze` freeze (`FreezeReason::Vote`).
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T, I = ()>(_);
+
+	/// A reason for this pallet placing a freeze on funds.
+	#[pallet::composite_enum]
+	pub enum FreezeReason<I: 'static = ()> {
+		/// Funds are frozen because they back (or backed, until unlocked) a conviction vote or
+		/// a vote delegation.
+		#[codec(index = 0)]
+		Vote,
+	}
 
 	#[pallet::config]
 	pub trait Config<I: 'static = ()>: frame_system::Config + Sized {
@@ -113,10 +126,14 @@ pub mod pallet {
 			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
-		/// Currency type with which voting happens.
-		type Currency: ReservableCurrency<Self::AccountId>
-			+ LockableCurrency<Self::AccountId, Moment = BlockNumberFor<Self, I>>
-			+ fungible::Inspect<Self::AccountId>;
+		/// Currency type with which voting happens. Voting balances are frozen (in place, on
+		/// top of any holds) rather than moved out of the account.
+		type Currency: FunInspect<Self::AccountId>
+			+ FunMutate<Self::AccountId>
+			+ FunMutateFreeze<Self::AccountId, Id = Self::RuntimeFreezeReason>;
+
+		/// The overarching freeze reason.
+		type RuntimeFreezeReason: From<FreezeReason<I>>;
 
 		/// The implementation of the logic which conducts polls.
 		type Polls: Polling<
@@ -344,7 +361,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			ensure_signed(origin)?;
 			let target = T::Lookup::lookup(target)?;
-			Self::update_lock(&class, &target);
+			Self::update_freeze(&class, &target)?;
 			Self::deposit_event(Event::VoteUnlocked { who: target, class });
 			Ok(())
 		}
@@ -463,9 +480,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				} else {
 					return Err(Error::<T, I>::AlreadyDelegating.into());
 				}
-				// Extend the lock to `balance` (rather than setting it) since we don't know what
-				// other votes are in place.
-				Self::extend_lock(who, &class, vote.balance());
+				// Extend the freeze to `balance` (rather than setting it) since we don't know
+				// what other votes are in place.
+				Self::extend_freeze_for(who, &class, vote.balance())?;
 				Self::deposit_event(Event::Voted { who: who.clone(), vote, poll_index });
 				Ok(())
 			})
@@ -657,9 +674,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 				let votes =
 					Self::increase_upstream_delegation(&target, &class, conviction.votes(balance));
-				// Extend the lock to `balance` (rather than setting it) since we don't know what
-				// other votes are in place.
-				Self::extend_lock(&who, &class, balance);
+				// Extend the freeze to `balance` (rather than setting it) since we don't know
+				// what other votes are in place.
+				Self::extend_freeze_for(&who, &class, balance)?;
 				Ok(votes)
 			})?;
 		Self::deposit_event(Event::<T, I>::Delegated(who, target, class));
@@ -705,7 +722,17 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(votes)
 	}
 
-	fn extend_lock(who: &T::AccountId, class: &ClassOf<T, I>, amount: BalanceOf<T, I>) {
+	/// Extend the `FreezeReason::Vote` freeze of `who` to at least `amount`, recording the
+	/// per-class requirement in `ClassLocksFor`.
+	///
+	/// The `ClassLocksFor` bookkeeping happens before the (fallible) freeze on purpose: every
+	/// caller runs inside a transactional `try_mutate`, so an `Err` here unwinds the
+	/// bookkeeping along with the vote itself.
+	fn extend_freeze_for(
+		who: &T::AccountId,
+		class: &ClassOf<T, I>,
+		amount: BalanceOf<T, I>,
+	) -> DispatchResult {
 		ClassLocksFor::<T, I>::mutate(who, |locks| {
 			match locks.iter().position(|x| &x.0 == class) {
 				Some(i) => locks[i].1 = locks[i].1.max(amount),
@@ -720,17 +747,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				},
 			}
 		});
-		T::Currency::extend_lock(
-			CONVICTION_VOTING_ID,
-			who,
-			amount,
-			WithdrawReasons::except(WithdrawReasons::RESERVE),
-		);
+		T::Currency::extend_freeze(&FreezeReason::Vote.into(), who, amount)
 	}
 
-	/// Rejig the lock on an account. It will never get more stringent (since that would indicate
-	/// a security hole) but may be reduced from what they are currently.
-	fn update_lock(class: &ClassOf<T, I>, who: &T::AccountId) {
+	/// Rejig the freeze on an account. It will never get more stringent (since that would
+	/// indicate a security hole) but may be reduced from what it is currently.
+	fn update_freeze(class: &ClassOf<T, I>, who: &T::AccountId) -> DispatchResult {
 		let class_lock_needed = VotingFor::<T, I>::mutate(who, class, |voting| {
 			voting.rejig(T::BlockNumberProvider::current_block_number());
 			voting.locked_balance()
@@ -749,14 +771,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			locks.iter().map(|x| x.1).max().unwrap_or(Zero::zero())
 		});
 		if lock_needed.is_zero() {
-			T::Currency::remove_lock(CONVICTION_VOTING_ID, who);
+			T::Currency::thaw(&FreezeReason::Vote.into(), who)
 		} else {
-			T::Currency::set_lock(
-				CONVICTION_VOTING_ID,
-				who,
-				lock_needed,
-				WithdrawReasons::except(WithdrawReasons::RESERVE),
-			);
+			T::Currency::set_freeze(&FreezeReason::Vote.into(), who, lock_needed)
 		}
 	}
 }

--- a/substrate/frame/conviction-voting/src/migrations.rs
+++ b/substrate/frame/conviction-voting/src/migrations.rs
@@ -1,0 +1,201 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Storage migrations for pallet-conviction-voting.
+
+use super::*;
+use frame_support::{
+	pallet_prelude::*,
+	traits::{InspectLockableCurrency, LockIdentifier, LockableCurrency},
+};
+
+#[cfg(feature = "try-runtime")]
+use alloc::vec::Vec;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+
+/// The lock identifier this pallet used before v1. Only migration vocabulary now: v1 replaced
+/// the `LockableCurrency` lock with a `fungible` freeze under [`FreezeReason::Vote`].
+const CONVICTION_VOTING_ID: LockIdentifier = *b"pyconvot";
+
+pub mod v1 {
+	use super::*;
+
+	/// Move every voter's `*b"pyconvot"` `LockableCurrency` lock over to a
+	/// `fungible::MutateFreeze` freeze under [`FreezeReason::Vote`].
+	///
+	/// `OldCurrency` is the `LockableCurrency` implementation the pallet was previously wired
+	/// to (in practice: the same `pallet-balances` instance as `T::Currency`); the pallet
+	/// itself no longer knows the legacy trait exists, so the migration takes it explicitly.
+	///
+	/// The set of accounts to migrate is exactly the key set of [`ClassLocksFor`]: the pallet
+	/// has always kept the on-chain lock equal to the max over that list (and removed the lock
+	/// when the list emptied), so no other account can hold a `"pyconvot"` lock.
+	///
+	/// NOTE: iterates all voters in one block. Fine for small/test networks; chains with large
+	/// voter counts must lift the per-account body into a stepped (multi-block) migration
+	/// before adopting this.
+	pub struct VoteLockToFreeze<T, OldCurrency, I = ()>(PhantomData<(T, OldCurrency, I)>);
+
+	impl<T, OldCurrency, I> frame_support::traits::UncheckedOnRuntimeUpgrade
+		for VoteLockToFreeze<T, OldCurrency, I>
+	where
+		T: Config<I>,
+		I: 'static,
+		OldCurrency: LockableCurrency<T::AccountId>
+			+ InspectLockableCurrency<T::AccountId, Balance = BalanceOf<T, I>>,
+	{
+		fn on_runtime_upgrade() -> Weight {
+			let mut migrated = 0u64;
+			let mut iterated = 0u64;
+			for (who, class_locks) in ClassLocksFor::<T, I>::iter() {
+				iterated.saturating_inc();
+				// The invariant the pallet has always enforced: on-chain encumbrance = max
+				// over the per-class requirements.
+				let amount =
+					class_locks.iter().map(|x| x.1).max().unwrap_or_else(Zero::zero);
+				if amount.is_zero() {
+					// Empty entry: `update_lock` already removed the legacy lock for it.
+					continue;
+				}
+				// Freeze first, remove the lock only on success: the account must never pass
+				// through a state where the balance backing a live vote is transferable.
+				match T::Currency::set_freeze(&FreezeReason::Vote.into(), &who, amount) {
+					Ok(()) => {
+						OldCurrency::remove_lock(CONVICTION_VOTING_ID, &who);
+						migrated.saturating_inc();
+					},
+					Err(e) => {
+						// Keeping the old lock keeps the funds encumbered; nothing is lost,
+						// but this needs investigating (`MaxFreezes` too small?).
+						log::error!(
+							target: "runtime::conviction-voting",
+							"failed to freeze for {who:?}: {e:?}; legacy lock kept in place",
+						);
+					},
+				}
+			}
+			log::info!(
+				target: "runtime::conviction-voting",
+				"migrated {migrated} of {iterated} conviction voting locks to freezes",
+			);
+			// Per account: 1 read (iteration) + freeze (account + freezes r/w) + lock removal
+			// (account + locks r/w).
+			T::DbWeight::get().reads_writes(
+				iterated.saturating_mul(3),
+				migrated.saturating_mul(4),
+			)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			let expected: Vec<(T::AccountId, BalanceOf<T, I>)> = ClassLocksFor::<T, I>::iter()
+				.map(|(who, class_locks)| {
+					let amount =
+						class_locks.iter().map(|x| x.1).max().unwrap_or_else(Zero::zero);
+					(who, amount)
+				})
+				.collect();
+			Ok(expected.encode())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
+			use frame_support::traits::fungible::InspectFreeze;
+			let expected: Vec<(T::AccountId, BalanceOf<T, I>)> =
+				Decode::decode(&mut state.as_slice())
+					.map_err(|_| TryRuntimeError::Other("pre_upgrade state decodes"))?;
+			for (who, amount) in expected {
+				ensure!(
+					T::Currency::balance_frozen(&FreezeReason::Vote.into(), &who) == amount,
+					TryRuntimeError::Other("freeze amount != pre-upgrade lock requirement"),
+				);
+				ensure!(
+					OldCurrency::balance_locked(CONVICTION_VOTING_ID, &who).is_zero(),
+					TryRuntimeError::Other("legacy pyconvot lock still in place"),
+				);
+			}
+			Ok(())
+		}
+	}
+}
+
+/// v0 → v1: [`v1::VoteLockToFreeze`], gated on the pallet's storage version so it runs exactly
+/// once. Wire as `MigrateV0ToV1<Runtime, Balances>` (or the instanced equivalent).
+pub type MigrateV0ToV1<T, OldCurrency, I = ()> = frame_support::migrations::VersionedMigration<
+	0,
+	1,
+	v1::VoteLockToFreeze<T, OldCurrency, I>,
+	Pallet<T, I>,
+	<T as frame_system::Config>::DbWeight,
+>;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::tests::{new_test_ext, Balances, Test};
+	use frame_support::traits::{fungible::InspectFreeze, OnRuntimeUpgrade, WithdrawReasons};
+
+	#[test]
+	fn vote_lock_to_freeze_migration_works() {
+		new_test_ext().execute_with(|| {
+			// Set up two voters exactly as the v0 pallet would have left them: a legacy
+			// `pyconvot` lock equal to the max of their `ClassLocksFor` entries.
+			ClassLocksFor::<Test>::insert(
+				1,
+				BoundedVec::truncate_from(vec![(0u8, 5u64), (1u8, 8u64)]),
+			);
+			Balances::set_lock(CONVICTION_VOTING_ID, &1, 8, WithdrawReasons::all());
+			ClassLocksFor::<Test>::insert(2, BoundedVec::truncate_from(vec![(0u8, 20u64)]));
+			Balances::set_lock(CONVICTION_VOTING_ID, &2, 20, WithdrawReasons::all());
+			// On-chain storage version 0, as on any live chain today.
+			StorageVersion::new(0).put::<Pallet<Test>>();
+
+			assert_eq!(Balances::usable_balance(1), 2);
+			assert_eq!(Balances::usable_balance(2), 0);
+
+			MigrateV0ToV1::<Test, Balances>::on_runtime_upgrade();
+
+			// The encumbrance moved from the Locks storage to the Freezes storage...
+			assert_eq!(Balances::balance_locked(CONVICTION_VOTING_ID, &1), 0);
+			assert_eq!(Balances::balance_locked(CONVICTION_VOTING_ID, &2), 0);
+			assert_eq!(Balances::balance_frozen(&FreezeReason::Vote.into(), &1), 8);
+			assert_eq!(Balances::balance_frozen(&FreezeReason::Vote.into(), &2), 20);
+			// ...with no observable balance change for the voters...
+			assert_eq!(Balances::usable_balance(1), 2);
+			assert_eq!(Balances::usable_balance(2), 0);
+			// ...and the storage version is bumped so the migration is one-shot.
+			assert_eq!(StorageVersion::get::<Pallet<Test>>(), 1);
+		});
+	}
+
+	#[test]
+	fn migration_is_noop_when_already_v1() {
+		new_test_ext().execute_with(|| {
+			// An already-migrated chain (on-chain version 1) must not be touched again, even
+			// if a stray legacy lock exists.
+			StorageVersion::new(1).put::<Pallet<Test>>();
+			Balances::set_lock(CONVICTION_VOTING_ID, &1, 8, WithdrawReasons::all());
+			ClassLocksFor::<Test>::insert(1, BoundedVec::truncate_from(vec![(0u8, 8u64)]));
+
+			MigrateV0ToV1::<Test, Balances>::on_runtime_upgrade();
+
+			assert_eq!(Balances::balance_locked(CONVICTION_VOTING_ID, &1), 8);
+			assert_eq!(Balances::balance_frozen(&FreezeReason::Vote.into(), &1), 0);
+		});
+	}
+}

--- a/substrate/frame/conviction-voting/src/migrations.rs
+++ b/substrate/frame/conviction-voting/src/migrations.rs
@@ -66,8 +66,7 @@ pub mod v1 {
 				iterated.saturating_inc();
 				// The invariant the pallet has always enforced: on-chain encumbrance = max
 				// over the per-class requirements.
-				let amount =
-					class_locks.iter().map(|x| x.1).max().unwrap_or_else(Zero::zero);
+				let amount = class_locks.iter().map(|x| x.1).max().unwrap_or_else(Zero::zero);
 				if amount.is_zero() {
 					// Empty entry: `update_lock` already removed the legacy lock for it.
 					continue;
@@ -95,18 +94,14 @@ pub mod v1 {
 			);
 			// Per account: 1 read (iteration) + freeze (account + freezes r/w) + lock removal
 			// (account + locks r/w).
-			T::DbWeight::get().reads_writes(
-				iterated.saturating_mul(3),
-				migrated.saturating_mul(4),
-			)
+			T::DbWeight::get().reads_writes(iterated.saturating_mul(3), migrated.saturating_mul(4))
 		}
 
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
 			let expected: Vec<(T::AccountId, BalanceOf<T, I>)> = ClassLocksFor::<T, I>::iter()
 				.map(|(who, class_locks)| {
-					let amount =
-						class_locks.iter().map(|x| x.1).max().unwrap_or_else(Zero::zero);
+					let amount = class_locks.iter().map(|x| x.1).max().unwrap_or_else(Zero::zero);
 					(who, amount)
 				})
 				.collect();

--- a/substrate/frame/conviction-voting/src/tests.rs
+++ b/substrate/frame/conviction-voting/src/tests.rs
@@ -21,7 +21,7 @@ use std::{cell::RefCell, collections::BTreeMap};
 
 use frame_support::{
 	assert_noop, assert_ok, derive_impl, parameter_types,
-	traits::{ConstU32, ConstU64, Contains, Polling, VoteTally},
+	traits::{fungible::InspectFreeze, ConstU32, ConstU64, Contains, Polling, VoteTally},
 };
 use sp_runtime::BuildStorage;
 
@@ -57,6 +57,11 @@ impl frame_system::Config for Test {
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Test {
 	type AccountStore = System;
+	// NOTE: `derive_impl` resolves the prelude's `Self::RuntimeFreezeReason` against the
+	// prelude struct (`()`), so `FreezeIdentifier`/`MaxFreezes` must be overridden explicitly.
+	type RuntimeFreezeReason = RuntimeFreezeReason;
+	type FreezeIdentifier = RuntimeFreezeReason;
+	type MaxFreezes = frame_support::traits::VariantCountOf<RuntimeFreezeReason>;
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -150,6 +155,7 @@ impl Polling<TallyOf<Test>> for TestPolls {
 
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type Currency = pallet_balances::Pallet<Self>;
 	type VoteLockingPeriod = ConstU64<3>;
 	type MaxVotes = ConstU32<3>;
@@ -1087,5 +1093,40 @@ fn empty_tally_approval_is_zero() {
 			<TallyOf<Test> as VoteTally<u64, u8>>::approval(&mixed, 0),
 			Perbill::from_percent(30),
 		);
+	});
+}
+
+#[test]
+fn freeze_is_registered_under_the_vote_reason() {
+	// The typed successor of the old `*b"pyconvot"` lock id: the pallet's encumbrance is a
+	// `fungible` freeze under `FreezeReason::Vote`, inspectable per reason.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(2, 5)));
+		assert_eq!(Balances::balance_frozen(&FreezeReason::Vote.into(), &1), 2);
+
+		// Voting bigger extends the freeze...
+		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(10, 1)));
+		assert_eq!(Balances::balance_frozen(&FreezeReason::Vote.into(), &1), 10);
+
+		// ...while re-voting smaller never shrinks it (only `unlock` recomputes downwards).
+		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(2, 5)));
+		assert_eq!(Balances::balance_frozen(&FreezeReason::Vote.into(), &1), 10);
+	});
+}
+
+#[test]
+fn unlock_thaws_the_freeze_entirely() {
+	// Once no votes or prior locks remain, `unlock` must `thaw` rather than set a zero
+	// freeze: no residual `Freezes` entry may stay behind on the account.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(10, 0)));
+		assert_eq!(Balances::usable_balance(1), 0);
+
+		// Removing the (still-ongoing) vote leaves nothing to freeze for.
+		assert_ok!(Voting::remove_vote(RuntimeOrigin::signed(1), None, 3));
+		assert_ok!(Voting::unlock(RuntimeOrigin::signed(1), class(3), 1));
+
+		assert!(pallet_balances::Freezes::<Test>::get(1).is_empty());
+		assert_eq!(Balances::usable_balance(1), 10);
 	});
 }

--- a/substrate/frame/staking-async/runtimes/parachain/src/governance/mod.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/governance/mod.rs
@@ -53,6 +53,7 @@ parameter_types! {
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = weights::pallet_conviction_voting::WeightInfo<Self>;
 	type RuntimeEvent = RuntimeEvent;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type Currency = Balances;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;

--- a/substrate/frame/staking-async/runtimes/rc/src/governance/mod.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/governance/mod.rs
@@ -38,6 +38,7 @@ parameter_types! {
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = weights::pallet_conviction_voting::WeightInfo<Self>;
 	type RuntimeEvent = RuntimeEvent;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type Currency = Balances;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;


### PR DESCRIPTION

# Description

Migrates `pallet-conviction-voting` from the deprecated `Currency`/`LockableCurrency` traits to
the `fungible` ones (part of #226  ): the untyped `*b"pyconvot"` **lock**
becomes a typed **freeze** under a new `FreezeReason::Vote` composite enum, moved over by a
`VersionedMigration` (v0 → v1).

Behavior is unchanged — locks and freezes both floor the account's `frozen` balance by `max`,
holds keep composing (`untouchable = frozen − reserved`), and voting stays gated by
`total_balance` — proven by the pre-existing behavior-level tests passing unmodified.

Besides paying down the #226 debt, this simplifies the upcoming **anonymous voting**
implementation: building it on typed, per-reason `fungible` freezes (inspectable via
`balance_frozen`, composable with holds by construction) is much cleaner than layering on the
untyped shared lock id.

## Integration

`Config::Currency` keeps its name (its bound is now `fungible::Inspect + Mutate +
MutateFreeze`), so downstream runtimes only need:

```diff
 impl pallet_conviction_voting::Config for Runtime {
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type Currency = Balances;
 	...
 }

 impl pallet_balances::Config for Runtime {
-	type FreezeIdentifier = ();
-	type MaxFreezes = ConstU32<1>;
+	type FreezeIdentifier = RuntimeFreezeReason;
+	type MaxFreezes = VariantCountOf<RuntimeFreezeReason>;
 	...
 }

 pub type Migrations = (
+	pallet_conviction_voting::migrations::MigrateV0ToV1<Runtime, Balances>,
 	...
 );
```

Fresh-genesis chains skip the migration — genesis writes storage version 1 directly.

> [!WARNING]
> The migration iterates all voters in one block. Chains with large voter counts must convert
> it to a multi-block/stepped migration before adopting this release.

Weights should be regenerated (`/cmd bench`) — storage access moved from `Locks` to `Freezes`.

## Review Notes

Best reviewed commit by commit — each commit is one self-contained step (pallet swap →
benchmarks → storage migration → runtime wiring → prdoc). Highlights:

- `extend_lock`/`set_lock`/`remove_lock` → `extend_freeze`/`set_freeze`/`thaw` with identical
  max-over-classes semantics; freeze errors are now **propagated** (misconfigured `MaxFreezes`
  fails loudly with `TooManyFreezes` instead of corrupting lock accounting).
- Migration is **freeze-first**: the freeze is placed before the lock is removed, so no account
  is ever transferable while backing a live vote; on failure the legacy lock is kept.
- Dropping `WithdrawReasons::except(RESERVE)` loses nothing — `pallet-balances` already ignores
  `WithdrawReasons`; lock/hold composition comes from holds discounting the freeze floor.
- The unused `ReservableCurrency` bound is dropped; `FreezeReason<I>` is instanced, so pallet
  instances no longer share one lock id.
- Tests: pre-existing suite unchanged, plus freeze-reason, thaw-completely, and migration
  round-trip tests with try-runtime hooks. All in-repo runtimes updated and compiling (Rococo
  also gets its dead `FreezeIdentifier = ()` fixed).

TODO: 
- [ ] generate benchmark
