### PR TITLE
fix(sc-service): reject chain_id path traversal in config_dir

### DIFF
--- a/prdoc/pr_13115.prdoc
+++ b/prdoc/pr_13115.prdoc
@@ -1,0 +1,15 @@
+title: 'fix(sc-service): reject chain_id path traversal in config_dir'
+doc:
+- audience: Node Operator
+  description: |-
+    Reject `chain_id` values that contain path separators or relative path components
+    when resolving `BasePath::config_dir`, preventing node data from being written
+    outside `base_path/chains/`. Invalid chain IDs now trigger a panic instead of
+    silently redirecting the database path.
+- audience: Node Dev
+  description: |-
+    Adds `is_chain_id_path_safe` to validate that a chain ID is a single path segment.
+    `BasePath::config_dir` asserts this invariant before joining paths.
+crates:
+- name: sc-service
+  bump: patch

--- a/substrate/client/service/src/config.rs
+++ b/substrate/client/service/src/config.rs
@@ -43,7 +43,7 @@ use std::{
 	io, iter,
 	net::SocketAddr,
 	num::NonZeroU32,
-	path::{Path, PathBuf},
+	path::{Component, Path, PathBuf},
 };
 use tempfile::TempDir;
 
@@ -298,7 +298,60 @@ impl BasePath {
 	///
 	/// The path looks like `$base_path/chains/$chain_id`
 	pub fn config_dir(&self, chain_id: &str) -> PathBuf {
+		assert!(
+			is_chain_id_path_safe(chain_id),
+			"chain_id must be a single valid path segment, but {:?} was provided",
+			chain_id,
+		);
 		self.path().join("chains").join(chain_id)
+	}
+}
+
+/// Returns `true` if `chain_id` may safely be used as a single directory name under `chains/`.
+///
+/// Path separators and relative path components (such as `..`) are rejected to prevent placing
+/// node data outside of the configured base path.
+pub fn is_chain_id_path_safe(chain_id: &str) -> bool {
+	let mut components = Path::new(chain_id).components();
+	matches!((components.next(), components.next()), (Some(Component::Normal(_)), None))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn chain_id_path_safety() {
+		for valid in ["polkadot", "dev", "rococo-local", "westend", "chain_v2"] {
+			assert!(is_chain_id_path_safe(valid));
+		}
+
+		for invalid in [
+			"",
+			".",
+			"..",
+			"foo/bar",
+			"foo\\bar",
+			"../../../../tmp/foo",
+			"/absolute",
+		] {
+			assert!(!is_chain_id_path_safe(invalid));
+		}
+	}
+
+	#[test]
+	fn config_dir_rejects_path_traversal() {
+		let base = BasePath::new(std::env::temp_dir().join("substrate-config-dir-test"));
+		let result = std::panic::catch_unwind(|| base.config_dir("../../../../tmp/foo"));
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn config_dir_stays_under_base_path() {
+		let base_dir = std::env::temp_dir().join("substrate-config-dir-test-valid");
+		let base = BasePath::new(&base_dir);
+		let config_dir = base.config_dir("polkadot");
+		assert!(config_dir.starts_with(base_dir.join("chains")));
 	}
 }
 


### PR DESCRIPTION
# Description

Reject `chain_id` values that contain path separators or relative path components when resolving `BasePath::config_dir`, preventing node data from being written outside `base_path/chains/`.

Fixes #5570

## Integration

No downstream integration changes are required for valid chain IDs. Custom chain specs whose `id()` contains `/`, `\`, `.`, `..`, or other multi-segment paths will now panic in `BasePath::config_dir` instead of redirecting the database path outside the configured base directory.

## Review Notes

- Adds `is_chain_id_path_safe` and asserts in `config_dir` before joining paths.
- Unit tests cover valid chain IDs, traversal attempts, and the config-dir guard.

## Test plan

- [x] `rustc` standalone check for `is_chain_id_path_safe` logic
- [ ] `cargo test -p sc-service chain_id_path --lib` (CI)
