### PR TITLE
WIP: resolve header hash by number without `chain_getBlockHash`

### DIFF
--- a/bridges/relays/client-substrate/src/client/caching.rs
+++ b/bridges/relays/client-substrate/src/client/caching.rs
@@ -48,6 +48,10 @@ use tokio::{
 /// `quick_cache::unsync::Cache` wrapped in async-aware synchronization primitives.
 type SyncCache<K, V> = Arc<RwLock<Cache<K, V>>>;
 
+/// Guard against hanging in `CachingClient::header_hash_by_number_walking_back`, not a tuning
+/// knob - a walk this long is already unusable.
+const MAX_HEADER_HASH_BY_NUMBER_WALK_BACK: u32 = 8192;
+
 /// Client implementation that is caching (whenever possible) results of its backend
 /// method calls. Apart from caching call results, it also supports some (at the
 /// moment: justifications) subscription sharing, meaning that the single server
@@ -69,6 +73,7 @@ struct ClientData<C: Chain> {
 	// but it uses synchronization primitives that are not aware of async execution. They
 	// can block the executor threads and cause deadlocks => let's use primitives from
 	// `async_std` crate around `quick_cache::unsync::Cache`
+	// only finalized headers may be cached here: a best header can be reorged away
 	header_hash_by_number_cache: SyncCache<BlockNumberOf<C>, HashOf<C>>,
 	header_by_hash_cache: SyncCache<HashOf<C>, HeaderOf<C>>,
 	block_by_hash_cache: SyncCache<HashOf<C>, SignedBlockOf<C>>,
@@ -85,11 +90,15 @@ impl<C: Chain, B: Client<C>> CachingClient<C, B> {
 		let best_header = Arc::new(RwLock::new(None));
 		let best_finalized_header = Arc::new(RwLock::new(None));
 		let header_by_hash_cache = Arc::new(RwLock::new(Cache::new(chain_state_capacity)));
+		// a whole walk of `header_hash_by_number_walking_back` must fit here to be of any use
+		let header_hash_by_number_cache =
+			Arc::new(RwLock::new(Cache::new(MAX_HEADER_HASH_BY_NUMBER_WALK_BACK as usize)));
 		let background_task_handle = Self::start_background_task(
 			backend.clone(),
 			best_header.clone(),
 			best_finalized_header.clone(),
 			header_by_hash_cache.clone(),
+			header_hash_by_number_cache.clone(),
 		)
 		.await;
 		CachingClient {
@@ -100,9 +109,7 @@ impl<C: Chain, B: Client<C>> CachingClient<C, B> {
 				background_task_handle: Arc::new(Mutex::new(background_task_handle)),
 				best_header,
 				best_finalized_header,
-				header_hash_by_number_cache: Arc::new(RwLock::new(Cache::new(
-					chain_state_capacity,
-				))),
+				header_hash_by_number_cache,
 				header_by_hash_cache,
 				block_by_hash_cache: Arc::new(RwLock::new(Cache::new(chain_state_capacity))),
 				raw_storage_value_cache: Arc::new(RwLock::new(Cache::new(1_024))),
@@ -135,6 +142,66 @@ impl<C: Chain, B: Client<C>> CachingClient<C, B> {
 		Ok(value)
 	}
 
+	async fn header_hash_by_number_uncached(&self, number: BlockNumberOf<C>) -> Result<HashOf<C>> {
+		match self.backend.header_hash_by_number(number).await {
+			Err(Error::UnknownHeaderHashByNumber { .. }) => {
+				self.header_hash_by_number_walking_back(number).await
+			},
+			result => result,
+		}
+	}
+
+	/// Fallback for nodes that do not answer `chain_getBlockHash` - light clients in particular,
+	/// which cannot verify a number-to-hash mapping served by a peer. Walking back is verifiable
+	/// instead: every header read is checked against the hash we asked for. Mappings are cached
+	/// along the way, so that reading a range of numbers does not restart the walk each time.
+	async fn header_hash_by_number_walking_back(
+		&self,
+		number: BlockNumberOf<C>,
+	) -> Result<HashOf<C>> {
+		let mut header = self
+			.read_header_from_background(
+				&self.data.best_finalized_header,
+				self.backend.best_finalized_header(),
+			)
+			.await?;
+		if number > *header.number() {
+			return Err(Error::unknown_header_hash_by_number::<C>(number));
+		}
+
+		let mut steps = 0;
+		loop {
+			let hash = header.hash();
+			self.data
+				.header_hash_by_number_cache
+				.write()
+				.await
+				.insert(*header.number(), hash);
+			if *header.number() == number {
+				if steps > ANCIENT_BLOCK_THRESHOLD {
+					tracing::warn!(
+						target: "bridge",
+						node=%C::NAME,
+						%number,
+						steps,
+						"Node has no `chain_getBlockHash` support - had to read many headers to \
+						resolve header hash by number"
+					);
+				}
+
+				return Ok(hash);
+			}
+
+			if steps >= MAX_HEADER_HASH_BY_NUMBER_WALK_BACK {
+				return Err(Error::unknown_header_hash_by_number::<C>(number));
+			}
+
+			// through the backend: stepping stones must not evict the header-by-hash cache
+			header = self.backend.header_by_hash(*header.parent_hash()).await?;
+			steps += 1;
+		}
+	}
+
 	/// Subscribe to finality justifications, trying to reuse existing subscription.
 	async fn subscribe_finality_justifications<'a>(
 		&'a self,
@@ -162,12 +229,17 @@ impl<C: Chain, B: Client<C>> CachingClient<C, B> {
 		best_header: Arc<RwLock<Option<HeaderOf<C>>>>,
 		best_finalized_header: Arc<RwLock<Option<HeaderOf<C>>>>,
 		header_by_hash_cache: SyncCache<HashOf<C>, HeaderOf<C>>,
+		header_hash_by_number_cache: SyncCache<BlockNumberOf<C>, HashOf<C>>,
 	) -> JoinHandle<Result<()>> {
 		tokio::spawn(async move {
 			// initialize by reading headers directly from backend to avoid doing that in the
 			// high-level code
 			let mut last_finalized_header =
 				backend.header_by_hash(backend.best_finalized_header_hash().await?).await?;
+			header_hash_by_number_cache
+				.write()
+				.await
+				.insert(*last_finalized_header.number(), last_finalized_header.hash());
 			*best_header.write().await = Some(backend.best_header().await?);
 			*best_finalized_header.write().await = Some(last_finalized_header.clone());
 
@@ -196,6 +268,7 @@ impl<C: Chain, B: Client<C>> CachingClient<C, B> {
 							Ordering::Greater => {
 								let new_finalized_header_hash = new_finalized_header.hash();
 								header_by_hash_cache.write().await.insert(new_finalized_header_hash, new_finalized_header.clone());
+								header_hash_by_number_cache.write().await.insert(new_finalized_header_number, new_finalized_header_hash);
 								*best_finalized_header.write().await = Some(new_finalized_header.clone());
 								last_finalized_header = new_finalized_header;
 							},
@@ -274,6 +347,7 @@ impl<C: Chain, B: Client<C>> Client<C> for CachingClient<C, B> {
 			self.data.best_header.clone(),
 			self.data.best_finalized_header.clone(),
 			self.data.header_by_hash_cache.clone(),
+			self.data.header_hash_by_number_cache.clone(),
 		)
 		.await;
 		Ok(())
@@ -287,7 +361,7 @@ impl<C: Chain, B: Client<C>> Client<C> for CachingClient<C, B> {
 		self.get_or_insert_async(
 			&self.data.header_hash_by_number_cache,
 			&number,
-			self.backend.header_hash_by_number(number),
+			self.header_hash_by_number_uncached(number),
 		)
 		.await
 	}

--- a/bridges/relays/client-substrate/src/client/rpc.rs
+++ b/bridges/relays/client-substrate/src/client/rpc.rs
@@ -142,7 +142,8 @@ impl<C: Chain> RpcClient<C> {
 				SubstrateChainClient::<C>::block_hash(&*genesis_hash_client, Some(Zero::zero()))
 					.await
 			})
-			.await??;
+			.await??
+			.ok_or_else(|| Error::unknown_header_hash_by_number::<C>(Zero::zero()))?;
 
 		let chain_runtime_version = params.chain_runtime_version;
 		let mut client = Self {
@@ -332,11 +333,15 @@ impl<C: Chain> Client<C> for RpcClient<C> {
 	}
 
 	async fn header_hash_by_number(&self, number: BlockNumberOf<C>) -> Result<HashOf<C>> {
-		self.jsonrpsee_execute(move |client| async move {
-			Ok(SubstrateChainClient::<C>::block_hash(&*client, Some(number)).await?)
-		})
-		.await
-		.map_err(|e| Error::failed_to_read_header_hash_by_number::<C>(number, e))
+		let maybe_hash = self
+			.jsonrpsee_execute(move |client| async move {
+				Ok(SubstrateChainClient::<C>::block_hash(&*client, Some(number)).await?)
+			})
+			.await
+			.map_err(|e| Error::failed_to_read_header_hash_by_number::<C>(number, e))?;
+
+		// `CachingClient` resolves the number without this RPC when the node has no answer
+		maybe_hash.ok_or_else(|| Error::unknown_header_hash_by_number::<C>(number))
 	}
 
 	async fn header_by_hash(&self, hash: HashOf<C>) -> Result<HeaderOf<C>> {

--- a/bridges/relays/client-substrate/src/client/rpc_api.rs
+++ b/bridges/relays/client-substrate/src/client/rpc_api.rs
@@ -43,8 +43,11 @@ pub(crate) trait SubstrateSystem<C> {
 #[rpc(client, client_bounds(C: Chain), namespace = "chain")]
 pub(crate) trait SubstrateChain<C> {
 	/// Get block hash by its number.
+	///
+	/// `None` is a valid answer: a light client cannot verify a number-to-hash mapping served by
+	/// a peer, so it only answers for block zero.
 	#[method(name = "getBlockHash")]
-	async fn block_hash(&self, block_number: Option<C::BlockNumber>) -> RpcResult<C::Hash>;
+	async fn block_hash(&self, block_number: Option<C::BlockNumber>) -> RpcResult<Option<C::Hash>>;
 	/// Return block header by its hash.
 	#[method(name = "getHeader")]
 	async fn header(&self, block_hash: Option<C::Hash>) -> RpcResult<C::Header>;

--- a/bridges/relays/client-substrate/src/error.rs
+++ b/bridges/relays/client-substrate/src/error.rs
@@ -90,6 +90,14 @@ pub enum Error {
 		/// Underlying error.
 		error: Box<Error>,
 	},
+	/// The chain does not know which header hash corresponds to the given header number.
+	#[error("Cannot find header hash by number {number} of {chain}.")]
+	UnknownHeaderHashByNumber {
+		/// Name of the chain where the error has happened.
+		chain: String,
+		/// Number of the header we've tried to read.
+		number: String,
+	},
 	/// Failed to read header by hash from given chain.
 	#[error("Failed to read header {hash} of {chain}: {error:?}.")]
 	FailedToReadHeaderByHash {
@@ -294,6 +302,11 @@ impl Error {
 			number: format!("{number}"),
 			error: e.boxed(),
 		}
+	}
+
+	/// Constructs `UnknownHeaderHashByNumber` variant.
+	pub fn unknown_header_hash_by_number<C: Chain>(number: BlockNumberOf<C>) -> Self {
+		Error::UnknownHeaderHashByNumber { chain: C::NAME.into(), number: format!("{number}") }
 	}
 
 	/// Constructs `FailedToReadHeaderByHash` variant.

--- a/bridges/relays/finality/src/finality_loop.rs
+++ b/bridges/relays/finality/src/finality_loop.rs
@@ -88,6 +88,14 @@ pub trait SourceClient<P: FinalitySyncPipeline>: SourceClientBase<P> {
 		&self,
 		number: P::Number,
 	) -> Result<(P::Header, Option<P::FinalityProof>), Self::Error>;
+
+	/// Get canonical header by number.
+	///
+	/// Preferred over `header_and_finality_proof` when the proof is not needed: reading the proof
+	/// reads the whole block, which is expensive against a light client source.
+	async fn header(&self, number: P::Number) -> Result<P::Header, Self::Error> {
+		self.header_and_finality_proof(number).await.map(|(header, _)| header)
+	}
 }
 
 /// Target client used in finality synchronization loop.
@@ -136,7 +144,7 @@ impl<P: FinalitySyncPipeline> SyncInfo<P> {
 		source_client: &SC,
 		id_at_target: &HeaderId<P::Hash, P::Number>,
 	) -> Result<bool, SC::Error> {
-		let header_at_source = source_client.header_and_finality_proof(id_at_target.0).await?.0;
+		let header_at_source = source_client.header(id_at_target.0).await?;
 		let header_hash_at_source = header_at_source.hash();
 		Ok(if id_at_target.1 == header_hash_at_source {
 			true

--- a/bridges/relays/lib-substrate-relay/src/finality/source.rs
+++ b/bridges/relays/lib-substrate-relay/src/finality/source.rs
@@ -239,6 +239,13 @@ impl<P: SubstrateFinalitySyncPipeline, SourceClnt: Client<P::SourceChain>>
 	> {
 		header_and_finality_proof::<P>(&self.client, number).await
 	}
+
+	async fn header(
+		&self,
+		number: BlockNumberOf<P::SourceChain>,
+	) -> Result<relay_substrate_client::SyncHeader<HeaderOf<P::SourceChain>>, Error> {
+		Ok(self.client.header_by_number(number).await?.into())
+	}
 }
 
 async fn header_and_finality_proof<P: SubstrateFinalitySyncPipeline>(


### PR DESCRIPTION
# Description

This is part of paritytech/parity-bridges-common#3270 - running the bridge relayers against **light clients (smoldot) instead of operated RPC nodes**, so that a relayer needs no dedicated RPC infrastructure and joins the network through public p2p bootnodes only.


## Why this is needed

`relay-substrate-client` has exactly one way to turn a block number into a hash - `chain_getBlockHash` — and a light client cannot answer it. smoldot returns `null` for every number but zero, on purpose:

> While could ask a full node for the block with a specific number, there is absolutely
> no way to verify the answer of the full node.
>
> — `light-base/src/json_rpc_service/background.rs`, `chain_getBlockHash` arm

That refusal is correct. There is no proof that block *N* has hash *H*; establishing it means following the chain. A light client that answered would be trusting a peer.

The relayer, meanwhile, treated the RPC as infallible: `block_hash` was declared as
returning `C::Hash`, so `null` wasn't even a clean error — it was a deserialization
failure. And this is not a rare path:

| Call site | Frequency |
|---|---|
| `SyncInfo::is_on_same_fork` | every finality loop iteration |
| `select_header_to_submit` | once per block in the gap |
| `find_mandatory_header_in_range` | once per block in the scanned range |
| message / parachain / equivocation sources | per proof |

So before this PR the relayer could not complete a **single** finality loop iteration
against a light client.

## Why the fix belongs here and not in smoldot

The mapping is recoverable from data a light client *can* prove: walk `parent_hash` back
from the finalized head, fetching each header **by hash**. Every header is checked
against the hash it was requested by, so the chain of custody holds all the way down —
which is precisely what `chain_getBlockHash` cannot offer. No trust assumption is added,
and no smoldot change is required for this part.

The caching is load-bearing rather than an optimisation: the relay scans *ranges* of
numbers, so a per-lookup walk would restart from the head each time and make a range scan
quadratic in round-trips.

The `is_on_same_fork` change has the same shape. Reading a block and discarding
everything but its header is merely wasteful against a full node serving from local disk;
against a light client `chain_getBlock` pulls the block body from peers over the network,
once per loop iteration.

## Scope

This does not by itself make the light-client relayer work end to end. Still open upstream:
`chain_getBlock` serialises `justifications` inside `block` (unparseable by
`sp_runtime::SignedBlock`), and GRANDPA justification exposure is
[paritytech/smoldot#3288](https://github.com/paritytech/smoldot/issues/3288). This PR is
independently correct and independently reviewable regardless of how those land.