### PR TITLE
sc-network: register `out_events` metrics on the litep2p backend

### DIFF
--- a/prdoc/pr_13191.prdoc
+++ b/prdoc/pr_13191.prdoc
@@ -1,0 +1,10 @@
+title: 'sc-network: register `out_events` metrics on the litep2p backend'
+doc:
+- audience: Node Operator
+  description: |-
+    The litep2p backend now registers the `substrate_sub_libp2p_out_events_events_total`
+    and `substrate_sub_libp2p_out_events_num_channels` metrics, as the libp2p backend
+    already did, so the backlog of every `event_stream` consumer is visible in Prometheus.
+crates:
+- name: sc-network
+  bump: patch

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -619,7 +619,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 			pending_queries: HashMap::new(),
 			peerstore_handle: peer_store_handle,
 			block_announce_protocol,
-			event_streams: out_events::OutChannels::new(None)?,
+			event_streams: out_events::OutChannels::new(params.metrics_registry.as_ref())?,
 			peers: HashMap::new(),
 			litep2p,
 		})


### PR DESCRIPTION
# Description

The litep2p backend now passes the Prometheus registry into `OutChannels::new`, as the libp2p backend does, instead of `None`. This exposes `substrate_sub_libp2p_out_events_events_total` and `substrate_sub_libp2p_out_events_num_channels` on litep2p nodes. #12319 added the `PeerIdentified` and `PeerRoutingTableUpdate` events to every `event_stream`, and we want to see on the fleet that consumers unaware of them keep draining their channels.

## Integration

This PR should not be integrated by downstream projects. 