### PR TITLE
try state check for offences pallet

### DIFF
--- a/prdoc/pr_13102.prdoc
+++ b/prdoc/pr_13102.prdoc
@@ -1,0 +1,10 @@
+title: try state check for offences pallet
+doc:
+- audience: Runtime Dev
+  description: |-
+    This PR introduces try state hook into the Offences Pallet. It also defines the invariants that holds for the pallet.
+
+    Part of: https://github.com/paritytech/polkadot-sdk/issues/239
+crates:
+- name: pallet-offences
+  bump: major

--- a/substrate/frame/offences/src/lib.rs
+++ b/substrate/frame/offences/src/lib.rs
@@ -52,6 +52,7 @@ const LOG_TARGET: &str = "runtime::offences";
 pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::BlockNumberFor;
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
@@ -92,6 +93,14 @@ pub mod pallet {
 		Vec<ReportIdOf<T>>,
 		ValueQuery,
 	>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()
+		}
+	}
 
 	/// Events type.
 	#[pallet::event]
@@ -207,6 +216,68 @@ impl<T: Config> Pallet<T> {
 		} else {
 			None
 		}
+	}
+}
+
+#[cfg(any(feature = "try-runtime", test))]
+impl<T: Config> Pallet<T> {
+	/// Ensure the correctness of the state of this pallet.
+	///
+	/// This should be valid before or after each state transition of this pallet.
+	pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+		Self::try_state_concurrent_reports_index()?;
+		Self::try_state_reports_are_indexed()?;
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * Every report id held in `ConcurrentReportsIndex` must resolve to a report in `Reports`.
+	///   The index is only ever written alongside the report it points at, so a dangling id means
+	///   the report behind it was lost.
+	/// * A report id must not be listed more than once. A report is only indexed at the point it is
+	///   first created, and a repeated offence for the same kind, time slot and offender is
+	///   discarded as a duplicate rather than indexed again.
+	fn try_state_concurrent_reports_index() -> Result<(), sp_runtime::TryRuntimeError> {
+		let mut seen = alloc::collections::BTreeSet::new();
+
+		for (_, _, report_ids) in ConcurrentReportsIndex::<T>::iter() {
+			for report_id in report_ids {
+				frame_support::ensure!(
+					Reports::<T>::contains_key(report_id),
+					"a report id in `ConcurrentReportsIndex` must resolve to a report"
+				);
+
+				frame_support::ensure!(
+					seen.insert(report_id),
+					"a report id must not be listed twice in `ConcurrentReportsIndex`"
+				);
+			}
+		}
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * Every report in `Reports` must be listed in `ConcurrentReportsIndex`. A report is only
+	///   ever inserted together with its index entry, and the index is the sole means of finding
+	///   the reports for a given kind and time slot, so an unindexed report can never be found
+	///   again when a later offence is triaged.
+	fn try_state_reports_are_indexed() -> Result<(), sp_runtime::TryRuntimeError> {
+		let indexed = ConcurrentReportsIndex::<T>::iter()
+			.flat_map(|(_, _, report_ids)| report_ids)
+			.collect::<alloc::collections::BTreeSet<_>>();
+
+		for report_id in Reports::<T>::iter_keys() {
+			frame_support::ensure!(
+				indexed.contains(&report_id),
+				"a report in `Reports` must be listed in `ConcurrentReportsIndex`"
+			);
+		}
+
+		Ok(())
 	}
 }
 

--- a/substrate/frame/offences/src/mock.rs
+++ b/substrate/frame/offences/src/mock.rs
@@ -92,6 +92,13 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
+pub fn build_and_execute(test: impl FnOnce()) {
+	new_test_ext().execute_with(|| {
+		test();
+		Offences::do_try_state().expect("All invariants must hold after a test");
+	});
+}
+
 pub const KIND: [u8; 16] = *b"test_report_1234";
 
 /// Returns all offence details for the specific `kind` happened at the specific time slot.

--- a/substrate/frame/offences/src/tests.rs
+++ b/substrate/frame/offences/src/tests.rs
@@ -21,8 +21,8 @@
 
 use super::*;
 use crate::mock::{
-	new_test_ext, offence_reports, with_on_offence_fractions, Offence, Offences, Runtime,
-	RuntimeEvent, System, KIND,
+	build_and_execute, new_test_ext, offence_reports, with_on_offence_fractions, Offence, Offences,
+	Runtime, RuntimeEvent, System, KIND,
 };
 use frame_system::{EventRecord, Phase};
 use sp_core::H256;
@@ -30,6 +30,8 @@ use sp_runtime::Perbill;
 
 #[test]
 fn should_get_reports_with_storagemap_getter_and_function_getter() {
+	// This writes into `Reports` directly rather than reporting an offence, so it deliberately
+	// leaves the report out of `ConcurrentReportsIndex` and cannot run the invariant checks.
 	new_test_ext().execute_with(|| {
 		// given
 		let report_id: ReportIdOf<Runtime> = H256::from_low_u64_be(1);
@@ -51,7 +53,7 @@ fn should_get_reports_with_storagemap_getter_and_function_getter() {
 
 #[test]
 fn should_report_an_authority_and_trigger_on_offence() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// given
 		let slot = 42;
 		assert_eq!(offence_reports(KIND, slot), vec![]);
@@ -70,7 +72,7 @@ fn should_report_an_authority_and_trigger_on_offence() {
 
 #[test]
 fn should_not_report_the_same_authority_twice_in_the_same_slot() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// given
 		let slot = 42;
 		assert_eq!(offence_reports(KIND, slot), vec![]);
@@ -95,7 +97,7 @@ fn should_not_report_the_same_authority_twice_in_the_same_slot() {
 
 #[test]
 fn should_report_in_different_slot() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// given
 		let slot = 42;
 		assert_eq!(offence_reports(KIND, slot), vec![]);
@@ -121,7 +123,7 @@ fn should_report_in_different_slot() {
 
 #[test]
 fn should_deposit_event() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// given
 		let slot = 42;
 		assert_eq!(offence_reports(KIND, slot), vec![]);
@@ -148,7 +150,7 @@ fn should_deposit_event() {
 
 #[test]
 fn doesnt_deposit_event_for_dups() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// given
 		let slot = 42;
 		assert_eq!(offence_reports(KIND, slot), vec![]);
@@ -182,7 +184,7 @@ fn doesnt_deposit_event_for_dups() {
 
 #[test]
 fn reports_if_an_offence_is_dup() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let slot = 42;
 		assert_eq!(offence_reports(KIND, slot), vec![]);
 
@@ -238,7 +240,7 @@ fn reports_if_an_offence_is_dup() {
 fn should_properly_count_offences() {
 	// We report two different authorities for the same issue. Ultimately, the 1st authority
 	// should have `count` equal 2 and the count of the 2nd one should be equal to 1.
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// given
 		let slot = 42;
 		assert_eq!(offence_reports(KIND, slot), vec![]);


### PR DESCRIPTION
This PR introduces try state hook into the Offences Pallet. It also defines the invariants that holds for the pallet.

Part of: https://github.com/paritytech/polkadot-sdk/issues/239