### PR TITLE
Close HRMP channels from the coretime chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13733,6 +13733,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hrmp-primitives",
+ "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",

--- a/polkadot/runtime/parachains/src/hrmp.rs
+++ b/polkadot/runtime/parachains/src/hrmp.rs
@@ -2015,8 +2015,16 @@ impl<T: Config> HrmpRegistry for Pallet<T> {
 	}
 
 	fn close_channel(channel: ChannelId, initiator: HrmpParaId) -> Result<(), FailureReason> {
-		let _ = (channel, initiator);
-		todo!()
+		let channel_id = to_hrmp_channel_id(channel);
+		ensure!(channel_id.is_participant(ParaId::from(initiator)), FailureReason::InvalidPara);
+		ensure!(HrmpChannels::<T>::contains_key(&channel_id), FailureReason::NotFound);
+
+		// One end asked on the calling chain, so the channel closes now rather than at the next
+		// session boundary. The refund inside is a no-op for channels this path opened, and the
+		// real thing for a channel that predates it.
+		Self::close_hrmp_channel(&channel_id);
+
+		Ok(())
 	}
 
 	fn force_clean(para_id: HrmpParaId) -> Result<(), FailureReason> {

--- a/polkadot/runtime/parachains/src/hrmp/tests.rs
+++ b/polkadot/runtime/parachains/src/hrmp/tests.rs
@@ -1390,4 +1390,123 @@ mod registry {
 			assert!(Hrmp::exists(channel(para_b, para_a)));
 		});
 	}
+
+	fn close(channel: ChannelId, initiator: u32) -> Result<(), FailureReason> {
+		// Qualified: `Pallet` has an inherent `close_channel` that would win otherwise.
+		<Hrmp as HrmpRegistry>::close_channel(channel, initiator)
+	}
+
+	#[test]
+	fn close_channel_closes_it_now() {
+		let (para_a, para_b) = (2000, 2001);
+		new_test_ext(GenesisConfigBuilder::default().build()).execute_with(|| {
+			run_to_block(2, Some(vec![1, 2]));
+			register_parachain(para_a.into());
+			register_parachain(para_b.into());
+			run_to_block(4, Some(vec![3, 4]));
+			assert_eq!(open(channel(para_a, para_b)), Ok(()));
+
+			assert_eq!(close(channel(para_a, para_b), para_a), Ok(()));
+
+			// No session boundary was needed here either.
+			let id = HrmpChannelId { sender: para_a.into(), recipient: para_b.into() };
+			assert!(HrmpChannels::<Test>::get(&id).is_none());
+			assert!(HrmpEgressChannelsIndex::<Test>::get(&ParaId::from(para_a)).is_empty());
+			assert!(HrmpIngressChannelsIndex::<Test>::get(&ParaId::from(para_b)).is_empty());
+			assert!(!Hrmp::exists(channel(para_a, para_b)));
+
+			Hrmp::assert_storage_consistency_exhaustive();
+		});
+	}
+
+	#[test]
+	fn either_end_may_close() {
+		let (para_a, para_b) = (2000, 2001);
+		new_test_ext(GenesisConfigBuilder::default().build()).execute_with(|| {
+			run_to_block(2, Some(vec![1, 2]));
+			register_parachain(para_a.into());
+			register_parachain(para_b.into());
+			run_to_block(4, Some(vec![3, 4]));
+			assert_eq!(open(channel(para_a, para_b)), Ok(()));
+
+			assert_eq!(close(channel(para_a, para_b), para_b), Ok(()));
+
+			assert!(!Hrmp::exists(channel(para_a, para_b)));
+			Hrmp::assert_storage_consistency_exhaustive();
+		});
+	}
+
+	#[test]
+	fn close_channel_needs_a_participant_and_an_open_channel() {
+		let (para_a, para_b, para_c) = (2000, 2001, 2002);
+		new_test_ext(GenesisConfigBuilder::default().build()).execute_with(|| {
+			run_to_block(2, Some(vec![1, 2]));
+			register_parachain(para_a.into());
+			register_parachain(para_b.into());
+			run_to_block(4, Some(vec![3, 4]));
+
+			assert_eq!(close(channel(para_a, para_b), para_a), Err(FailureReason::NotFound));
+
+			assert_eq!(open(channel(para_a, para_b)), Ok(()));
+			assert_eq!(close(channel(para_a, para_b), para_c), Err(FailureReason::InvalidPara));
+			// The reverse direction is a different channel.
+			assert_eq!(close(channel(para_b, para_a), para_a), Err(FailureReason::NotFound));
+		});
+	}
+
+	#[test]
+	fn close_channel_drops_the_messages_still_in_the_channel() {
+		let (para_a, para_b) = (2000, 2001);
+		new_test_ext(GenesisConfigBuilder::default().build()).execute_with(|| {
+			run_to_block(2, Some(vec![1, 2]));
+			register_parachain(para_a.into());
+			register_parachain(para_b.into());
+			run_to_block(4, Some(vec![3, 4]));
+			assert_eq!(open(channel(para_a, para_b)), Ok(()));
+
+			let id = HrmpChannelId { sender: para_a.into(), recipient: para_b.into() };
+			let msgs: HorizontalMessages =
+				vec![OutboundHrmpMessage { recipient: para_b.into(), data: b"hello".to_vec() }]
+					.try_into()
+					.unwrap();
+			Hrmp::queue_outbound_hrmp(para_a.into(), msgs);
+			assert!(!HrmpChannelContents::<Test>::get(&id).is_empty());
+
+			assert_eq!(close(channel(para_a, para_b), para_a), Ok(()));
+
+			assert!(HrmpChannelContents::<Test>::get(&id).is_empty());
+			Hrmp::assert_storage_consistency_exhaustive();
+		});
+	}
+
+	#[test]
+	fn close_channel_refunds_a_legacy_channels_deposits() {
+		let (para_a, para_b) = (2000, 2001);
+
+		let mut genesis = GenesisConfigBuilder::default();
+		genesis.hrmp_sender_deposit = 20;
+		genesis.hrmp_recipient_deposit = 15;
+		new_test_ext(genesis.build()).execute_with(|| {
+			register_parachain_with_balance(para_a.into(), 100);
+			register_parachain_with_balance(para_b.into(), 110);
+			run_to_block(5, Some(vec![4, 5]));
+
+			// A channel opened the old way holds its deposits here, not on the calling chain.
+			Hrmp::init_open_channel(para_a.into(), para_b.into(), CAPACITY, MESSAGE_SIZE).unwrap();
+			Hrmp::accept_open_channel(para_b.into(), para_a.into()).unwrap();
+			run_to_block(8, Some(vec![8]));
+			assert_eq!(free_balance(para_a), 80);
+			assert_eq!(free_balance(para_b), 95);
+
+			assert_eq!(close(channel(para_a, para_b), para_a), Ok(()));
+
+			assert_eq!(free_balance(para_a), 100);
+			assert_eq!(free_balance(para_b), 110);
+			Hrmp::assert_storage_consistency_exhaustive();
+		});
+	}
+
+	fn free_balance(para: u32) -> Balance {
+		<Test as Config>::Currency::free_balance(&ParaId::from(para).into_account_truncating())
+	}
 }

--- a/substrate/frame/hrmp/integration-tests/src/tests.rs
+++ b/substrate/frame/hrmp/integration-tests/src/tests.rs
@@ -245,3 +245,65 @@ fn a_channel_with_a_system_chain_takes_no_deposit() {
 		assert!(pallet_hrmp_para::Channels::<para::Runtime>::get(CHANNEL).is_none());
 	});
 }
+
+#[test]
+fn a_para_closes_a_channel_through_the_channel_managing_parachain() {
+	MockNet::reset();
+
+	let channel_id = polkadot_primitives::HrmpChannelId {
+		sender: CHANNEL.sender.into(),
+		recipient: CHANNEL.recipient.into(),
+	};
+
+	Relay::execute_with(|| {
+		ask(
+			SENDER,
+			ParaRequestV1::InitOpenChannel {
+				recipient: RECIPIENT,
+				proposed_max_capacity: CAPACITY,
+				proposed_max_message_size: MESSAGE_SIZE,
+			},
+		);
+		ask(RECIPIENT, ParaRequestV1::AcceptOpenChannel { sender: SENDER });
+	});
+
+	HrmpPara::execute_with(|| {
+		assert!(pallet_hrmp_para::Channels::<para::Runtime>::get(CHANNEL).is_some());
+	});
+
+	// One end asks, and the whole round trip settles before this closure returns.
+	Relay::execute_with(|| {
+		ask(SENDER, ParaRequestV1::CloseChannel { channel: CHANNEL });
+	});
+
+	Relay::execute_with(|| {
+		assert!(parachains_hrmp::HrmpChannels::<relay::Runtime>::get(&channel_id).is_none());
+		assert!(parachains_hrmp::HrmpEgressChannelsIndex::<relay::Runtime>::get(
+			&polkadot_primitives::Id::from(SENDER)
+		)
+		.is_empty());
+		assert!(parachains_hrmp::HrmpIngressChannelsIndex::<relay::Runtime>::get(
+			&polkadot_primitives::Id::from(RECIPIENT)
+		)
+		.is_empty());
+
+		// Only the other end is told, as the instruction the relay chain has always used.
+		assert_eq!(
+			downward_messages(RECIPIENT).last(),
+			Some(&xcm::opaque::VersionedXcm::from(xcm::opaque::latest::Xcm(vec![
+				xcm::opaque::latest::prelude::HrmpChannelClosing {
+					initiator: SENDER,
+					sender: SENDER,
+					recipient: RECIPIENT,
+				}
+			])))
+		);
+	});
+
+	HrmpPara::execute_with(|| {
+		assert!(pallet_hrmp_para::Channels::<para::Runtime>::get(CHANNEL).is_none());
+		assert!(pallet_hrmp_para::CloseRequests::<para::Runtime>::get(CHANNEL).is_none());
+		assert!(pallet_hrmp_para::EgressIndex::<para::Runtime>::get(CHANNEL.sender).is_empty());
+		assert!(pallet_hrmp_para::IngressIndex::<para::Runtime>::get(CHANNEL.recipient).is_empty());
+	});
+}

--- a/substrate/frame/hrmp/para/Cargo.toml
+++ b/substrate/frame/hrmp/para/Cargo.toml
@@ -20,6 +20,7 @@ frame-benchmarking = { optional = true, workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 hrmp-primitives = { workspace = true }
+log = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 sp-runtime = { workspace = true }
 
@@ -35,6 +36,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"hrmp-primitives/std",
+	"log/std",
 	"pallet-balances/std",
 	"scale-info/std",
 	"sp-runtime/std",

--- a/substrate/frame/hrmp/para/src/lib.rs
+++ b/substrate/frame/hrmp/para/src/lib.rs
@@ -135,6 +135,18 @@ pub struct CloseRequest {
 	pub message_id: u64,
 }
 
+/// Something that breaks an invariant this pallet relies on.
+#[derive(
+	Encode, Decode, DecodeWithMemTracking, Clone, Eq, PartialEq, Debug, TypeInfo, MaxEncodedLen,
+)]
+pub enum UnexpectedKind {
+	/// A channel notification could not be handed to the transport.
+	NotifyFailed {
+		/// The para that was to be told.
+		para_id: ParaId,
+	},
+}
+
 /// A pending open request, with the sizes it asked for.
 #[derive(
 	Encode, Decode, DecodeWithMemTracking, Clone, Eq, PartialEq, Debug, TypeInfo, MaxEncodedLen,
@@ -349,6 +361,15 @@ pub mod pallet {
 			/// The id of the message this concludes.
 			message_id: u64,
 		},
+		/// The relay chain refused to close a channel. The deposits stay held.
+		ChannelCloseFailed {
+			/// The channel.
+			channel: ChannelId,
+			/// The id of the message this concludes.
+			message_id: u64,
+			/// Why the relay chain refused.
+			reason: FailureReason,
+		},
 		/// A deposit-free channel with a system chain was asked for.
 		SystemChannelRequested {
 			/// The channel. Both directions are opened.
@@ -403,6 +424,8 @@ pub mod pallet {
 			/// The channel.
 			channel: ChannelId,
 		},
+		/// Something that should never happen.
+		Unexpected(UnexpectedKind),
 	}
 
 	#[pallet::error]
@@ -649,6 +672,11 @@ impl<T: Config> Pallet<T> {
 		.map_err(|()| Error::<T>::SendFailed.into())
 	}
 
+	fn unexpected(kind: UnexpectedKind, error: DispatchError) {
+		log::error!(target: "runtime::hrmp-para", "{kind:?}: {error:?}");
+		Self::deposit_event(Event::Unexpected(kind));
+	}
+
 	fn next_message_id() -> u64 {
 		NextMessageId::<T>::mutate(|next| {
 			let id = *next;
@@ -776,8 +804,30 @@ impl<T: Config> Pallet<T> {
 
 	/// `hrmp_close_channel`, asked for by `initiator` through the relay chain.
 	fn on_close_channel(initiator: ParaId, channel: ChannelId) -> DispatchResult {
-		let _ = (initiator, channel);
-		todo!()
+		ensure!(channel.is_participant(initiator), Error::<T>::CloseHrmpChannelUnauthorized);
+		ensure!(Channels::<T>::contains_key(channel), Error::<T>::CloseHrmpChannelDoesntExist);
+		ensure!(
+			!CloseRequests::<T>::contains_key(channel),
+			Error::<T>::CloseHrmpChannelAlreadyUnderway,
+		);
+
+		let message_id = Self::next_message_id();
+		CloseRequests::<T>::insert(channel, CloseRequest { initiator, message_id });
+
+		T::SendToRelay::send(MessageToRelay::V1(MessageToRelayV1::CloseChannel {
+			channel,
+			message_id,
+			initiator,
+		}))
+		.map_err(|()| Error::<T>::SendFailed)?;
+
+		Self::deposit_event(Event::ChannelClosedPending {
+			channel,
+			message_id,
+			by_parachain: initiator,
+		});
+
+		Ok(())
 	}
 
 	/// `hrmp_cancel_open_request`, asked for by `initiator` through the relay chain.
@@ -881,8 +931,61 @@ impl<T: Config> Pallet<T> {
 		.defensive();
 	}
 
+	/// Drop a closed channel from both indexes.
+	fn unindex_channel(channel: ChannelId) {
+		EgressIndex::<T>::mutate(channel.sender, |recipients| {
+			if let Ok(i) = recipients.binary_search(&channel.recipient) {
+				recipients.remove(i);
+			}
+		});
+		IngressIndex::<T>::mutate(channel.recipient, |senders| {
+			if let Ok(i) = senders.binary_search(&channel.sender) {
+				senders.remove(i);
+			}
+		});
+	}
+
 	fn on_close_response(channel: ChannelId, message_id: u64, outcome: Outcome) -> DispatchResult {
-		let _ = (channel, message_id, outcome);
-		todo!()
+		let request = CloseRequests::<T>::get(channel).ok_or(Error::<T>::UnexpectedResponse)?;
+		ensure!(request.message_id == message_id, Error::<T>::UnexpectedResponse);
+
+		CloseRequests::<T>::remove(channel);
+
+		match outcome {
+			Ok(()) => {
+				let channel_info =
+					Channels::<T>::take(channel).ok_or(Error::<T>::UnexpectedResponse)?;
+				if let Some(deposit) = channel_info.sender_deposit {
+					deposit.drop(&Self::sovereign_account(channel.sender))?;
+				}
+				if let Some(deposit) = channel_info.recipient_deposit {
+					deposit.drop(&Self::sovereign_account(channel.recipient))?;
+				}
+				Self::unindex_channel(channel);
+
+				let other_end = if request.initiator == channel.sender {
+					channel.recipient
+				} else {
+					channel.sender
+				};
+				if let Err(error) = Self::notify_para(
+					other_end,
+					ParaNotification::ChannelClosing {
+						initiator: request.initiator,
+						sender: channel.sender,
+						recipient: channel.recipient,
+					},
+				) {
+					Self::unexpected(UnexpectedKind::NotifyFailed { para_id: other_end }, error);
+				}
+
+				Self::deposit_event(Event::ChannelCloseDone { channel, message_id });
+			},
+			Err(reason) => {
+				Self::deposit_event(Event::ChannelCloseFailed { channel, message_id, reason });
+			},
+		}
+
+		Ok(())
 	}
 }

--- a/substrate/frame/hrmp/para/src/tests.rs
+++ b/substrate/frame/hrmp/para/src/tests.rs
@@ -20,13 +20,13 @@
 //! One test per flow lands with the extrinsic it covers.
 
 use crate::{
-	mock::*, AcceptedRequestCount, Channels, EgressIndex, Error, Event, HoldReason, IngressIndex,
-	OpenKind, OpenRequestCount, RequestState, Requests,
+	mock::*, AcceptedRequestCount, Channels, CloseRequests, EgressIndex, Error, Event, HoldReason,
+	IngressIndex, OpenKind, OpenRequestCount, RequestState, Requests, UnexpectedKind,
 };
 use frame_support::{assert_noop, assert_ok};
 use hrmp_primitives::{
 	ChannelId, FailureReason, MessageToPara, MessageToParaV1, MessageToRelay, MessageToRelayV1,
-	ParaId, ParaNotification, ParaRequest, ParaRequestV1,
+	Outcome, ParaId, ParaNotification, ParaRequest, ParaRequestV1,
 };
 use sp_runtime::DispatchError;
 
@@ -433,5 +433,254 @@ fn a_refusing_transport_unwinds_the_whole_request() {
 		assert!(Requests::<Test>::get(CHANNEL).is_none());
 		assert_eq!(OpenRequestCount::<Test>::get(CHANNEL.sender), 0);
 		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), 0);
+	});
+}
+
+/// An open channel, with both logs cleared.
+fn opened(channel: ChannelId) {
+	agreed(channel);
+	let message_id = Requests::<Test>::get(channel).unwrap().message_id;
+	assert_ok!(respond(channel, message_id, Ok((CAPACITY, MESSAGE_SIZE))));
+	let _ = take_sent();
+	let _ = hrmp_events();
+}
+
+fn close(channel: ChannelId, initiator: ParaId) -> sp_runtime::DispatchResult {
+	forwarded(initiator, ParaRequestV1::CloseChannel { channel })
+}
+
+fn respond_close(
+	channel: ChannelId,
+	message_id: u64,
+	outcome: Outcome,
+) -> sp_runtime::DispatchResult {
+	Hrmp::receive(
+		RuntimeOrigin::root(),
+		MessageToPara::V1(MessageToParaV1::CloseResponse { channel, message_id, outcome }),
+	)
+}
+
+/// Ask to close `channel` and hand back the id the relay chain will answer with.
+fn close_pending(channel: ChannelId, initiator: ParaId) -> u64 {
+	assert_ok!(close(channel, initiator));
+	let message_id = CloseRequests::<Test>::get(channel).unwrap().message_id;
+	let _ = take_sent();
+	let _ = hrmp_events();
+	message_id
+}
+
+#[test]
+fn close_channel_records_the_request_and_asks_the_relay_chain() {
+	new_test_ext().execute_with(|| {
+		opened(CHANNEL);
+
+		assert_ok!(close(CHANNEL, CHANNEL.sender));
+
+		let request = CloseRequests::<Test>::get(CHANNEL).unwrap();
+		assert_eq!(request.initiator, CHANNEL.sender);
+
+		// The channel and both deposits stay until the relay chain answers.
+		assert!(Channels::<Test>::get(CHANNEL).is_some());
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), DEPOSIT);
+		assert_eq!(held(CHANNEL.recipient, HoldReason::RecipientDeposit), DEPOSIT);
+
+		assert_eq!(
+			take_sent(),
+			vec![MessageToRelay::V1(MessageToRelayV1::CloseChannel {
+				channel: CHANNEL,
+				message_id: request.message_id,
+				initiator: CHANNEL.sender,
+			})]
+		);
+		assert_eq!(
+			hrmp_events(),
+			vec![Event::ChannelClosedPending {
+				channel: CHANNEL,
+				message_id: request.message_id,
+				by_parachain: CHANNEL.sender,
+			}]
+		);
+	});
+}
+
+#[test]
+fn close_channel_is_only_for_a_participant() {
+	new_test_ext().execute_with(|| {
+		opened(CHANNEL);
+
+		assert_noop!(close(CHANNEL, 2002), Error::<Test>::CloseHrmpChannelUnauthorized);
+	});
+}
+
+#[test]
+fn close_channel_needs_an_open_channel() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(close(CHANNEL, CHANNEL.sender), Error::<Test>::CloseHrmpChannelDoesntExist);
+
+		// A request the relay chain has not confirmed is not a channel either.
+		agreed(CHANNEL);
+		assert_noop!(close(CHANNEL, CHANNEL.sender), Error::<Test>::CloseHrmpChannelDoesntExist);
+	});
+}
+
+#[test]
+fn close_channel_rejects_a_second_request() {
+	new_test_ext().execute_with(|| {
+		opened(CHANNEL);
+		assert_ok!(close(CHANNEL, CHANNEL.sender));
+
+		assert_noop!(
+			close(CHANNEL, CHANNEL.recipient),
+			Error::<Test>::CloseHrmpChannelAlreadyUnderway
+		);
+	});
+}
+
+#[test]
+fn a_confirming_close_response_releases_both_deposits() {
+	new_test_ext().execute_with(|| {
+		opened(CHANNEL);
+		let message_id = close_pending(CHANNEL, CHANNEL.sender);
+
+		assert_ok!(respond_close(CHANNEL, message_id, Ok(())));
+
+		assert!(CloseRequests::<Test>::get(CHANNEL).is_none());
+		assert!(Channels::<Test>::get(CHANNEL).is_none());
+		assert!(EgressIndex::<Test>::get(CHANNEL.sender).is_empty());
+		assert!(IngressIndex::<Test>::get(CHANNEL.recipient).is_empty());
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), 0);
+		assert_eq!(held(CHANNEL.recipient, HoldReason::RecipientDeposit), 0);
+
+		// Only the other end is told: the initiator asked for this.
+		assert_eq!(
+			take_sent(),
+			vec![MessageToRelay::V1(MessageToRelayV1::NotifyPara {
+				para_id: CHANNEL.recipient,
+				notification: ParaNotification::ChannelClosing {
+					initiator: CHANNEL.sender,
+					sender: CHANNEL.sender,
+					recipient: CHANNEL.recipient,
+				},
+			})]
+		);
+		assert_eq!(hrmp_events(), vec![Event::ChannelCloseDone { channel: CHANNEL, message_id }]);
+	});
+}
+
+#[test]
+fn either_end_may_close() {
+	new_test_ext().execute_with(|| {
+		opened(CHANNEL);
+		let message_id = close_pending(CHANNEL, CHANNEL.recipient);
+
+		assert_ok!(respond_close(CHANNEL, message_id, Ok(())));
+
+		assert_eq!(
+			take_sent(),
+			vec![MessageToRelay::V1(MessageToRelayV1::NotifyPara {
+				para_id: CHANNEL.sender,
+				notification: ParaNotification::ChannelClosing {
+					initiator: CHANNEL.recipient,
+					sender: CHANNEL.sender,
+					recipient: CHANNEL.recipient,
+				},
+			})]
+		);
+	});
+}
+
+#[test]
+fn a_refused_close_keeps_the_channel_and_the_deposits() {
+	new_test_ext().execute_with(|| {
+		opened(CHANNEL);
+		let message_id = close_pending(CHANNEL, CHANNEL.sender);
+
+		assert_ok!(respond_close(CHANNEL, message_id, Err(FailureReason::NotFound)));
+
+		assert!(CloseRequests::<Test>::get(CHANNEL).is_none());
+		assert!(Channels::<Test>::get(CHANNEL).is_some());
+		assert_eq!(EgressIndex::<Test>::get(CHANNEL.sender).to_vec(), vec![CHANNEL.recipient]);
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), DEPOSIT);
+		assert_eq!(held(CHANNEL.recipient, HoldReason::RecipientDeposit), DEPOSIT);
+
+		assert!(take_sent().is_empty());
+		assert_eq!(
+			hrmp_events(),
+			vec![Event::ChannelCloseFailed {
+				channel: CHANNEL,
+				message_id,
+				reason: FailureReason::NotFound,
+			}]
+		);
+	});
+}
+
+#[test]
+fn a_close_response_must_match_a_request_this_chain_is_waiting_for() {
+	new_test_ext().execute_with(|| {
+		opened(CHANNEL);
+
+		// Nothing is being closed.
+		assert_noop!(respond_close(CHANNEL, 0, Ok(())), Error::<Test>::UnexpectedResponse);
+
+		let message_id = close_pending(CHANNEL, CHANNEL.sender);
+		assert_noop!(
+			respond_close(CHANNEL, message_id + 1, Ok(())),
+			Error::<Test>::UnexpectedResponse
+		);
+	});
+}
+
+#[test]
+fn a_refusing_transport_unwinds_the_close_request() {
+	new_test_ext().execute_with(|| {
+		opened(CHANNEL);
+		SendFails::set(true);
+
+		assert_noop!(close(CHANNEL, CHANNEL.sender), Error::<Test>::SendFailed);
+
+		assert!(CloseRequests::<Test>::get(CHANNEL).is_none());
+		assert!(Channels::<Test>::get(CHANNEL).is_some());
+	});
+}
+
+#[test]
+fn a_system_channel_closes_without_touching_any_deposit() {
+	new_test_ext().execute_with(|| {
+		opened(SYSTEM_CHANNEL);
+		let message_id = close_pending(SYSTEM_CHANNEL, SYSTEM_CHANNEL.sender);
+
+		assert_ok!(respond_close(SYSTEM_CHANNEL, message_id, Ok(())));
+
+		assert!(Channels::<Test>::get(SYSTEM_CHANNEL).is_none());
+		assert_eq!(held(SYSTEM_CHANNEL.sender, HoldReason::SenderDeposit), 0);
+		assert_eq!(
+			hrmp_events(),
+			vec![Event::ChannelCloseDone { channel: SYSTEM_CHANNEL, message_id }]
+		);
+	});
+}
+
+#[test]
+fn a_refusing_transport_does_not_undo_a_confirmed_close() {
+	new_test_ext().execute_with(|| {
+		opened(CHANNEL);
+		let message_id = close_pending(CHANNEL, CHANNEL.sender);
+		SendFails::set(true);
+
+		assert_ok!(respond_close(CHANNEL, message_id, Ok(())));
+
+		// The relay chain has already closed the channel, so the state stands and the undelivered
+		// notification is only recorded.
+		assert!(Channels::<Test>::get(CHANNEL).is_none());
+		assert_eq!(held(CHANNEL.sender, HoldReason::SenderDeposit), 0);
+		assert_eq!(held(CHANNEL.recipient, HoldReason::RecipientDeposit), 0);
+		assert_eq!(
+			hrmp_events(),
+			vec![
+				Event::Unexpected(UnexpectedKind::NotifyFailed { para_id: CHANNEL.recipient }),
+				Event::ChannelCloseDone { channel: CHANNEL, message_id },
+			]
+		);
 	});
 }

--- a/substrate/frame/hrmp/relay/src/lib.rs
+++ b/substrate/frame/hrmp/relay/src/lib.rs
@@ -164,6 +164,15 @@ pub mod pallet {
 			/// The id of the message that asked for it.
 			message_id: u64,
 		},
+		/// A request to close a channel was refused.
+		CloseChannelRejected {
+			/// The channel.
+			channel: ChannelId,
+			/// The id of the message that asked for it.
+			message_id: u64,
+			/// Why it was refused.
+			reason: FailureReason,
+		},
 		/// Every channel of a para was dropped.
 		ChannelsCleaned {
 			/// The para.
@@ -367,9 +376,26 @@ pub mod pallet {
 			todo!()
 		}
 
+		/// The parachain has already checked its own mirror, so a refusal here means the two have
+		/// drifted. It is reported rather than raised, as on the open path.
 		fn on_close_channel(channel: ChannelId, message_id: u64, initiator: ParaId) {
-			let _ = (channel, message_id, initiator);
-			todo!()
+			let outcome = with_storage_layer(|| T::Registry::close_channel(channel, initiator));
+
+			match &outcome {
+				Ok(()) => Self::deposit_event(Event::ChannelClosed { channel, message_id }),
+				Err(reason) => Self::deposit_event(Event::CloseChannelRejected {
+					channel,
+					message_id,
+					reason: reason.clone(),
+				}),
+			}
+
+			// The other end hears about this from the parachain, which is what knows who asked.
+			Self::report(
+				channel.sender,
+				message_id,
+				MessageToParaV1::CloseResponse { channel, message_id, outcome },
+			);
 		}
 
 		fn on_force_clean(para_id: ParaId, message_id: u64) {

--- a/substrate/frame/hrmp/relay/src/tests.rs
+++ b/substrate/frame/hrmp/relay/src/tests.rs
@@ -24,7 +24,7 @@ use crate::{mock::*, Error, Event};
 use frame_support::{assert_noop, assert_ok};
 use hrmp_primitives::{
 	ChannelId, FailureReason, HrmpRegistry, MessageToPara, MessageToParaV1, MessageToRelay,
-	MessageToRelayV1, ParaNotification, ParaRequest, ParaRequestV1,
+	MessageToRelayV1, Outcome, ParaId, ParaNotification, ParaRequest, ParaRequestV1,
 };
 use sp_runtime::DispatchError;
 
@@ -245,6 +245,94 @@ fn a_refusing_notify_transport_does_not_undo_the_channel() {
 				Event::ChannelOpened { channel: CHANNEL, message_id: MESSAGE_ID },
 				Event::NotifyFailed { para_id: CHANNEL.sender },
 				Event::NotifyFailed { para_id: CHANNEL.recipient },
+			]
+		);
+	});
+}
+
+fn close_channel(initiator: ParaId) -> sp_runtime::DispatchResult {
+	Hrmp::receive(
+		RuntimeOrigin::root(),
+		MessageToRelay::V1(MessageToRelayV1::CloseChannel {
+			channel: CHANNEL,
+			message_id: MESSAGE_ID,
+			initiator,
+		}),
+	)
+}
+
+fn close_response(outcome: Outcome) -> MessageToPara {
+	MessageToPara::V1(MessageToParaV1::CloseResponse {
+		channel: CHANNEL,
+		message_id: MESSAGE_ID,
+		outcome,
+	})
+}
+
+#[test]
+fn close_channel_clears_the_registry_and_answers() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(open_channel());
+		let _ = take_sent();
+		let _ = take_notified();
+		let _ = hrmp_events();
+
+		assert_ok!(close_channel(CHANNEL.sender));
+
+		assert!(!MockRegistry::exists(CHANNEL));
+		assert_eq!(take_sent(), vec![close_response(Ok(()))]);
+		// Unlike an open, neither end is told from here: the parachain knows who asked.
+		assert!(take_notified().is_empty());
+		assert_eq!(
+			hrmp_events(),
+			vec![Event::ChannelClosed { channel: CHANNEL, message_id: MESSAGE_ID }]
+		);
+	});
+}
+
+#[test]
+fn a_refused_close_is_reported_back() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(open_channel());
+		let _ = take_sent();
+		let _ = take_notified();
+		let _ = hrmp_events();
+		RegistryRefuses::set(Some(FailureReason::NotFound));
+
+		assert_ok!(close_channel(CHANNEL.sender));
+
+		assert!(MockRegistry::exists(CHANNEL));
+		assert_eq!(take_sent(), vec![close_response(Err(FailureReason::NotFound))]);
+		assert!(take_notified().is_empty());
+		assert_eq!(
+			hrmp_events(),
+			vec![Event::CloseChannelRejected {
+				channel: CHANNEL,
+				message_id: MESSAGE_ID,
+				reason: FailureReason::NotFound,
+			}]
+		);
+	});
+}
+
+#[test]
+fn a_refusing_transport_does_not_reopen_the_channel() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(open_channel());
+		let _ = take_sent();
+		let _ = take_notified();
+		let _ = hrmp_events();
+		SendFails::set(true);
+
+		assert_ok!(close_channel(CHANNEL.sender));
+
+		assert!(!MockRegistry::exists(CHANNEL));
+		assert!(take_sent().is_empty());
+		assert_eq!(
+			hrmp_events(),
+			vec![
+				Event::ChannelClosed { channel: CHANNEL, message_id: MESSAGE_ID },
+				Event::ReportFailed { para_id: CHANNEL.sender, message_id: MESSAGE_ID },
 			]
 		);
 	});


### PR DESCRIPTION
Closes #12951.

Flow: a para calls `hrmp_close_channel` on the coretime chain, which records the request and forwards it to the relay chain. The relay chain closes the channel in the registry and answers. On the answer the coretime chain drops the channel from both indexes, returns both deposits and tells the other end.

- `HrmpRegistry::close_channel`: closes now rather than at the next session boundary, since one end asked on the calling chain. The refund is a no-op for channels opened through this path, real for a legacy channel.
- `pallet-hrmp-relay`: runs the registry in its own storage layer and reports a refusal as an event plus a response, as on the open path.
- `pallet-hrmp-para`: the channel and both deposits stay until the relay chain answers. A bounced notification is recorded, not raised: the channel is already gone on the relay chain.