### PR TITLE
Clarify Polkadot SDK README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-<div align="center">
-
-![SDK Logo](./docs/images/Polkadot_Logo_Horizontal_Pink_White.png#gh-dark-mode-only)
-![SDK Logo](./docs/images/Polkadot_Logo_Horizontal_Pink_Black.png#gh-light-mode-only)
-
 # Polkadot SDK
 
 ![GitHub stars](https://img.shields.io/github/stars/paritytech/polkadot-sdk)&nbsp;&nbsp;![GitHub
@@ -11,11 +6,7 @@ forks](https://img.shields.io/github/forks/paritytech/polkadot-sdk)
 <!-- markdownlint-disable-next-line MD013 -->
 [![StackExchange](https://img.shields.io/badge/StackExchange-Community%20&%20Support-222222?logo=stackexchange)](https://substrate.stackexchange.com/)&nbsp;&nbsp;![GitHub contributors](https://img.shields.io/github/contributors/paritytech/polkadot-sdk)&nbsp;&nbsp;![GitHub commit activity](https://img.shields.io/github/commit-activity/m/paritytech/polkadot-sdk)&nbsp;&nbsp;![GitHub last commit](https://img.shields.io/github/last-commit/paritytech/polkadot-sdk)
 
-> The Polkadot SDK repository provides all the components needed to start building on the
-> [Polkadot](https://polkadot.com/) network, a multi-chain blockchain platform that enables
-> different blockchains to interoperate and share information in a secure and scalable way.
-
-</div>
+> The Polkadot SDK repository contains the core libraries and tools for building Polkadot-based blockchains, runtimes, and infrastructure.
 
 ## ⚡ Quickstart
 If you want to get an example node running quickly you can execute the following getting started script:


### PR DESCRIPTION
Updates the README opening to make the repository’s focus on blockchains, runtimes, and infrastructure clearer.

Also removes the outdated header logo and centred layout for a simpler, more consistent first impression.

Existing Quickstart, build, and technical documentation remain unchanged.