### PR TITLE
Update ci-unified image to `bullseye-1.93.0-2026-01-27-v202609081126`

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,2 +1,2 @@
-IMAGE="docker.io/paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202605151311"
+IMAGE="docker.io/paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202609081126"
 RESOLC_VERSION="1.0.0"

--- a/.github/workflows/check-runtime-compatibility.yml
+++ b/.github/workflows/check-runtime-compatibility.yml
@@ -97,12 +97,12 @@ jobs:
           fi
           exit $EXIT_CODE
 
-      - name: Stop all workflows if failed
-        if: ${{ failure() && (steps.build-runtime.conclusion == 'failure' || steps.check-compatibility.conclusion == 'failure') }}
-        uses: ./.github/actions/workflow-stopper
-        with:
-          app-id: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_ID }}
-          app-key: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_KEY }}
+      #- name: Stop all workflows if failed
+      #  if: ${{ failure() && (steps.build-runtime.conclusion == 'failure' || steps.check-compatibility.conclusion == 'failure') }}
+      #  uses: ./.github/actions/workflow-stopper
+      #  with:
+      #    app-id: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_ID }}
+      #    app-key: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_KEY }}
 
   # name of this job must be unique across all workflows
   # otherwise GitHub will mark all these jobs as required


### PR DESCRIPTION
New bullseye ci-unified with temporary workaround for the expired `bullseye-security`

cc https://github.com/paritytech/devops/issues/5593