### PR TITLE
bags-list: fix overflow in on_idle lookahead when MaxAutoRebagPerBlock is u32::MAX

### DIFF
--- a/prdoc/pr_13183.prdoc
+++ b/prdoc/pr_13183.prdoc
@@ -1,0 +1,15 @@
+title: 'bags-list: fix overflow in on_idle lookahead when MaxAutoRebagPerBlock is
+  u32::MAX'
+doc:
+- audience: Runtime Dev
+  description: |-
+    `Pallet::on_idle `computed the lookahead collection size as (rebag_budget + 1) as usize, a plain addition on the u32 value returned by `Config::MaxAutoRebagPerBlock`. That config trait accepts `u32::MAX` with no documented upper bound, and it is a natural choice for a runtime that wants the feature weight-governed rather than artificially capped. With that value the addition overflows, which panics in overflow-checked builds and silently wraps to 0 in standard release builds, disabling auto-rebag on every block without any error.
+
+    This changes the addition to rebag_budget.saturating_add(1), matching the saturating arithmetic already used a few lines earlier in the same function for the weight early-exit check. The rest of the function already handles a lookahead collection shorter than or equal to the budget gracefully, so this is the only change needed.
+
+    Added a test that configures `MaxAutoRebagPerBlock` as `u32::MAX` and confirms `on_idle` still rebags every account and clears the cursor instead of panicking or silently doing nothing.
+
+    Closes #13139
+crates:
+- name: pallet-bags-list
+  bump: patch

--- a/prdoc/pr_13183.prdoc
+++ b/prdoc/pr_13183.prdoc
@@ -5,10 +5,6 @@ doc:
   description: |-
     `Pallet::on_idle `computed the lookahead collection size as (rebag_budget + 1) as usize, a plain addition on the u32 value returned by `Config::MaxAutoRebagPerBlock`. That config trait accepts `u32::MAX` with no documented upper bound, and it is a natural choice for a runtime that wants the feature weight-governed rather than artificially capped. With that value the addition overflows, which panics in overflow-checked builds and silently wraps to 0 in standard release builds, disabling auto-rebag on every block without any error.
 
-    This changes the addition to rebag_budget.saturating_add(1), matching the saturating arithmetic already used a few lines earlier in the same function for the weight early-exit check. The rest of the function already handles a lookahead collection shorter than or equal to the budget gracefully, so this is the only change needed.
-
-    Added a test that configures `MaxAutoRebagPerBlock` as `u32::MAX` and confirms `on_idle` still rebags every account and clears the cursor instead of panicking or silently doing nothing.
-
     Closes #13139
 crates:
 - name: pallet-bags-list

--- a/substrate/frame/bags-list/src/lib.rs
+++ b/substrate/frame/bags-list/src/lib.rs
@@ -493,7 +493,8 @@ pub mod pallet {
 			// PendingRebag comes first for priority processing
 			let combined_iter = PendingRebag::<T, I>::iter_keys().chain(regular_iter);
 
-			let accounts: Vec<_> = combined_iter.take((rebag_budget + 1) as usize).collect();
+			let accounts: Vec<_> =
+				combined_iter.take(rebag_budget.saturating_add(1) as usize).collect();
 
 			// Safe split: if we reached (or passed) the tail of the list, we don't want to panic.
 			let (to_process, next_cursor) = if accounts.len() <= rebag_budget as usize {

--- a/substrate/frame/bags-list/src/tests.rs
+++ b/substrate/frame/bags-list/src/tests.rs
@@ -836,6 +836,22 @@ mod on_idle {
 	}
 
 	#[test]
+	fn rebags_nodes_when_budget_is_u32_max() {
+		ExtBuilder::default().build_and_execute(|| {
+			// A "weight-governed, uncapped" budget must not overflow the lookahead
+			// collection in `on_idle`.
+			<Runtime as Config>::MaxAutoRebagPerBlock::set(u32::MAX);
+
+			StakingMock::set_score_of(&3, 10);
+			run_to_block(1, Weight::MAX);
+
+			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 3]), (1_000, vec![2, 4])]);
+			// The whole list fits under the budget, so no cursor is left for next block.
+			assert_eq!(NextNodeAutoRebagged::<Runtime>::get(), None);
+		});
+	}
+
+	#[test]
 	fn does_nothing_when_list_empty() {
 		ExtBuilder::default().skip_genesis_ids().build_and_execute(|| {
 			// Set auto-rebag limit to 2 nodes per block


### PR DESCRIPTION
`Pallet::on_idle `computed the lookahead collection size as (rebag_budget + 1) as usize, a plain addition on the u32 value returned by `Config::MaxAutoRebagPerBlock`. That config trait accepts `u32::MAX` with no documented upper bound, and it is a natural choice for a runtime that wants the feature weight-governed rather than artificially capped. With that value the addition overflows, which panics in overflow-checked builds and silently wraps to 0 in standard release builds, disabling auto-rebag on every block without any error.

This changes the addition to rebag_budget.saturating_add(1), matching the saturating arithmetic already used a few lines earlier in the same function for the weight early-exit check. The rest of the function already handles a lookahead collection shorter than or equal to the budget gracefully, so this is the only change needed.

Added a test that configures `MaxAutoRebagPerBlock` as `u32::MAX` and confirms `on_idle` still rebags every account and clears the cursor instead of panicking or silently doing nothing.

Closes #13139
