### PR TITLE
bags-list: fix on_idle cursor skipping nodes on weight exhaustion

### DIFF
--- a/prdoc/pr_13184.prdoc
+++ b/prdoc/pr_13184.prdoc
@@ -1,0 +1,14 @@
+title: 'bags-list: fix on_idle cursor skipping nodes on weight exhaustion'
+doc:
+- audience: Runtime Dev
+  description: |-
+    `Pallet::on_idle `chose the persistent rebag cursor from a count-based split computed before the per-item loop ran, so it always pointed to `accounts[rebag_budget]`. The loop itself can stop earlier than that for two separate reasons: the weight meter runs out, or the pallet becomes locked mid-run. In both cases processed ends up smaller than `rebag_budget`, and the nodes between the point the loop actually stopped and `accounts[rebag_budget]` were never touched, yet the cursor still jumped past them. Those nodes stayed misplaced until an unrelated end-of-list wrap-around eventually restarted the scan from the head.
+
+    This computes the resume point after the loop instead, as `accounts[processed..]`. Since processed is the true count of items the loop actually got through, this slice is correct for every way the loop can end: the count budget being reached, the weight meter running out, or a lock, as well as the loop finishing the whole collected batch naturally. That also makes the old pre-loop split redundant, so it's removed rather than kept alongside the new logic.
+
+    Added a test with five misplaced nodes, a count budget of four, and a weight limit that only covers two rebags. It asserts the cursor resumes at the third node, the first one the weight limit actually forced it to skip, rather than jumping to the fifth as the old count-based logic would.
+
+    Closes #13138
+crates:
+- name: pallet-bags-list
+  bump: patch

--- a/substrate/frame/bags-list/src/lib.rs
+++ b/substrate/frame/bags-list/src/lib.rs
@@ -495,22 +495,13 @@ pub mod pallet {
 
 			let accounts: Vec<_> = combined_iter.take((rebag_budget + 1) as usize).collect();
 
-			// Safe split: if we reached (or passed) the tail of the list, we don't want to panic.
-			let (to_process, next_cursor) = if accounts.len() <= rebag_budget as usize {
-				// This guarantees we either get the next account to process
-				// or gracefully receive None.
-				(accounts.as_slice(), &[][..])
-			} else {
-				accounts.split_at(rebag_budget as usize)
-			};
-
 			let mut processed = 0u32;
 			let mut successful_rebags = 0u32;
 			let mut failed_rebags = 0u32;
 			let mut pending_processed = 0u32;
 
 			// First item's weight was already consumed above.
-			for (i, account) in to_process.iter().enumerate() {
+			for (i, account) in accounts.iter().enumerate() {
 				// Consume weight for every item after the first.
 				if i > 0 && meter.try_consume(per_item).is_err() {
 					break;
@@ -544,16 +535,19 @@ pub mod pallet {
 				}
 			}
 
-			// Update cursor - only track regular ListNodes accounts, not PendingRebag
+			// Whatever the count budget, the weight meter, or a lock stopped the loop from
+			// getting to is exactly where the cursor must resume from next time. Only regular
+			// ListNodes accounts are tracked, not PendingRebag.
+			let unprocessed = &accounts[processed as usize..];
 			let next_regular_account =
-				next_cursor.iter().find(|account| !PendingRebag::<T, I>::contains_key(account));
+				unprocessed.iter().find(|account| !PendingRebag::<T, I>::contains_key(account));
 
 			match next_regular_account {
 				// Defensive check: prevents re-processing the same node multiple times within a
 				// single block. This situation should not occur during normal execution, but
 				// can happen in test environments or if `on_idle()` is invoked more than once
 				// per block (e.g. via custom test harnesses or manual calls).
-				Some(next) if to_process.contains(next) => {
+				Some(next) if accounts[..processed as usize].contains(next) => {
 					NextNodeAutoRebagged::<T, I>::kill();
 					defensive!("Loop detected: {:?} already processed — cursor killed", next);
 				},

--- a/substrate/frame/bags-list/src/tests.rs
+++ b/substrate/frame/bags-list/src/tests.rs
@@ -903,6 +903,32 @@ mod on_idle {
 			assert_eq!(NextNodeAutoRebagged::<Runtime>::get(), Some(4));
 		});
 	}
+
+	#[test]
+	fn cursor_resumes_at_first_node_skipped_by_weight_exhaustion() {
+		ExtBuilder::default()
+			.skip_genesis_ids()
+			.add_ids(vec![(1, 1_000), (2, 1_000), (3, 1_000), (4, 1_000), (5, 1_000)])
+			.build_and_execute(|| {
+				// The count budget allows 4 rebags, but the weight limit only covers 2.
+				<Runtime as Config>::MaxAutoRebagPerBlock::set(4);
+				for id in 1..=5u64 {
+					StakingMock::set_score_of(&id, 10);
+				}
+				let per_item = <Runtime as Config>::WeightInfo::on_idle_rebag();
+
+				run_to_block(1, per_item.saturating_mul(2));
+
+				// Only the two accounts the weight limit actually paid for were rebagged.
+				assert_eq!(
+					List::<Runtime>::get_bags(),
+					vec![(10, vec![1, 2]), (1_000, vec![3, 4, 5])]
+				);
+				// The cursor must resume at 3, the first node the weight limit forced it to
+				// skip, not jump past it to 5 as the count budget alone would suggest.
+				assert_eq!(NextNodeAutoRebagged::<Runtime>::get(), Some(3));
+			});
+	}
 	#[test]
 	fn can_rebag_across_bags() {
 		ExtBuilder::default().build_and_execute(|| {


### PR DESCRIPTION
`Pallet::on_idle `chose the persistent rebag cursor from a count-based split computed before the per-item loop ran, so it always pointed to `accounts[rebag_budget]`. The loop itself can stop earlier than that for two separate reasons: the weight meter runs out, or the pallet becomes locked mid-run. In both cases processed ends up smaller than `rebag_budget`, and the nodes between the point the loop actually stopped and `accounts[rebag_budget]` were never touched, yet the cursor still jumped past them. Those nodes stayed misplaced until an unrelated end-of-list wrap-around eventually restarted the scan from the head.

This computes the resume point after the loop instead, as `accounts[processed..]`. Since processed is the true count of items the loop actually got through, this slice is correct for every way the loop can end: the count budget being reached, the weight meter running out, or a lock, as well as the loop finishing the whole collected batch naturally. That also makes the old pre-loop split redundant, so it's removed rather than kept alongside the new logic.

Added a test with five misplaced nodes, a count budget of four, and a weight limit that only covers two rebags. It asserts the cursor resumes at the third node, the first one the weight limit actually forced it to skip, rather than jumping to the fifth as the old count-based logic would.

Closes #13138
