### PR TITLE
try state check for transaction storage pallet

### DIFF
--- a/prdoc/pr_13106.prdoc
+++ b/prdoc/pr_13106.prdoc
@@ -1,0 +1,8 @@
+title: try state check for transaction storage pallet
+doc:
+- audience: Runtime Dev
+  description: |-
+    This PR introduces try state hook into the Transaction Storage Pallet. It also defines the invariants that holds for the pallet.
+
+    Part of: https://github.com/paritytech/polkadot-sdk/issues/239
+crates: []

--- a/substrate/frame/transaction-storage/src/lib.rs
+++ b/substrate/frame/transaction-storage/src/lib.rs
@@ -213,6 +213,11 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()
+		}
+
 		fn on_initialize(n: BlockNumberFor<T>) -> Weight {
 			// TODO: https://github.com/paritytech/polkadot-sdk/issues/10203 - Replace this with benchmarked weights.
 			let mut weight = Weight::zero();
@@ -648,6 +653,58 @@ pub mod pallet {
 				),
 				Error::<T>::InvalidProof
 			);
+
+			Ok(())
+		}
+	}
+	#[cfg(any(feature = "try-runtime", test))]
+	impl<T: Config> Pallet<T> {
+		/// Ensure the correctness of the state of this pallet.
+		///
+		/// This should be valid before or after each state transition of this pallet.
+		pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::try_state_stored_blocks_have_chunks()?;
+			Self::try_state_block_chunks_are_cumulative()?;
+
+			Ok(())
+		}
+
+		/// # Invariants
+		///
+		/// * A block is recorded in `Transactions` only if it stored at least one chunk.
+		///   `on_finalize` leans on this to treat a block with no entry as one that held no data
+		///   and so needs no storage proof; an entry without chunks would have it demand a proof
+		///   that cannot be produced.
+		fn try_state_stored_blocks_have_chunks() -> Result<(), sp_runtime::TryRuntimeError> {
+			for (_, transactions) in Transactions::<T>::iter() {
+				frame_support::ensure!(
+					TransactionInfo::total_chunks(&transactions) != 0,
+					"a block recorded in `Transactions` must hold at least one chunk"
+				);
+			}
+
+			Ok(())
+		}
+
+		/// # Invariants
+		///
+		/// * `block_chunks` is the running total of the chunks stored in the block, and is binary
+		///   searched to map a chunk index back to the transaction that holds it. Every entry must
+		///   therefore carry the sum of `num_chunks` over itself and all transactions before it,
+		///   which also makes the sequence strictly increasing as no blob may be empty.
+		fn try_state_block_chunks_are_cumulative() -> Result<(), sp_runtime::TryRuntimeError> {
+			for (_, transactions) in Transactions::<T>::iter() {
+				let mut total: ChunkIndex = 0;
+
+				for transaction in transactions.iter() {
+					total = total.saturating_add(num_chunks(transaction.size));
+
+					frame_support::ensure!(
+						transaction.block_chunks == total,
+						"`block_chunks` must be the running total of the chunks in the block"
+					);
+				}
+			}
 
 			Ok(())
 		}

--- a/substrate/frame/transaction-storage/src/mock.rs
+++ b/substrate/frame/transaction-storage/src/mock.rs
@@ -78,6 +78,13 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	t.into()
 }
 
+pub fn build_and_execute(test: impl FnOnce()) {
+	new_test_ext().execute_with(|| {
+		test();
+		TransactionStorage::do_try_state().expect("All invariants must hold after a test");
+	});
+}
+
 pub fn run_to_block(n: u64, f: impl Fn() -> Option<TransactionStorageProof> + 'static) {
 	System::run_to_block_with::<AllPalletsWithSystem>(
 		n,

--- a/substrate/frame/transaction-storage/src/tests.rs
+++ b/substrate/frame/transaction-storage/src/tests.rs
@@ -28,7 +28,7 @@ const MAX_DATA_SIZE: u32 = DEFAULT_MAX_TRANSACTION_SIZE;
 
 #[test]
 fn discards_data() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		run_to_block(1, || None);
 		let caller = 1;
 		assert_ok!(TransactionStorage::<Test>::store(
@@ -60,7 +60,7 @@ fn discards_data() {
 
 #[test]
 fn burns_fee() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		run_to_block(1, || None);
 		let caller = 1;
 		assert_noop!(
@@ -80,7 +80,7 @@ fn burns_fee() {
 
 #[test]
 fn checks_proof() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		run_to_block(1, || None);
 		let caller = 1;
 		assert_ok!(TransactionStorage::<Test>::store(
@@ -115,7 +115,7 @@ fn checks_proof() {
 
 #[test]
 fn verify_chunk_proof_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// Prepare a bunch of transactions with variable chunk sizes.
 		let transactions = vec![
 			vec![0u8; CHUNK_SIZE - 1],
@@ -171,7 +171,7 @@ fn verify_chunk_proof_works() {
 
 #[test]
 fn renews_data() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		run_to_block(1, || None);
 		let caller = 1;
 		assert_noop!(


### PR DESCRIPTION
This PR introduces try state hook into the Transaction Storage Pallet. It also defines the invariants that holds for the pallet.

Part of: https://github.com/paritytech/polkadot-sdk/issues/239