### PR TITLE
staking-async parachain and WAH genesis: fund DAP buffer as signed reward pot

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/genesis_config_presets.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/genesis_config_presets.rs
@@ -46,10 +46,11 @@ fn asset_hub_westend_genesis(
 	foreign_assets: Vec<(Location, AccountId, Balance)>,
 	foreign_assets_endowed_accounts: Vec<(Location, AccountId, Balance)>,
 ) -> serde_json::Value {
-	// Fund DAP buffer account with ED so it can receive slashes. Also fund the
-	// DAP staging account with ED so it can receive incoming funds.
+	// Fund DAP buffer account: it receives slashes and is the signed-phase reward pot. Also fund
+	// the DAP staging account with ED so it can receive incoming funds.
 	let mut balances: Vec<_> = endowed_accounts.iter().cloned().map(|k| (k, endowment)).collect();
-	balances.push((Dap::buffer_account(), ASSET_HUB_WESTEND_ED));
+	// Above ED, as the reward payout transfers with `Preservation::Preserve`.
+	balances.push((Dap::buffer_account(), endowment));
 	balances.push((Dap::staging_account(), ASSET_HUB_WESTEND_ED));
 
 	build_struct_json_patch!(RuntimeGenesisConfig {

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/genesis_config_presets.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/genesis_config_presets.rs
@@ -46,11 +46,13 @@ fn asset_hub_westend_genesis(
 	foreign_assets: Vec<(Location, AccountId, Balance)>,
 	foreign_assets_endowed_accounts: Vec<(Location, AccountId, Balance)>,
 ) -> serde_json::Value {
-	// Fund DAP buffer account: it receives slashes and is the signed-phase reward pot. Also fund
-	// the DAP staging account with ED so it can receive incoming funds.
 	let mut balances: Vec<_> = endowed_accounts.iter().cloned().map(|k| (k, endowment)).collect();
-	// Above ED, as the reward payout transfers with `Preservation::Preserve`.
-	balances.push((Dap::buffer_account(), endowment));
+	// The DAP buffer receives slashes and is the signed-phase reward pot. Payouts transfer with
+	// `Preservation::Preserve`, so it needs spendable balance above ED, sized in rounds of
+	// `RewardBase` rather than tracking whatever endowment a preset picked.
+	balances
+		.push((Dap::buffer_account(), ASSET_HUB_WESTEND_ED + staking::RewardBase::get() * 1_000));
+	// The staging account only receives, so ED is enough for it to exist.
 	balances.push((Dap::staging_account(), ASSET_HUB_WESTEND_ED));
 
 	build_struct_json_patch!(RuntimeGenesisConfig {

--- a/prdoc/pr_13166.prdoc
+++ b/prdoc/pr_13166.prdoc
@@ -1,0 +1,18 @@
+title: Fund the DAP buffer as the signed-phase reward pot in genesis presets
+doc:
+- audience: Runtime Dev
+  description: |-
+    The DAP buffer account is the `RewardSource` pot for the
+    `pallet-election-provider-multi-block` signed phase, but the Asset Hub Westend and
+    staking-async parachain genesis presets funded it with exactly the existential deposit. The
+    payout transfers with `Preservation::Preserve`, so the pot had no spendable balance and every
+    round-winner reward was deferred into `UnpaidRewards` instead of emitting `Rewarded`.
+
+    Both presets now fund the buffer with the standard endowment. This affects chains built fresh
+    from these runtimes, such as dev chains and integration tests. Running chains are unaffected,
+    as their buffer is funded and topped up by the DAP budget allocation.
+crates:
+- name: asset-hub-westend-runtime
+  bump: patch
+- name: pallet-staking-async-parachain-runtime
+  bump: patch

--- a/prdoc/pr_13166.prdoc
+++ b/prdoc/pr_13166.prdoc
@@ -8,9 +8,10 @@ doc:
     payout transfers with `Preservation::Preserve`, so the pot had no spendable balance and every
     round-winner reward was deferred into `UnpaidRewards` instead of emitting `Rewarded`.
 
-    Both presets now fund the buffer with the standard endowment. This affects chains built fresh
-    from these runtimes, such as dev chains and integration tests. Running chains are unaffected,
-    as their buffer is funded and topped up by the DAP budget allocation.
+    Both presets now size the buffer from `RewardBase`, so the pot holds enough for many rounds
+    whatever endowment a preset picked for its accounts. This affects chains built fresh from
+    these runtimes, such as dev chains and integration tests. Running chains are unaffected, as
+    their buffer is funded and topped up by the DAP budget allocation.
 crates:
 - name: asset-hub-westend-runtime
   bump: patch

--- a/substrate/frame/staking-async/runtimes/parachain/src/genesis_config_presets.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/genesis_config_presets.rs
@@ -59,10 +59,10 @@ fn staking_async_parachain_genesis(params: GenesisParams, preset: String) -> ser
 		root,
 		id,
 	} = params;
-	// Fund DAP buffer account with ED so it can receive slashes.
+	// Fund DAP buffer account: it receives slashes and is the signed-phase reward pot.
 	let dap_buffer: AccountId = DapPalletId::get().into_account_truncating();
 	let mut balances: Vec<_> = endowed_accounts.iter().cloned().map(|k| (k, endowment)).collect();
-	balances.push((dap_buffer, STAKING_ASYNC_PARA_ED));
+	balances.push((dap_buffer, endowment));
 
 	build_struct_json_patch!(RuntimeGenesisConfig {
 		balances: BalancesConfig { balances },

--- a/substrate/frame/staking-async/runtimes/parachain/src/genesis_config_presets.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/genesis_config_presets.rs
@@ -62,6 +62,7 @@ fn staking_async_parachain_genesis(params: GenesisParams, preset: String) -> ser
 	// Fund DAP buffer account: it receives slashes and is the signed-phase reward pot.
 	let dap_buffer: AccountId = DapPalletId::get().into_account_truncating();
 	let mut balances: Vec<_> = endowed_accounts.iter().cloned().map(|k| (k, endowment)).collect();
+	// Above ED, as the reward payout transfers with `Preservation::Preserve`.
 	balances.push((dap_buffer, endowment));
 
 	build_struct_json_patch!(RuntimeGenesisConfig {

--- a/substrate/frame/staking-async/runtimes/parachain/src/genesis_config_presets.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/genesis_config_presets.rs
@@ -59,11 +59,12 @@ fn staking_async_parachain_genesis(params: GenesisParams, preset: String) -> ser
 		root,
 		id,
 	} = params;
-	// Fund DAP buffer account: it receives slashes and is the signed-phase reward pot.
 	let dap_buffer: AccountId = DapPalletId::get().into_account_truncating();
 	let mut balances: Vec<_> = endowed_accounts.iter().cloned().map(|k| (k, endowment)).collect();
-	// Above ED, as the reward payout transfers with `Preservation::Preserve`.
-	balances.push((dap_buffer, endowment));
+	// The DAP buffer receives slashes and is the signed-phase reward pot. Payouts transfer with
+	// `Preservation::Preserve`, so it needs spendable balance above ED, sized in rounds of
+	// `RewardBase` rather than tracking whatever endowment a preset picked.
+	balances.push((dap_buffer, STAKING_ASYNC_PARA_ED + crate::staking::RewardBase::get() * 1_000));
 
 	build_struct_json_patch!(RuntimeGenesisConfig {
 		balances: BalancesConfig { balances },


### PR DESCRIPTION
#12843 pointed `signed::Config::RewardSource` at the DAP buffer account and changed the winner payout from `mint_into` to a `Preservation::Preserve` transfer. Genesis funded that account with exactly ED, enough only to make it exist as a slash sink, so its spendable balance is zero and every payout fails into `UnpaidRewards`. Fund it above  ED,  sized in rounds of `RewardBase`.

Same issue for Westend AH's genesis. Live WAH is unaffected, its buffer is funded and `BudgetAllocation` keeps it
topped up. It only bites devnet and test chains spawned from genesis.

Fix https://github.com/paritytech/polkadot-staking-miner/issues/1327

