### PR TITLE
Remove coretime assignments chunking

### DIFF
--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/coretime.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/coretime.rs
@@ -175,42 +175,30 @@ impl CoretimeInterface for CoretimeAllocator {
 		// Add 5% to each component and round to 2 significant figures.
 		let call_weight = Weight::from_parts(980_000_000, 3800);
 
-		// A maximum of 28 assignments fit in one message, so we split the assignments and send as
-		// multiple messages. This will get reassembled into a full list of assignments on the
-		// relay chain side.
+		let assign_core_call =
+			RelayRuntimePallets::Coretime(AssignCore(core, begin, assignment, end_hint));
 
-		for chunk in assignment.chunks(28) {
-			let partial_assignment = chunk.to_vec();
+		let message = Xcm(vec![
+			Instruction::UnpaidExecution {
+				weight_limit: WeightLimit::Unlimited,
+				check_origin: None,
+			},
+			Instruction::Transact {
+				origin_kind: OriginKind::Native,
+				call: assign_core_call.encode().into(),
+				fallback_max_weight: Some(call_weight),
+			},
+		]);
 
-			let assign_core_call = RelayRuntimePallets::Coretime(AssignCore(
-				core,
-				begin,
-				partial_assignment,
-				end_hint,
-			));
-
-			let message = Xcm(vec![
-				Instruction::UnpaidExecution {
-					weight_limit: WeightLimit::Unlimited,
-					check_origin: None,
-				},
-				Instruction::Transact {
-					origin_kind: OriginKind::Native,
-					call: assign_core_call.encode().into(),
-					fallback_max_weight: Some(call_weight),
-				},
-			]);
-
-			match PolkadotXcm::send_xcm(Here, Location::parent(), message) {
-				Ok(_) => tracing::debug!(
-					target: "runtime::coretime",
-					"Core assignment sent successfully."
-				),
-				Err(e) => tracing::error!(
-					target: "runtime::coretime", error=?e,
-					"Core assignment failed to send"
-				),
-			}
+		match PolkadotXcm::send_xcm(Here, Location::parent(), message) {
+			Ok(_) => tracing::debug!(
+				target: "runtime::coretime",
+				"Core assignment sent successfully."
+			),
+			Err(e) => tracing::error!(
+				target: "runtime::coretime", error=?e,
+				"Core assignment failed to send"
+			),
 		}
 	}
 }

--- a/prdoc/pr_13121.prdoc
+++ b/prdoc/pr_13121.prdoc
@@ -7,8 +7,9 @@ doc:
   - audience: Runtime Dev
     description: |-
       Removes the chunking mechanism in the way coretime assignments are being reported
-	  to the Relay Chain, reducing the number of XCM messages that will be sent when
-	  there are more than 28 assignments.
+      to the Relay Chain, reducing the number of XCM messages that will be sent when
+      there are more than 28 assignments.
+
 crates:
   - name: coretime-westend-runtime
     bump: patch

--- a/prdoc/pr_13121.prdoc
+++ b/prdoc/pr_13121.prdoc
@@ -1,0 +1,14 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: 'Westend Coretime: remove chunking of the assignments vector'
+
+doc:
+  - audience: Runtime Dev
+    description: |-
+      Removes the chunking mechanism in the way coretime assignments are being reported
+	  to the Relay Chain, reducing the number of XCM messages that will be sent when
+	  there are more than 28 assignments.
+crates:
+  - name: coretime-westend-runtime
+    bump: patch


### PR DESCRIPTION
The limit of 28 assignments per message to Relay Chain seems to be an artifact of very low message size limits in XCM emulator tests - it used to be 256 bytes, while Westend, Kusama and Polkadot runtimes have a limit of 50 KiB. The limit has been raised in the emulator to 1 MiB in #10313, which means there is now no place in the system which would make 28-assignments chunks necessary. Because of that, this PR proposes to remove the chunking logic from the Westend runtime entirely, and an analogous PR to polkadot-fellows/runtimes may also be desirable.
