### PR TITLE
statement-store: rate-limit topic affinity updates per peer

### DIFF
--- a/prdoc/pr_13196.prdoc
+++ b/prdoc/pr_13196.prdoc
@@ -6,7 +6,8 @@ doc:
     `ExplicitTopicAffinity` updates on the `statement/2` protocol now draw from a dedicated
     per-peer token bucket, one update per second with a burst of five, instead of the peer's
     statement bucket. An update past the limit is dropped and reported with the new
-    `AFFINITY_FLOODING` reputation change; the peer stays connected.
+    `AFFINITY_FLOODING` reputation change; the peer stays connected. Dropped updates are
+    counted by the new `substrate_sync_statement_affinity_flooding_detected` metric.
 
 crates:
 - name: sc-network-statement

--- a/prdoc/pr_13196.prdoc
+++ b/prdoc/pr_13196.prdoc
@@ -1,0 +1,13 @@
+title: 'statement-store: rate-limit topic affinity updates per peer'
+
+doc:
+- audience: Node Dev
+  description: |-
+    `ExplicitTopicAffinity` updates on the `statement/2` protocol now draw from a dedicated
+    per-peer token bucket, one update per second with a burst of five, instead of the peer's
+    statement bucket. An update past the limit is dropped and reported with the new
+    `AFFINITY_FLOODING` reputation change; the peer stays connected.
+
+crates:
+- name: sc-network-statement
+  bump: minor

--- a/substrate/client/network/statement/src/config.rs
+++ b/substrate/client/network/statement/src/config.rs
@@ -19,7 +19,10 @@
 //! Configuration of the statement protocol
 
 use sp_statement_store::Topic;
-use std::{num::NonZeroUsize, time};
+use std::{
+	num::{NonZeroU32, NonZeroUsize},
+	time,
+};
 
 /// Interval at which we propagate statements;
 pub(crate) const PROPAGATE_TIMEOUT: time::Duration = time::Duration::from_millis(1000);
@@ -58,6 +61,12 @@ pub const DEFAULT_STATEMENTS_PER_SECOND: u32 = 50_000;
 
 /// Burst capacity coefficient for the rate limiter.
 pub const STATEMENTS_BURST_COEFFICIENT: u32 = 5;
+
+/// Maximum topic affinity updates per second from one peer before rate limiting kicks in.
+pub const AFFINITY_UPDATES_PER_SECOND: NonZeroU32 = NonZeroU32::new(1).expect("1 is non-zero");
+
+/// Burst capacity for the affinity update rate limiter.
+pub const AFFINITY_UPDATES_BURST: NonZeroU32 = NonZeroU32::new(5).expect("5 is non-zero");
 
 /// Default and lowest accepted false-positive rate for an affinity bloom filter built from a
 /// local topic list. Lower rates inflate the filter's size and hash count toward the wire limits

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -88,7 +88,7 @@
 //! The `statement/2` protocol lets a peer advertise which topics it cares about as a bloom filter
 //! ("topic affinity"). Once a peer has an active affinity filter, only matching statements are
 //! forwarded to it; when its affinity changes, newly relevant statements are re-sent. Affinity
-//! advertisements are rate-limited. See the `affinity` module.
+//! advertisements are rate-limited per peer, see `config::AFFINITY_UPDATES_PER_SECOND`.
 //!
 //! Light-client peers on `statement/2` must advertise an affinity before receiving any statements:
 //! a light V2 peer pulls only the topics it cares about instead of the full feed, and is synced
@@ -289,6 +289,7 @@ struct Metrics {
 	initial_sync_peers_active: Gauge<U64>,
 	initial_sync_duration_seconds: HistogramVec,
 	statement_flooding_detected: Counter<U64>,
+	affinity_flooding_detected: Counter<U64>,
 	send_failures: CounterVec<U64>,
 	undelivered_statements: CounterVec<U64>,
 }
@@ -457,6 +458,13 @@ impl Metrics {
 				Counter::new(
 					"substrate_sync_statement_flooding_detected",
 					"Number of peers disconnected for exceeding statement rate limits",
+				)?,
+				r,
+			)?,
+			affinity_flooding_detected: register(
+				Counter::new(
+					"substrate_sync_statement_affinity_flooding_detected",
+					"Number of topic affinity updates dropped for exceeding the per-peer rate limit",
 				)?,
 				r,
 			)?,
@@ -817,11 +825,6 @@ impl PeerRateLimiter {
 		Self::with_clock(statements_per_second, burst, &DefaultClock::default())
 	}
 
-	/// The quota for `ExplicitTopicAffinity` updates from one peer.
-	fn for_affinity_updates() -> Self {
-		Self::new(config::AFFINITY_UPDATES_PER_SECOND, config::AFFINITY_UPDATES_BURST)
-	}
-
 	/// The same quota, measured against `clock`.
 	fn with_clock<C>(statements_per_second: NonZeroU32, burst: NonZeroU32, clock: &C) -> Self
 	where
@@ -832,7 +835,12 @@ impl PeerRateLimiter {
 		Self { bucket: Box::new(RateLimiter::direct_with_clock(quota, clock)) }
 	}
 
-	/// Check if receiving `count` statements would exceed the rate limit.
+	/// The quota for `ExplicitTopicAffinity` updates from one peer.
+	fn for_affinity_updates() -> Self {
+		Self::new(config::AFFINITY_UPDATES_PER_SECOND, config::AFFINITY_UPDATES_BURST)
+	}
+
+	/// Check if receiving `count` more messages would exceed the rate limit.
 	fn is_flooding(&self, count: usize) -> bool {
 		if count > u32::MAX as usize {
 			return true;
@@ -1701,9 +1709,12 @@ where
 									if peer_data.affinity_rate_limiter.is_flooding(1) {
 										log::debug!(
 											target: LOG_TARGET,
-											"Rate-limiting ExplicitTopicAffinity from {peer}"
+											"Dropping rate-limited ExplicitTopicAffinity from {peer}"
 										);
 										self.network.report_peer(peer, rep::AFFINITY_FLOODING);
+										if let Some(ref metrics) = self.metrics {
+											metrics.affinity_flooding_detected.inc();
+										}
 										return;
 									}
 									if v2dht_enabled() {

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -233,6 +233,8 @@ mod rep {
 	pub const STATEMENT_FLOODING: Rep = Rep::new_fatal("Statement flooding");
 	/// Reputation change when a peer sends us a message we can't decode.
 	pub const BAD_MESSAGE: Rep = Rep::new(-(1 << 12), "Bad statement message");
+	/// Reputation change when a peer sends topic affinity updates faster than the limit.
+	pub const AFFINITY_FLOODING: Rep = Rep::new(-(1 << 12), "Topic affinity flooding");
 }
 
 const LOG_TARGET: &str = "statement-gossip";
@@ -815,6 +817,11 @@ impl PeerRateLimiter {
 		Self::with_clock(statements_per_second, burst, &DefaultClock::default())
 	}
 
+	/// The quota for `ExplicitTopicAffinity` updates from one peer.
+	fn for_affinity_updates() -> Self {
+		Self::new(config::AFFINITY_UPDATES_PER_SECOND, config::AFFINITY_UPDATES_BURST)
+	}
+
 	/// The same quota, measured against `clock`.
 	fn with_clock<C>(statements_per_second: NonZeroU32, burst: NonZeroU32, clock: &C) -> Self
 	where
@@ -844,6 +851,9 @@ impl PeerRateLimiter {
 pub struct Peer {
 	/// Rate limiter for statement flooding protection.
 	rate_limiter: PeerRateLimiter,
+	/// Rate limiter for `ExplicitTopicAffinity` updates, kept apart from the statement bucket
+	/// so a statement burst cannot reject a filter change.
+	affinity_rate_limiter: PeerRateLimiter,
 	/// Protocol version negotiated with this peer.
 	protocol_version: PeerProtocolVersion,
 	/// Topic affinity filter received from a v2 peer.
@@ -1098,6 +1108,7 @@ impl Peer {
 	pub fn new_for_testing(statements_per_second: NonZeroU32, burst: NonZeroU32) -> Self {
 		Self {
 			rate_limiter: PeerRateLimiter::new(statements_per_second, burst),
+			affinity_rate_limiter: PeerRateLimiter::for_affinity_updates(),
 			protocol_version: PeerProtocolVersion::V1,
 			topic_affinity: None,
 			is_light: false,
@@ -1539,8 +1550,8 @@ where
 	/// - Decodes incoming notifications: V1 peers send raw statement batches; V2 peers send a
 	///   `StatementMessage` that is either a batch of statements or an `ExplicitTopicAffinity`
 	///   advertisement.
-	/// - Rate-limits affinity advertisements (reporting `rep::BAD_MESSAGE` on abuse); otherwise
-	///   stores the filter as pending until applied by the main loop.
+	/// - Rate-limits affinity advertisements (reporting `rep::AFFINITY_FLOODING` on abuse);
+	///   otherwise stores the filter as pending until applied by the main loop.
 	async fn handle_notification_event(&mut self, event: NotificationEvent) {
 		match event {
 			NotificationEvent::ValidateInboundSubstream { peer, handshake, result_tx, .. } => {
@@ -1590,6 +1601,7 @@ where
 							)
 							.expect("burst capacity is nonzero"),
 						),
+						affinity_rate_limiter: PeerRateLimiter::for_affinity_updates(),
 						protocol_version,
 						topic_affinity: None,
 						is_light,
@@ -1686,12 +1698,12 @@ where
 									self.on_statements(peer, statements.into_inner());
 								},
 								StatementMessage::ExplicitTopicAffinity(filter) => {
-									if peer_data.rate_limiter.is_flooding(1) {
+									if peer_data.affinity_rate_limiter.is_flooding(1) {
 										log::debug!(
 											target: LOG_TARGET,
 											"Rate-limiting ExplicitTopicAffinity from {peer}"
 										);
-										self.network.report_peer(peer, rep::BAD_MESSAGE);
+										self.network.report_peer(peer, rep::AFFINITY_FLOODING);
 										return;
 									}
 									if v2dht_enabled() {
@@ -3272,6 +3284,7 @@ mod tests {
 						)
 						.expect("burst capacity is nonzero"),
 					),
+					affinity_rate_limiter: PeerRateLimiter::for_affinity_updates(),
 					protocol_version: PeerProtocolVersion::V1,
 					topic_affinity: None,
 					is_light: false,
@@ -3916,6 +3929,7 @@ mod tests {
 					)
 					.expect("nonzero"),
 				),
+				affinity_rate_limiter: PeerRateLimiter::for_affinity_updates(),
 				protocol_version: PeerProtocolVersion::V1,
 				topic_affinity: Some(AffinityFilter::new(BLOOM_SEED, 0.01, 10)),
 				is_light: false,
@@ -5692,6 +5706,69 @@ mod tests {
 		);
 	}
 
+	async fn send_affinity(
+		handler: &mut StatementHandler<TestNetwork, TestSync>,
+		peer_id: PeerId,
+		topic: [u8; 32],
+	) {
+		let mut filter = AffinityFilter::new(BLOOM_SEED, 0.01, 100);
+		filter.insert(&topic);
+		let notification = StatementMessage::ExplicitTopicAffinity(filter).encode().into();
+		handler
+			.handle_notification_event(NotificationEvent::NotificationReceived {
+				peer: peer_id,
+				notification,
+			})
+			.await;
+	}
+
+	#[tokio::test]
+	async fn affinity_updates_are_rate_limited_per_peer() {
+		let (mut handler, _statement_store, network, _notification_service) =
+			build_handler_no_peers();
+		let peer_id = PeerId::random();
+		handler
+			.handle_notification_event(NotificationEvent::NotificationStreamOpened {
+				peer: peer_id,
+				direction: sc_network::service::traits::Direction::Inbound,
+				handshake: vec![],
+				negotiated_fallback: None,
+			})
+			.await;
+		let clock = FakeRelativeClock::default();
+		handler.peers.get_mut(&peer_id).unwrap().affinity_rate_limiter =
+			PeerRateLimiter::with_clock(
+				config::AFFINITY_UPDATES_PER_SECOND,
+				config::AFFINITY_UPDATES_BURST,
+				&clock,
+			);
+		let flooding_reports = || {
+			network
+				.get_reports()
+				.iter()
+				.filter(|(id, rep)| *id == peer_id && *rep == rep::AFFINITY_FLOODING)
+				.count()
+		};
+
+		let burst = config::AFFINITY_UPDATES_BURST.get() as u8;
+		for i in 0..=burst {
+			send_affinity(&mut handler, peer_id, [i; 32]).await;
+		}
+		assert_eq!(flooding_reports(), 1, "only the update past the burst is reported");
+		assert!(!network.get_disconnected_peers().contains(&peer_id));
+		handler.process_pending_affinities();
+		let affinity = handler.peers[&peer_id].topic_affinity.clone().unwrap();
+		assert!(affinity.contains(&[burst - 1; 32]), "last accepted update is applied");
+		assert!(!affinity.contains(&[burst; 32]), "dropped update is not applied");
+
+		clock.advance(Duration::from_secs(1));
+		send_affinity(&mut handler, peer_id, [burst; 32]).await;
+		assert_eq!(flooding_reports(), 1, "the refilled token admits the next update");
+		handler.process_pending_affinities();
+		let affinity = handler.peers[&peer_id].topic_affinity.clone().unwrap();
+		assert!(affinity.contains(&[burst; 32]), "update after the refill is applied");
+	}
+
 	#[tokio::test]
 	async fn test_topic_affinity_filters_propagation() {
 		let (mut handler, statement_store, _network, notification_service) =
@@ -6192,6 +6269,7 @@ mod tests {
 					)
 					.expect("nonzero"),
 				),
+				affinity_rate_limiter: PeerRateLimiter::for_affinity_updates(),
 				protocol_version: version,
 				topic_affinity,
 				is_light,
@@ -6466,6 +6544,7 @@ mod tests {
 					)
 					.unwrap(),
 				),
+				affinity_rate_limiter: PeerRateLimiter::for_affinity_updates(),
 				protocol_version: PeerProtocolVersion::V1,
 				topic_affinity: None,
 				is_light: false,
@@ -7035,6 +7114,7 @@ mod tests {
 					)
 					.expect("burst capacity is nonzero"),
 				),
+				affinity_rate_limiter: PeerRateLimiter::for_affinity_updates(),
 				protocol_version: PeerProtocolVersion::V1,
 				topic_affinity: None,
 				is_light: false,
@@ -7152,6 +7232,7 @@ mod tests {
 				)
 				.expect("burst capacity is nonzero"),
 			),
+			affinity_rate_limiter: PeerRateLimiter::for_affinity_updates(),
 			protocol_version: PeerProtocolVersion::V1,
 			topic_affinity: None,
 			is_light: false,
@@ -7257,6 +7338,7 @@ mod tests {
 				)
 				.expect("burst capacity is nonzero"),
 			),
+			affinity_rate_limiter: PeerRateLimiter::for_affinity_updates(),
 			protocol_version: PeerProtocolVersion::V1,
 			topic_affinity: None,
 			is_light: false,


### PR DESCRIPTION
# Description

Gives `ExplicitTopicAffinity` its own per-peer token bucket and reports `rep::AFFINITY_FLOODING` for updates past it. Until now an affinity update drew one token from the peer's statement bucket, 50k/s with a 250k burst, so a peer could push tens of thousands of 1 MiB filters per second unchecked, and a burst of its own statements could reject a legitimate filter change.

Closes https://github.com/paritytech/polkadot-sdk/issues/12556.

## Integration

Node operators: no action. Two new constants in `sc-network-statement`:

```rust
pub const AFFINITY_UPDATES_PER_SECOND: NonZeroU32 = 100;
pub const AFFINITY_UPDATES_BURST: NonZeroU32 =
	AFFINITY_UPDATES_PER_SECOND * STATEMENTS_BURST_COEFFICIENT; // 500
```

A peer past the limit keeps its connection, the extra update is dropped, reported, and counted by the new `substrate_sync_statement_affinity_flooding_detected` metric.

## Review Notes

- Handling an update costs a decode plus a map insert that replaces the peer's previous filter, and the filter itself is applied only at the next tick, so a queue drained in one poll is not abuse. The bucket is therefore loose: it exists to catch a runaway peer and to give peer scoring a signal, not to police the honest rate. The statement path already admits 50k notifications per second, so a much tighter affinity limit would buy no protection while risking false positives on a light client that changes its subscriptions.
- The burst reuses `STATEMENTS_BURST_COEFFICIENT`, leaving the sustained rate as the only number chosen by hand.
- `Peer` gains `affinity_rate_limiter`, built via `PeerRateLimiter::for_affinity_updates()` at every construction site.
- New reputation constant so peer scoring has a signal to build on.
- Test: `affinity_updates_are_rate_limited_per_peer`.
- Files: `substrate/client/network/statement/src/{lib.rs,config.rs}`.
