### PR TITLE
fix(elections-phragmen): correct runners-up try_state invariant

### DIFF
--- a/prdoc/pr_13116.prdoc
+++ b/prdoc/pr_13116.prdoc
@@ -2,10 +2,8 @@ title: 'fix(elections-phragmen): correct runners-up try_state invariant'
 doc:
 - audience: Runtime Dev
   description: |-
-    Fix `try_state_runners_up` to stop requiring approval-stake ordering. Runners-up
-    are stored in phragmen merit order (worst to best), matching election output and
-    `remove_member` replacement order. The check now documents this invariant and
-    performs no assertion; positive stakes remain validated elsewhere.
+    Remove the incorrect approval-stake ordering check because `RunnersUp` storage
+    follows election/Phragmen merit order rather than approval-stake ordering.
 crates:
 - name: pallet-elections-phragmen
   bump: patch

--- a/prdoc/pr_13116.prdoc
+++ b/prdoc/pr_13116.prdoc
@@ -4,8 +4,8 @@ doc:
   description: |-
     Fix `try_state_runners_up` to stop requiring approval-stake ordering. Runners-up
     are stored in phragmen merit order (worst to best), matching election output and
-    `remove_member` replacement order. The check now only enforces the
-    `DesiredRunnersUp` length bound; positive stakes remain validated elsewhere.
+    `remove_member` replacement order. The check now documents this invariant and
+    performs no assertion; positive stakes remain validated elsewhere.
 crates:
 - name: pallet-elections-phragmen
   bump: patch

--- a/prdoc/pr_13116.prdoc
+++ b/prdoc/pr_13116.prdoc
@@ -1,0 +1,11 @@
+title: 'fix(elections-phragmen): correct runners-up try_state invariant'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Fix `try_state_runners_up` to stop requiring approval-stake ordering. Runners-up
+    are stored in phragmen merit order (worst to best), matching election output and
+    `remove_member` replacement order. The check now only enforces the
+    `DesiredRunnersUp` length bound; positive stakes remain validated elsewhere.
+crates:
+- name: pallet-elections-phragmen
+  bump: patch

--- a/substrate/frame/elections-phragmen/src/lib.rs
+++ b/substrate/frame/elections-phragmen/src/lib.rs
@@ -1225,18 +1225,16 @@ impl<T: Config> Pallet<T> {
 	}
 
 	// [`RunnersUp`] state checks. Invariants:
-	//  - Elements are sorted based on weight (worst to best).
+	//  - Length does not exceed [`Config::DesiredRunnersUp`].
+	//  - Elements are stored in phragmen merit order (worst to best), as produced by the election.
+	//    They are not sorted by approval stake.
 	fn try_state_runners_up() -> Result<(), TryRuntimeError> {
-		let mut sorted = RunnersUp::<T>::get();
-		// worst stake first
-		sorted.sort_by(|a, b| a.stake.cmp(&b.stake));
-
-		if RunnersUp::<T>::get() == sorted {
-			Ok(())
-		} else {
-			Err("try_state checks: Runners Up must always be sorted by stake (worst to best)"
-				.into())
+		let runners_up = RunnersUp::<T>::get();
+		if runners_up.len() > T::DesiredRunnersUp::get() as usize {
+			return Err("try_state checks: Runners Up length exceeds DesiredRunnersUp".into())
 		}
+
+		Ok(())
 	}
 
 	// [`Candidates`] state checks. Invariants:
@@ -2745,6 +2743,38 @@ mod tests {
 			assert_eq!(members_and_stake(), vec![(4, 45), (5, 35)]);
 			// merit: low -> high.
 			assert_eq!(runners_up_and_stake(), vec![(3, 15), (2, 25)]);
+
+			assert_ok!(Elections::do_try_state());
+		});
+	}
+
+	#[test]
+	fn try_state_runners_up_does_not_require_stake_order() {
+		ExtBuilder::default().desired_runners_up(2).build_and_execute(|| {
+			RunnersUp::<Test>::put(vec![
+				SeatHolder { who: 2, stake: 25, deposit: 5 },
+				SeatHolder { who: 3, stake: 15, deposit: 5 },
+			]);
+
+			let mut stake_sorted = RunnersUp::<Test>::get();
+			stake_sorted.sort_by_key(|r| r.stake);
+			assert_ne!(RunnersUp::<Test>::get(), stake_sorted);
+
+			assert_ok!(Elections::do_try_state());
+		});
+	}
+
+	#[test]
+	fn try_state_runners_up_rejects_excess_runners() {
+		ExtBuilder::default().desired_runners_up(1).build_and_execute(|| {
+			RunnersUp::<Test>::put(vec![
+				SeatHolder { who: 2, stake: 20, deposit: 5 },
+				SeatHolder { who: 3, stake: 15, deposit: 5 },
+			]);
+
+			assert!(Elections::do_try_state().is_err());
+
+			RunnersUp::<Test>::kill();
 		});
 	}
 

--- a/substrate/frame/elections-phragmen/src/lib.rs
+++ b/substrate/frame/elections-phragmen/src/lib.rs
@@ -1204,7 +1204,6 @@ impl<T: Config> ContainsLengthBound for Pallet<T> {
 impl<T: Config> Pallet<T> {
 	fn do_try_state() -> Result<(), TryRuntimeError> {
 		Self::try_state_members()?;
-		Self::try_state_runners_up()?;
 		Self::try_state_candidates()?;
 		Self::try_state_candidates_runners_up_disjoint()?;
 		Self::try_state_members_disjoint()?;
@@ -1222,15 +1221,6 @@ impl<T: Config> Pallet<T> {
 		} else {
 			Err("try_state checks: Members must be always sorted by account ID".into())
 		}
-	}
-
-	// [`RunnersUp`] state checks. Invariants:
-	//  - Elements are stored in phragmen merit order (worst to best), as produced by the election.
-	//    They are not sorted by approval stake.
-	fn try_state_runners_up() -> Result<(), TryRuntimeError> {
-		// Merit order is not a cheap storage-only invariant; the pallet does not store phragmen
-		// desirability scores, so there is nothing to assert without re-running the election.
-		Ok(())
 	}
 
 	// [`Candidates`] state checks. Invariants:
@@ -2744,29 +2734,38 @@ mod tests {
 
 	#[test]
 	fn runners_up_merit_order_differs_from_stake_order() {
-		ExtBuilder::default().desired_runners_up(2).build_and_execute(|| {
-			assert_ok!(submit_candidacy(RuntimeOrigin::signed(6)));
-			assert_ok!(submit_candidacy(RuntimeOrigin::signed(5)));
-			assert_ok!(submit_candidacy(RuntimeOrigin::signed(4)));
-			assert_ok!(submit_candidacy(RuntimeOrigin::signed(3)));
+		ExtBuilder::default()
+			.balance_factor(20)
+			.desired_members(1)
+			.desired_runners_up(3)
+			.build_and_execute(|| {
+				assert_ok!(submit_candidacy(RuntimeOrigin::signed(3)));
+				assert_ok!(submit_candidacy(RuntimeOrigin::signed(4)));
+				assert_ok!(submit_candidacy(RuntimeOrigin::signed(5)));
+				assert_ok!(submit_candidacy(RuntimeOrigin::signed(6)));
 
-			assert_ok!(vote(RuntimeOrigin::signed(2), vec![3], 10));
-			assert_ok!(vote(RuntimeOrigin::signed(3), vec![3], 10));
-			assert_ok!(vote(RuntimeOrigin::signed(4), vec![4], 10));
-			assert_ok!(vote(RuntimeOrigin::signed(5), vec![5, 6], 15));
+				assert_ok!(vote(RuntimeOrigin::signed(1), vec![3, 5], 100));
+				assert_ok!(vote(RuntimeOrigin::signed(2), vec![4, 6], 55));
 
-			System::set_block_number(5);
-			Elections::on_initialize(System::block_number());
+				System::set_block_number(5);
+				Elections::on_initialize(System::block_number());
 
-			let runners_up = runners_up_and_stake();
-			assert_eq!(runners_up.len(), 2);
-			// Phragmen merit order (worst to best) is [6, 4], not stake order [4, 6].
-			assert_eq!(runners_up[0].0, 6);
-			assert_eq!(runners_up[1].0, 4);
-			assert!(runners_up[0].1 < runners_up[1].1);
+				// Phragmen elects in merit order 3, 4, 5, 6: 3 becomes the sole member and the
+				// runners-up are stored worst-to-best merit as [6, 5, 4]. Voter 1's stake is
+				// split between 3 and 5 and voter 2's between 4 and 6, so 5 (elected in a later
+				// round than 4) ends up with more backing stake. The stored order therefore
+				// violates the removed approval-stake ascending invariant (#6815).
+				let runners_up = runners_up_and_stake();
+				assert_eq!(runners_up.iter().map(|r| r.0).collect::<Vec<_>>(), vec![6, 5, 4]);
+				assert!(runners_up[1].1 > runners_up[2].1);
 
-			assert_ok!(Elections::do_try_state());
-		});
+				let stored = RunnersUp::<Test>::get();
+				let mut stake_sorted = stored.clone();
+				stake_sorted.sort_by_key(|runner| runner.stake);
+				assert_ne!(stored, stake_sorted);
+
+				assert_ok!(Elections::do_try_state());
+			});
 	}
 
 	#[test]

--- a/substrate/frame/elections-phragmen/src/lib.rs
+++ b/substrate/frame/elections-phragmen/src/lib.rs
@@ -1225,15 +1225,11 @@ impl<T: Config> Pallet<T> {
 	}
 
 	// [`RunnersUp`] state checks. Invariants:
-	//  - Length does not exceed [`Config::DesiredRunnersUp`].
 	//  - Elements are stored in phragmen merit order (worst to best), as produced by the election.
 	//    They are not sorted by approval stake.
 	fn try_state_runners_up() -> Result<(), TryRuntimeError> {
-		let runners_up = RunnersUp::<T>::get();
-		if runners_up.len() > T::DesiredRunnersUp::get() as usize {
-			return Err("try_state checks: Runners Up length exceeds DesiredRunnersUp".into())
-		}
-
+		// Merit order is not a cheap storage-only invariant; the pallet does not store phragmen
+		// desirability scores, so there is nothing to assert without re-running the election.
 		Ok(())
 	}
 
@@ -2743,38 +2739,33 @@ mod tests {
 			assert_eq!(members_and_stake(), vec![(4, 45), (5, 35)]);
 			// merit: low -> high.
 			assert_eq!(runners_up_and_stake(), vec![(3, 15), (2, 25)]);
-
-			assert_ok!(Elections::do_try_state());
 		});
 	}
 
 	#[test]
-	fn try_state_runners_up_does_not_require_stake_order() {
+	fn runners_up_merit_order_differs_from_stake_order() {
 		ExtBuilder::default().desired_runners_up(2).build_and_execute(|| {
-			RunnersUp::<Test>::put(vec![
-				SeatHolder { who: 2, stake: 25, deposit: 5 },
-				SeatHolder { who: 3, stake: 15, deposit: 5 },
-			]);
+			assert_ok!(submit_candidacy(RuntimeOrigin::signed(6)));
+			assert_ok!(submit_candidacy(RuntimeOrigin::signed(5)));
+			assert_ok!(submit_candidacy(RuntimeOrigin::signed(4)));
+			assert_ok!(submit_candidacy(RuntimeOrigin::signed(3)));
 
-			let mut stake_sorted = RunnersUp::<Test>::get();
-			stake_sorted.sort_by_key(|r| r.stake);
-			assert_ne!(RunnersUp::<Test>::get(), stake_sorted);
+			assert_ok!(vote(RuntimeOrigin::signed(2), vec![3], 10));
+			assert_ok!(vote(RuntimeOrigin::signed(3), vec![3], 10));
+			assert_ok!(vote(RuntimeOrigin::signed(4), vec![4], 10));
+			assert_ok!(vote(RuntimeOrigin::signed(5), vec![5, 6], 15));
+
+			System::set_block_number(5);
+			Elections::on_initialize(System::block_number());
+
+			let runners_up = runners_up_and_stake();
+			assert_eq!(runners_up.len(), 2);
+			// Phragmen merit order (worst to best) is [6, 4], not stake order [4, 6].
+			assert_eq!(runners_up[0].0, 6);
+			assert_eq!(runners_up[1].0, 4);
+			assert!(runners_up[0].1 < runners_up[1].1);
 
 			assert_ok!(Elections::do_try_state());
-		});
-	}
-
-	#[test]
-	fn try_state_runners_up_rejects_excess_runners() {
-		ExtBuilder::default().desired_runners_up(1).build_and_execute(|| {
-			RunnersUp::<Test>::put(vec![
-				SeatHolder { who: 2, stake: 20, deposit: 5 },
-				SeatHolder { who: 3, stake: 15, deposit: 5 },
-			]);
-
-			assert!(Elections::do_try_state().is_err());
-
-			RunnersUp::<Test>::kill();
 		});
 	}
 


### PR DESCRIPTION
# Description

Remove the incorrect runners-up approval-stake ordering check from `pallet-elections-phragmen` try-state validation. Runners-up are stored in phragmen merit order (worst to best), matching election output and `remove_member` replacement via `pop()`; approval-stake order is not a storage invariant.

Fixes #6815

## Integration

No downstream integration changes are required. Runtimes that previously failed try-state checks due to the wrong runners-up ordering assertion will now pass.

## Review Notes

- Removes `try_state_runners_up` and its call in `do_try_state`: the old ascending approval-stake assertion was invalid, and no cheap storage-only invariant remains (phragmen desirability scores are not stored).
- Runners-up are stored in election merit order (worst to best), which legitimately diverges from approval-stake order.
- The regression test `runners_up_merit_order_differs_from_stake_order` runs a real election where a runner-up elected in a later round ends up with more backing stake than one elected earlier, so the stored order violates the old ascending-stake assumption. Verified to fail with the old check restored (`Runners Up must always be sorted by stake (worst to best)`) and to pass with this change.

## Test plan

- [x] `cargo test -p pallet-elections-phragmen`
- [x] `cargo fmt --all -- --check`
