### PR TITLE
try state check for node authorization pallet

### DIFF
--- a/prdoc/pr_13104.prdoc
+++ b/prdoc/pr_13104.prdoc
@@ -1,0 +1,10 @@
+title: try state check for node authorization pallet
+doc:
+- audience: Runtime Dev
+  description: |-
+    This PR introduces try state hook into the Node Authorization Pallet. It also defines the invariants that holds for the pallet.
+
+    Part of: https://github.com/paritytech/polkadot-sdk/issues/239
+crates:
+- name: pallet-node-authorization
+  bump: major

--- a/substrate/frame/node-authorization/src/lib.rs
+++ b/substrate/frame/node-authorization/src/lib.rs
@@ -49,6 +49,8 @@ pub mod weights;
 extern crate alloc;
 
 use alloc::{collections::btree_set::BTreeSet, vec::Vec};
+#[cfg(any(feature = "try-runtime", test))]
+use frame::deps::sp_runtime::TryRuntimeError;
 use frame::{
 	deps::{sp_core::OpaquePeerId as PeerId, sp_io},
 	prelude::*,
@@ -172,6 +174,11 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), TryRuntimeError> {
+			Self::do_try_state()
+		}
+
 		/// Set reserved node every block. It may not be enabled depends on the offchain
 		/// worker settings when starting the node.
 		fn offchain_worker(now: BlockNumberFor<T>) {
@@ -468,5 +475,61 @@ impl<T: Config> Pallet<T> {
 		}
 
 		Vec::from_iter(nodes)
+	}
+}
+
+#[cfg(any(feature = "try-runtime", test))]
+impl<T: Config> Pallet<T> {
+	/// Ensure the correctness of the state of this pallet.
+	///
+	/// This should be valid before or after each state transition of this pallet.
+	pub fn do_try_state() -> Result<(), TryRuntimeError> {
+		Self::try_state_well_known_nodes_are_owned()?;
+		Self::try_state_additional_connections_are_owned()?;
+		Self::try_state_well_known_nodes_limit()?;
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * Every well known node must have an owner. A well known node is only ever added together
+	///   with its owner, and a claim cannot be removed while the node is well known, so an unowned
+	///   well known node could never be managed by anyone.
+	fn try_state_well_known_nodes_are_owned() -> Result<(), TryRuntimeError> {
+		for node in WellKnownNodes::<T>::get() {
+			ensure!(Owners::<T>::contains_key(&node), "a well known node must have an owner");
+		}
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * Only the owner of a node may change its additional connections, so a node with connections
+	///   recorded against it must be owned. The connections are removed alongside the ownership,
+	///   whether the claim is dropped or the well known node is removed.
+	fn try_state_additional_connections_are_owned() -> Result<(), TryRuntimeError> {
+		for (node, _) in AdditionalConnections::<T>::iter() {
+			ensure!(
+				Owners::<T>::contains_key(&node),
+				"a node with additional connections must have an owner"
+			);
+		}
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * The set of well known nodes must not grow past `MaxWellKnownNodes`, which is the bound
+	///   both `add_well_known_node` and `reset_well_known_nodes` enforce.
+	fn try_state_well_known_nodes_limit() -> Result<(), TryRuntimeError> {
+		ensure!(
+			WellKnownNodes::<T>::get().len() as u32 <= T::MaxWellKnownNodes::get(),
+			"the number of well known nodes must not exceed `MaxWellKnownNodes`"
+		);
+
+		Ok(())
 	}
 }

--- a/substrate/frame/node-authorization/src/mock.rs
+++ b/substrate/frame/node-authorization/src/mock.rs
@@ -68,3 +68,10 @@ pub fn new_test_ext() -> TestState {
 	.unwrap();
 	t.into()
 }
+
+pub fn build_and_execute(test: impl FnOnce()) {
+	new_test_ext().execute_with(|| {
+		test();
+		NodeAuthorization::do_try_state().expect("All invariants must hold after a test");
+	});
+}

--- a/substrate/frame/node-authorization/src/tests.rs
+++ b/substrate/frame/node-authorization/src/tests.rs
@@ -23,7 +23,7 @@ use frame::testing_prelude::*;
 
 #[test]
 fn add_well_known_node_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			NodeAuthorization::add_well_known_node(RuntimeOrigin::signed(2), test_node(15), 15),
 			BadOrigin
@@ -64,7 +64,7 @@ fn add_well_known_node_works() {
 
 #[test]
 fn remove_well_known_node_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			NodeAuthorization::remove_well_known_node(RuntimeOrigin::signed(3), test_node(20)),
 			BadOrigin
@@ -102,7 +102,7 @@ fn remove_well_known_node_works() {
 
 #[test]
 fn swap_well_known_node_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			NodeAuthorization::swap_well_known_node(
 				RuntimeOrigin::signed(4),
@@ -180,7 +180,7 @@ fn swap_well_known_node_works() {
 
 #[test]
 fn reset_well_known_nodes_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			NodeAuthorization::reset_well_known_nodes(
 				RuntimeOrigin::signed(3),
@@ -217,7 +217,7 @@ fn reset_well_known_nodes_works() {
 
 #[test]
 fn claim_node_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			NodeAuthorization::claim_node(RuntimeOrigin::signed(1), PeerId(vec![1, 2, 3])),
 			Error::<Test>::PeerIdTooLong
@@ -234,7 +234,7 @@ fn claim_node_works() {
 
 #[test]
 fn remove_claim_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			NodeAuthorization::remove_claim(RuntimeOrigin::signed(15), PeerId(vec![1, 2, 3])),
 			Error::<Test>::PeerIdTooLong
@@ -267,7 +267,7 @@ fn remove_claim_works() {
 
 #[test]
 fn transfer_node_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			NodeAuthorization::transfer_node(RuntimeOrigin::signed(15), PeerId(vec![1, 2, 3]), 10),
 			Error::<Test>::PeerIdTooLong
@@ -289,7 +289,7 @@ fn transfer_node_works() {
 
 #[test]
 fn add_connections_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			NodeAuthorization::add_connections(
 				RuntimeOrigin::signed(15),
@@ -330,7 +330,7 @@ fn add_connections_works() {
 
 #[test]
 fn remove_connections_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			NodeAuthorization::remove_connections(
 				RuntimeOrigin::signed(15),
@@ -375,7 +375,7 @@ fn remove_connections_works() {
 
 #[test]
 fn get_authorized_nodes_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		AdditionalConnections::<Test>::insert(
 			test_node(20),
 			BTreeSet::from_iter(vec![test_node(5), test_node(15), test_node(25)]),


### PR DESCRIPTION
This PR introduces try state hook into the Node Authorization Pallet. It also defines the invariants that holds for the pallet.

Part of: https://github.com/paritytech/polkadot-sdk/issues/239