### PR TITLE
pallet-bounties, pallet-child-bounties: saturate award `unlock_at` instead of overflowing

### DIFF
--- a/substrate/frame/bounties/src/lib.rs
+++ b/substrate/frame/bounties/src/lib.rs
@@ -773,7 +773,8 @@ pub mod pallet {
 				bounty.status = BountyStatus::PendingPayout {
 					curator: signer,
 					beneficiary: beneficiary.clone(),
-					unlock_at: Self::treasury_block_number() + T::BountyDepositPayoutDelay::get(),
+					unlock_at: Self::treasury_block_number()
+						.saturating_add(T::BountyDepositPayoutDelay::get()),
 				};
 
 				Ok(())

--- a/substrate/frame/bounties/src/tests.rs
+++ b/substrate/frame/bounties/src/tests.rs
@@ -2296,3 +2296,31 @@ fn reclaim_bounty_funds_respects_native_locks() {
 		assert_eq!(res.unwrap().pays_fee, Pays::No);
 	});
 }
+
+#[test]
+fn award_bounty_saturates_unlock_at_at_block_limit() {
+	ExtBuilder::default().build_and_execute(|| {
+		Balances::make_free_balance_be(&Treasury::account_id(), 101);
+		Balances::make_free_balance_be(&4, 10);
+		assert_ok!(Bounties::propose_bounty(RuntimeOrigin::signed(0), 50, b"12345".to_vec()));
+		assert_ok!(Bounties::approve_bounty(RuntimeOrigin::root(), 0));
+
+		go_to_block(2);
+		assert_ok!(Bounties::propose_curator(RuntimeOrigin::root(), 0, 4, 4));
+		assert_ok!(Bounties::accept_curator(RuntimeOrigin::signed(4), 0));
+
+		// When treasury block is within BountyDepositPayoutDelay (3) of u64::MAX
+		go_to_block(u64::MAX - 2);
+
+		// Then: saturates to max instead of overflowing
+		assert_ok!(Bounties::award_bounty(RuntimeOrigin::signed(4), 0, 3));
+		assert_eq!(
+			pallet_bounties::Bounties::<Test>::get(0).unwrap().status,
+			BountyStatus::PendingPayout {
+				curator: 4,
+				beneficiary: 3,
+				unlock_at: BlockNumberFor::<Test>::max_value(),
+			}
+		);
+	});
+}

--- a/substrate/frame/child-bounties/src/lib.rs
+++ b/substrate/frame/child-bounties/src/lib.rs
@@ -645,8 +645,8 @@ pub mod pallet {
 						child_bounty.status = ChildBountyStatus::PendingPayout {
 							curator: signer,
 							beneficiary: beneficiary.clone(),
-							unlock_at: Self::treasury_block_number() +
-								T::BountyDepositPayoutDelay::get(),
+							unlock_at: Self::treasury_block_number()
+								.saturating_add(T::BountyDepositPayoutDelay::get()),
 						};
 						Ok(())
 					} else {

--- a/substrate/frame/child-bounties/src/tests.rs
+++ b/substrate/frame/child-bounties/src/tests.rs
@@ -1683,3 +1683,61 @@ fn max_active_child_bounty_count_is_strictly_enforced() {
 		assert_eq!(pallet_child_bounties::ParentChildBounties::<Test>::get(0), 2);
 	});
 }
+
+#[test]
+fn award_child_bounty_saturates_unlock_at_at_block_limit() {
+	new_test_ext().execute_with(|| {
+		// Make the parent bounty.
+		go_to_block(1);
+		Balances::make_free_balance_be(&Treasury::account_id(), 101);
+		Balances::make_free_balance_be(&account_id(4), 101);
+		Balances::make_free_balance_be(&account_id(8), 101);
+
+		assert_ok!(Bounties::propose_bounty(
+			RuntimeOrigin::signed(account_id(0)),
+			50,
+			b"12345".to_vec()
+		));
+		assert_ok!(Bounties::approve_bounty(RuntimeOrigin::root(), 0));
+
+		go_to_block(2);
+		assert_ok!(Bounties::propose_curator(RuntimeOrigin::root(), 0, account_id(4), 6));
+		assert_ok!(Bounties::accept_curator(RuntimeOrigin::signed(account_id(4)), 0));
+
+		assert_ok!(ChildBounties::add_child_bounty(
+			RuntimeOrigin::signed(account_id(4)),
+			0,
+			10,
+			b"12345-p1".to_vec()
+		));
+
+		assert_ok!(ChildBounties::propose_curator(
+			RuntimeOrigin::signed(account_id(4)),
+			0,
+			0,
+			account_id(8),
+			8
+		));
+		assert_ok!(ChildBounties::accept_curator(RuntimeOrigin::signed(account_id(8)), 0, 0));
+
+		// When the external block-number provider is within BountyDepositPayoutDelay (3)
+		// of the block-number type maximum:
+		go_to_block(u64::MAX - 2);
+
+		// Then: unlock_at saturates to max instead of overflowing.
+		assert_ok!(ChildBounties::award_child_bounty(
+			RuntimeOrigin::signed(account_id(8)),
+			0,
+			0,
+			account_id(7)
+		));
+		assert_eq!(
+			pallet_child_bounties::ChildBounties::<Test>::get(0, 0).unwrap().status,
+			ChildBountyStatus::PendingPayout {
+				curator: account_id(8),
+				beneficiary: account_id(7),
+				unlock_at: u64::MAX,
+			}
+		);
+	});
+}


### PR DESCRIPTION
Fixes #13148, fixes #13146.

## Summary
- `award_bounty` (substrate/frame/bounties/src/lib.rs:776) and `award_child_bounty` (substrate/frame/child-bounties/src/lib.rs:648) computed `unlock_at` with a plain `+`. When the treasury block number is within `BountyDepositPayoutDelay` of the block-number type maximum, this panics in overflow-checked builds and silently wraps in unchecked builds — a wrapped `unlock_at` passes the `Premature` gate immediately, defeating the payout delay.
- Both sites now use `saturating_add`, matching the pallet's own convention (`accept_curator`, `extend_bounty_expiry`, and the saturating counters in pallet-child-bounties).
- Regression tests added in both pallets: award at `u64::MAX - BountyDepositPayoutDelay + 1` now pins `unlock_at == BlockNumberFor::max_value()` instead of panicking.

## Testing
- `cargo test -p pallet-bounties --lib` — 58 passed, 0 failed (incl. new `award_bounty_saturates_unlock_at_at_block_limit`)
- `cargo test -p pallet-child-bounties --lib` — 20 passed, 0 failed (incl. new `award_child_bounty_saturates_unlock_at_at_block_limit`)