### PR TITLE
HRMP: Cancel Open Request

### DIFF
--- a/substrate/frame/hrmp/integration-tests/src/tests.rs
+++ b/substrate/frame/hrmp/integration-tests/src/tests.rs
@@ -23,7 +23,10 @@
 use crate::{
 	para, relay, senders, HrmpPara, MockNet, Relay, PARA_ID, RECIPIENT, SENDER, SYSTEM_PARA,
 };
-use frame_support::{assert_ok, traits::EnsureOrigin};
+use frame_support::{
+	assert_ok,
+	traits::{fungible::InspectHold, EnsureOrigin},
+};
 use hrmp_primitives::{
 	ChannelId, MessageToRelay, MessageToRelayV1, ParaId, ParaNotification, ParaRequest,
 	ParaRequestV1,
@@ -32,12 +35,22 @@ use pallet_hrmp_para::RequestState;
 use polkadot_runtime_parachains::{
 	dmp as parachains_dmp, hrmp as parachains_hrmp, Origin as ParachainsOrigin,
 };
+use sp_runtime::traits::Convert;
 use xcm_simulator::TestExt;
+use codec::DecodeAll;
 
 const CHANNEL: ChannelId = ChannelId { sender: SENDER, recipient: RECIPIENT };
 const SYSTEM_CHANNEL: ChannelId = ChannelId { sender: SENDER, recipient: SYSTEM_PARA };
 const CAPACITY: u32 = 4;
 const MESSAGE_SIZE: u32 = 512;
+
+/// What `para_id` has held on the channel-managing parachain under `reason`.
+fn held(para_id: ParaId, reason: pallet_hrmp_para::HoldReason) -> para::Balance {
+	para::Balances::balance_on_hold(
+		&para::RuntimeHoldReason::Hrmp(reason),
+		&para::SovereignAccountOf::convert(para_id),
+	)
+}
 
 /// The origin `para_id` reaches the relay chain's HRMP pallet with.
 fn para_origin(para_id: ParaId) -> relay::RuntimeOrigin {
@@ -61,24 +74,22 @@ fn downward_queue(para_id: ParaId) -> Vec<Vec<u8>> {
 
 /// The queued messages that are XCM, which is the three notifications with an instruction.
 ///
-/// The other two go down as a bare [`ParaNotification`], so the two wire formats are told apart
-/// by which one decodes; see [`crate::senders::RelayNotifyParachain`].
+/// The rest go down as a bare [`ParaNotification`], so the two wire formats are told apart by
+/// which one decodes; see [`crate::senders::RelayNotifyParachain`].
 fn downward_messages(para_id: ParaId) -> Vec<xcm::opaque::VersionedXcm> {
-	use codec::Decode;
 
 	downward_queue(para_id)
 		.into_iter()
-		.filter_map(|message| xcm::opaque::VersionedXcm::decode(&mut &message[..]).ok())
+		.filter_map(|message| xcm::opaque::VersionedXcm::decode_all(&mut &message[..]).ok())
 		.collect()
 }
 
 /// The queued messages that conclude an open request, which have no XCM instruction.
 fn downward_conclusions(para_id: ParaId) -> Vec<ParaNotification> {
-	use codec::Decode;
 
 	downward_queue(para_id)
 		.into_iter()
-		.filter_map(|message| ParaNotification::decode(&mut &message[..]).ok())
+		.filter_map(|message| ParaNotification::decode_all(&mut &message[..]).ok())
 		.collect()
 }
 
@@ -243,5 +254,87 @@ fn a_channel_with_a_system_chain_takes_no_deposit() {
 		// The paying channel next to it still holds both deposits, so this is not a blanket free
 		// pass.
 		assert!(pallet_hrmp_para::Channels::<para::Runtime>::get(CHANNEL).is_none());
+	});
+}
+
+#[test]
+fn a_para_cancels_its_open_request_through_the_channel_managing_parachain() {
+	MockNet::reset();
+
+	Relay::execute_with(|| {
+		ask(
+			SENDER,
+			ParaRequestV1::InitOpenChannel {
+				recipient: RECIPIENT,
+				proposed_max_capacity: CAPACITY,
+				proposed_max_message_size: MESSAGE_SIZE,
+			},
+		);
+	});
+
+	HrmpPara::execute_with(|| {
+		assert!(pallet_hrmp_para::Requests::<para::Runtime>::get(CHANNEL).is_some());
+		assert!(held(SENDER, pallet_hrmp_para::HoldReason::SenderDeposit) > 0);
+	});
+
+	// The relay chain was never asked to open this, so the cancel stops at the parachain.
+	Relay::execute_with(|| {
+		ask(SENDER, ParaRequestV1::CancelOpenRequest { channel: CHANNEL, open_requests: 1 });
+	});
+
+	HrmpPara::execute_with(|| {
+		assert!(pallet_hrmp_para::Requests::<para::Runtime>::get(CHANNEL).is_none());
+		assert_eq!(pallet_hrmp_para::OpenRequestCount::<para::Runtime>::get(SENDER), 0);
+		assert_eq!(held(SENDER, pallet_hrmp_para::HoldReason::SenderDeposit), 0);
+	});
+
+	Relay::execute_with(|| {
+		// The routing table never heard of it, before or after.
+		assert!(parachains_hrmp::HrmpChannels::<relay::Runtime>::get(
+			&polkadot_primitives::HrmpChannelId {
+				sender: CHANNEL.sender.into(),
+				recipient: CHANNEL.recipient.into(),
+			},
+		)
+		.is_none());
+
+		// The recipient was told about the request, so it is told the request is gone.
+		assert_eq!(
+			downward_conclusions(RECIPIENT),
+			vec![ParaNotification::OpenRequestCanceled { channel: CHANNEL, by_parachain: SENDER }]
+		);
+	});
+}
+
+#[test]
+fn the_recipient_can_cancel_too_and_the_sender_is_told() {
+	MockNet::reset();
+
+	Relay::execute_with(|| {
+		ask(
+			SENDER,
+			ParaRequestV1::InitOpenChannel {
+				recipient: RECIPIENT,
+				proposed_max_capacity: CAPACITY,
+				proposed_max_message_size: MESSAGE_SIZE,
+			},
+		);
+		ask(RECIPIENT, ParaRequestV1::CancelOpenRequest { channel: CHANNEL, open_requests: 1 });
+	});
+
+	HrmpPara::execute_with(|| {
+		assert!(pallet_hrmp_para::Requests::<para::Runtime>::get(CHANNEL).is_none());
+		// The released deposit is the sender's either way.
+		assert_eq!(held(SENDER, pallet_hrmp_para::HoldReason::SenderDeposit), 0);
+	});
+
+	Relay::execute_with(|| {
+		assert_eq!(
+			downward_conclusions(SENDER),
+			vec![ParaNotification::OpenRequestCanceled {
+				channel: CHANNEL,
+				by_parachain: RECIPIENT,
+			}]
+		);
 	});
 }

--- a/substrate/frame/hrmp/para/src/lib.rs
+++ b/substrate/frame/hrmp/para/src/lib.rs
@@ -781,13 +781,48 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// `hrmp_cancel_open_request`, asked for by `initiator` through the relay chain.
+	///
+	/// The relay chain has nothing to undo: it was never told about this request. It is only
+	/// asked to carry word of the withdrawal to the other end.
 	fn on_cancel_open_request(
 		initiator: ParaId,
 		channel: ChannelId,
 		open_requests: u32,
 	) -> DispatchResult {
-		let _ = (initiator, channel, open_requests);
-		todo!()
+		ensure!(
+			OpenRequestCount::<T>::get(channel.sender) <= open_requests,
+			Error::<T>::WrongWitness,
+		);
+		ensure!(channel.is_participant(initiator), Error::<T>::CancelHrmpOpenChannelUnauthorized);
+
+		let request = Requests::<T>::get(channel).ok_or(Error::<T>::OpenHrmpChannelDoesntExist)?;
+		let RequestState::Requested { sender_deposit } = request.state else {
+			return Err(Error::<T>::OpenHrmpChannelAlreadyConfirmed.into());
+		};
+
+		Requests::<T>::remove(channel);
+		OpenRequestCount::<T>::mutate(channel.sender, |count| *count = count.saturating_sub(1));
+
+		// Only the sender can have paid: an unaccepted request never held the recipient's deposit,
+		// which is also why `AcceptedRequestCount` is left alone.
+		if let Some(deposit) = sender_deposit {
+			deposit.drop(&Self::sovereign_account(channel.sender))?;
+		}
+
+		let other_end =
+			if initiator == channel.sender { channel.recipient } else { channel.sender };
+		Self::notify_para(
+			other_end,
+			ParaNotification::OpenRequestCanceled { channel, by_parachain: initiator },
+		)?;
+
+		Self::deposit_event(Event::OpenChannelCanceled {
+			channel,
+			message_id: request.message_id,
+			by_parachain: initiator,
+		});
+
+		Ok(())
 	}
 
 	/// `establish_channel_with_system`, asked for by `sender` through the relay chain.

--- a/substrate/frame/hrmp/para/src/tests.rs
+++ b/substrate/frame/hrmp/para/src/tests.rs
@@ -73,6 +73,20 @@ fn agreed(channel: ChannelId) {
 	let _ = hrmp_events();
 }
 
+/// A request the sender has made and nobody has accepted, with the logs cleared.
+fn requested(channel: ChannelId) -> u64 {
+	fund(channel);
+	assert_ok!(init(channel, CAPACITY, MESSAGE_SIZE));
+	let message_id = Requests::<Test>::get(channel).unwrap().message_id;
+	let _ = take_sent();
+	let _ = hrmp_events();
+	message_id
+}
+
+fn cancel(initiator: ParaId, channel: ChannelId, open_requests: u32) -> sp_runtime::DispatchResult {
+	forwarded(initiator, ParaRequestV1::CancelOpenRequest { channel, open_requests })
+}
+
 fn respond(
 	channel: ChannelId,
 	message_id: u64,
@@ -433,5 +447,161 @@ fn a_refusing_transport_unwinds_the_whole_request() {
 		assert!(Requests::<Test>::get(CHANNEL).is_none());
 		assert_eq!(OpenRequestCount::<Test>::get(CHANNEL.sender), 0);
 		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), 0);
+	});
+}
+
+#[test]
+fn cancel_open_request_releases_the_sender_deposit() {
+	new_test_ext().execute_with(|| {
+		let message_id = requested(CHANNEL);
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), DEPOSIT);
+
+		assert_ok!(cancel(CHANNEL.sender, CHANNEL, 1));
+
+		assert!(Requests::<Test>::get(CHANNEL).is_none());
+		assert_eq!(OpenRequestCount::<Test>::get(CHANNEL.sender), 0);
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), 0);
+		assert_eq!(
+			hrmp_events(),
+			vec![Event::OpenChannelCanceled {
+				channel: CHANNEL,
+				message_id,
+				by_parachain: CHANNEL.sender,
+			}]
+		);
+	});
+}
+
+#[test]
+fn cancel_open_request_can_be_done_by_the_recipient() {
+	new_test_ext().execute_with(|| {
+		let message_id = requested(CHANNEL);
+
+		assert_ok!(cancel(CHANNEL.recipient, CHANNEL, 1));
+
+		assert!(Requests::<Test>::get(CHANNEL).is_none());
+		assert_eq!(OpenRequestCount::<Test>::get(CHANNEL.sender), 0);
+		// The released deposit is the sender's either way.
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), 0);
+		assert_eq!(
+			hrmp_events(),
+			vec![Event::OpenChannelCanceled {
+				channel: CHANNEL,
+				message_id,
+				by_parachain: CHANNEL.recipient,
+			}]
+		);
+	});
+}
+
+#[test]
+fn cancel_open_request_tells_the_other_end() {
+	new_test_ext().execute_with(|| {
+		requested(CHANNEL);
+		assert_ok!(cancel(CHANNEL.sender, CHANNEL, 1));
+		assert_eq!(
+			take_sent(),
+			vec![MessageToRelay::V1(MessageToRelayV1::NotifyPara {
+				para_id: CHANNEL.recipient,
+				notification: ParaNotification::OpenRequestCanceled {
+					channel: CHANNEL,
+					by_parachain: CHANNEL.sender,
+				},
+			})]
+		);
+
+		requested(CHANNEL);
+		assert_ok!(cancel(CHANNEL.recipient, CHANNEL, 1));
+		assert_eq!(
+			take_sent(),
+			vec![MessageToRelay::V1(MessageToRelayV1::NotifyPara {
+				para_id: CHANNEL.sender,
+				notification: ParaNotification::OpenRequestCanceled {
+					channel: CHANNEL,
+					by_parachain: CHANNEL.recipient,
+				},
+			})]
+		);
+	});
+}
+
+#[test]
+fn cancel_open_request_rejects_a_stranger() {
+	new_test_ext().execute_with(|| {
+		requested(CHANNEL);
+
+		assert_noop!(cancel(2002, CHANNEL, 1), Error::<Test>::CancelHrmpOpenChannelUnauthorized);
+		assert!(Requests::<Test>::get(CHANNEL).is_some());
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), DEPOSIT);
+	});
+}
+
+#[test]
+fn cancel_open_request_needs_an_unaccepted_request() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(cancel(CHANNEL.sender, CHANNEL, 0), Error::<Test>::OpenHrmpChannelDoesntExist);
+
+		agreed(CHANNEL);
+		assert_noop!(
+			cancel(CHANNEL.sender, CHANNEL, 1),
+			Error::<Test>::OpenHrmpChannelAlreadyConfirmed
+		);
+		assert!(Requests::<Test>::get(CHANNEL).is_some());
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), DEPOSIT);
+		assert_eq!(held(CHANNEL.recipient, HoldReason::RecipientDeposit), DEPOSIT);
+	});
+}
+
+#[test]
+fn cancel_open_request_checks_the_witness() {
+	new_test_ext().execute_with(|| {
+		requested(CHANNEL);
+
+		assert_noop!(cancel(CHANNEL.sender, CHANNEL, 0), Error::<Test>::WrongWitness);
+		// The count checked is the sender's, whoever is cancelling: the recipient has none of its
+		// own, so a witness of zero would pass if the initiator's were used.
+		assert_noop!(cancel(CHANNEL.recipient, CHANNEL, 0), Error::<Test>::WrongWitness);
+		// Over-declaring only overpays.
+		assert_ok!(cancel(CHANNEL.sender, CHANNEL, 2));
+	});
+}
+
+#[test]
+fn cancelling_a_system_channel_releases_nothing() {
+	new_test_ext().execute_with(|| {
+		// Only the sender is funded: a channel with the system holds nothing on either end.
+		fund_para(SYSTEM_CHANNEL.sender);
+		assert_ok!(init(SYSTEM_CHANNEL, CAPACITY, MESSAGE_SIZE));
+
+		assert_ok!(cancel(SYSTEM_CHANNEL.sender, SYSTEM_CHANNEL, 1));
+
+		assert!(Requests::<Test>::get(SYSTEM_CHANNEL).is_none());
+		assert_eq!(held(SYSTEM_CHANNEL.sender, HoldReason::SenderDeposit), 0);
+	});
+}
+
+#[test]
+fn cancelling_lets_the_sender_ask_again() {
+	new_test_ext().execute_with(|| {
+		requested(CHANNEL);
+		assert_ok!(cancel(CHANNEL.sender, CHANNEL, 1));
+
+		// Nothing of the first request is left to get in the way.
+		assert_ok!(init(CHANNEL, CAPACITY, MESSAGE_SIZE));
+		assert_eq!(OpenRequestCount::<Test>::get(CHANNEL.sender), 1);
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), DEPOSIT);
+	});
+}
+
+#[test]
+fn a_refusing_transport_unwinds_the_cancel() {
+	new_test_ext().execute_with(|| {
+		requested(CHANNEL);
+		SendFails::set(true);
+
+		assert_noop!(cancel(CHANNEL.sender, CHANNEL, 1), Error::<Test>::SendFailed);
+		assert!(Requests::<Test>::get(CHANNEL).is_some());
+		assert_eq!(OpenRequestCount::<Test>::get(CHANNEL.sender), 1);
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), DEPOSIT);
 	});
 }

--- a/substrate/frame/hrmp/primitives/src/lib.rs
+++ b/substrate/frame/hrmp/primitives/src/lib.rs
@@ -134,7 +134,7 @@ pub enum ParaRequestV1 {
 	CancelOpenRequest {
 		/// The channel the request is for.
 		channel: ChannelId,
-		/// The asking para's count of open requests, checked against storage.
+		/// The sender's count of open requests, checked against storage.
 		open_requests: u32,
 	},
 	/// Open both deposit-free directions between the asking para and a system chain.
@@ -148,8 +148,8 @@ pub enum ParaRequestV1 {
 /// What a parachain is told about a channel it is one end of.
 ///
 /// The first three are delivered as the XCM `HrmpNewChannelOpenRequest`, `HrmpChannelAccepted`
-/// and `HrmpChannelClosing` instructions, whose fields they mirror. The last two conclude a
-/// request and have no instruction of their own, so how they reach a para is up to the transport.
+/// and `HrmpChannelClosing` instructions, whose fields they mirror. The rest conclude a request
+/// and have no instruction of their own, so how they reach a para is up to the transport.
 /// Versioned by the message carrying it, as [`ChannelId`] and [`FailureReason`] are.
 #[derive(
 	Encode, Decode, DecodeWithMemTracking, Clone, Eq, PartialEq, Debug, TypeInfo, MaxEncodedLen,
@@ -194,6 +194,14 @@ pub enum ParaNotification {
 		channel: ChannelId,
 		/// Why the relay chain refused.
 		reason: FailureReason,
+	},
+	/// An open request the para being told is one end of was withdrawn.
+	#[codec(index = 5)]
+	OpenRequestCanceled {
+		/// The channel the request was for.
+		channel: ChannelId,
+		/// Which end withdrew it.
+		by_parachain: ParaId,
 	},
 }
 


### PR DESCRIPTION
Closes #12949. Stacked on #13168 — review that first, this PR targets its branch.

## Flow

A request lives on the Coretime chain until it is accepted; only accepting asks the relay chain to open the channel. So a cancel never has to reach the relay chain to undo anything, and this whole call is CT-local:

1. Either end sends `hrmp_cancel_open_request` to the relay chain, which authenticates the asking para from the origin and forwards it to CT.
2. CT checks the witness, that the caller is one of the two ends, and that the request exists and has not been accepted.
3. The request is dropped, the sender's `OpenRequestCount` is decremented and its deposit is released. Only the sender can have paid, so `AcceptedRequestCount` is untouched.
4. The other end is told, via the relay chain, that the request is gone.