### PR TITLE
[pallet-revive] Use an EIP-684 collision check for contract creation

### DIFF
--- a/prdoc/pr_13202.prdoc
+++ b/prdoc/pr_13202.prdoc
@@ -1,0 +1,23 @@
+title: '[pallet-revive] Use an EIP-684 collision check for contract creation'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Fixes https://github.com/paritytech/polkadot-sdk/issues/13128
+
+    `ContractInfo::new` only rejected addresses that were already `AccountType::Contract`, so a
+    CREATE or CREATE2 landing on an EIP-7702 `DelegatedEOA` was accepted. `insert_contract` then
+    swapped in the new `ContractInfo` while keeping the delegation target and payer, which left
+    `eth_getCode` reporting the delegation indicator for an account executing different code and
+    orphaned the delegation trie and its deposits.
+
+    `ContractInfo::new` now applies an EIP-684 check through the new
+    `AccountInfo::is_create_collision`: the address is rejected with `DuplicateContract` if it
+    has a nonzero nonce or any account entry other than a plain EOA, which includes a cleared
+    delegation. Genesis config and `eth_call` state overrides install code on accounts whose
+    nonce is already set, so they use the new `ContractInfo::new_without_collision_check`.
+
+    `terminate_if_same_tx` no longer schedules a delegated EOA for deletion. The balance transfer
+    still happens, as EIP-6780 requires for `SELFDESTRUCT` in delegated code.
+crates:
+- name: pallet-revive
+  bump: minor

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1317,7 +1317,7 @@ where
 			self.exec_config,
 		)? {
 			// EIP-684: an in-construction address is not in `AccountInfoOf` yet, so the
-			// `is_contract` guard in `ContractInfo::new` misses this re-entrant collision.
+			// collision check in `ContractInfo::new` can miss this re-entrant collision.
 			if frame.entry_point == ExportedFunction::Constructor &&
 				self.frames().any(|f| {
 					f.entry_point == ExportedFunction::Constructor &&
@@ -2128,6 +2128,12 @@ where
 			&mut frame.frame_meter,
 			self.exec_config,
 		)?;
+
+		// EIP-7702: the balance still moves, but a delegated EOA is never destroyed. Its
+		// `contract_info` is the authority's delegation trie and the target's code hash.
+		if AccountInfo::<T>::is_delegated(&contract_address) {
+			return Ok(CodeRemoved::No);
+		}
 
 		// schedule for delayed deletion
 		let account_id = frame.account_id.clone();

--- a/substrate/frame/revive/src/exec/tests.rs
+++ b/substrate/frame/revive/src/exec/tests.rs
@@ -1437,6 +1437,65 @@ fn termination_from_instantiate_succeeds() {
 		});
 }
 
+/// `SELFDESTRUCT` by a delegated EOA only moves balance, even if the address shows up as
+/// created in the same transaction.
+#[test]
+fn termination_of_delegated_eoa_created_in_same_tx_is_skipped() {
+	let terminate_ch = MockLoader::insert(Constructor, |ctx, _| {
+		let address = <Test as Config>::AddressMapper::to_address(ctx.ext.account_id());
+		crate::storage::AccountInfo::<Test>::set_delegation(&address, Some(CHARLIE_ADDR), &ALICE)
+			.unwrap();
+		let _ = ctx.ext.terminate_if_same_tx(&ALICE_ADDR)?;
+		exec_success()
+	});
+	let instantiated = Rc::new(RefCell::new(None::<H160>));
+	let factory_ch = MockLoader::insert(Call, {
+		let instantiated = Rc::clone(&instantiated);
+		move |ctx, _| {
+			let min_balance = <Test as Config>::Currency::minimum_balance();
+			let address = ctx
+				.ext
+				.instantiate(
+					&CallResources::NoLimits,
+					Code::Existing(terminate_ch),
+					Pallet::<Test>::convert_native_to_evm(min_balance),
+					vec![],
+					Some(&[0; 32]),
+				)
+				.unwrap();
+			*instantiated.borrow_mut() = Some(address);
+			exec_success()
+		}
+	});
+
+	ExtBuilder::default()
+		.with_code_hashes(MockLoader::code_hashes())
+		.existential_deposit(15)
+		.build()
+		.execute_with(|| {
+			let min_balance = <Test as Config>::Currency::minimum_balance();
+			set_balance(&ALICE, min_balance * 1000);
+			place_contract(&BOB, factory_ch);
+			let mut meter =
+				TransactionMeter::<Test>::new_from_limits(WEIGHT_LIMIT, min_balance * 100).unwrap();
+
+			assert_ok!(MockStack::run_call(
+				Origin::from_account_id(ALICE),
+				BOB_ADDR,
+				&mut meter,
+				Pallet::<Test>::convert_native_to_evm(min_balance * 100),
+				vec![],
+				&ExecConfig::new_substrate_tx(),
+			));
+
+			let address = instantiated.borrow().unwrap();
+			assert_eq!(
+				crate::storage::AccountInfo::<Test>::get_delegation_target(&address),
+				Some(CHARLIE_ADDR)
+			);
+		});
+}
+
 #[test]
 fn in_memory_changes_not_discarded() {
 	// Call stack: BOB -> CHARLIE (trap) -> BOB' (success)

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -917,11 +917,14 @@ pub mod pallet {
 						};
 
 						let code_hash = *blob.code_hash();
-						let Ok(info) = <ContractInfo<T>>::new(&address, 0u32.into(), code_hash)
-							.inspect_err(|err| {
-								log::error!(target: LOG_TARGET, "Failed to create ContractInfo for {address:?}: {err:?}");
-							})
-						else {
+						let Ok(info) = <ContractInfo<T>>::new_without_collision_check(
+							&address,
+							0u32.into(),
+							code_hash,
+						)
+						.inspect_err(|err| {
+							log::error!(target: LOG_TARGET, "Failed to create ContractInfo for {address:?}: {err:?}");
+						}) else {
 							continue;
 						};
 

--- a/substrate/frame/revive/src/state_overrides.rs
+++ b/substrate/frame/revive/src/state_overrides.rs
@@ -195,7 +195,8 @@ fn apply_code_override<T: Config>(address: &H160, code: Vec<u8>) -> Result<(), E
 			},
 			_ => {
 				let nonce = frame_system::Pallet::<T>::account_nonce(&account_id);
-				let contract = ContractInfo::<T>::new(address, nonce, code_hash)?;
+				let contract =
+					ContractInfo::<T>::new_without_collision_check(address, nonce, code_hash)?;
 				*account = Some(AccountInfo {
 					account_type: contract.into(),
 					dust: account.as_ref().map(|a| a.dust).unwrap_or(0),

--- a/substrate/frame/revive/src/storage.rs
+++ b/substrate/frame/revive/src/storage.rs
@@ -189,6 +189,17 @@ impl<T: Config> AccountInfo<T> {
 		matches!(info.account_type, AccountType::Contract(_))
 	}
 
+	/// EIP-684: deploying to `address` collides if it has a nonce, code, or a delegation entry.
+	///
+	/// A cleared `DelegatedEOA` still counts: its child trie and deposit accounting outlive the
+	/// delegation and would be orphaned by a contract taking over the entry.
+	pub fn is_create_collision(address: &H160) -> bool {
+		<AccountInfoOf<T>>::get(address)
+			.is_some_and(|info| !matches!(info.account_type, AccountType::EOA)) ||
+			!frame_system::Pallet::<T>::account_nonce(&T::AddressMapper::to_account_id(address))
+				.is_zero()
+	}
+
 	/// Returns the balance of the account at the given address.
 	pub fn balance_of(account: AccountIdOrAddress<T>) -> BalanceWithDust<BalanceOf<T>> {
 		let info = <AccountInfoOf<T>>::get(account.address()).unwrap_or_default();
@@ -444,17 +455,28 @@ impl<T: Config> AccountInfo<T> {
 impl<T: Config> ContractInfo<T> {
 	/// Constructs a new contract info **without** writing it to storage.
 	///
-	/// This returns an `Err` if an contract with the supplied `account` already exists
-	/// in storage.
+	/// This returns an `Err` if deploying to `address` collides with an existing account, see
+	/// [`AccountInfo::is_create_collision`].
 	pub fn new(
 		address: &H160,
 		nonce: T::Nonce,
 		code_hash: sp_core::H256,
 	) -> Result<Self, DispatchError> {
-		if <AccountInfo<T>>::is_contract(address) {
+		if <AccountInfo<T>>::is_create_collision(address) {
 			return Err(Error::<T>::DuplicateContract.into());
 		}
+		Self::new_without_collision_check(address, nonce, code_hash)
+	}
 
+	/// Like [`Self::new`] but allows an address that already has a nonce or an entry.
+	///
+	/// Only for callers that deliberately install code on an existing account, such as genesis
+	/// config or `eth_call` state overrides.
+	pub fn new_without_collision_check(
+		address: &H160,
+		nonce: T::Nonce,
+		code_hash: sp_core::H256,
+	) -> Result<Self, DispatchError> {
 		// Reject reuse of an address whose previous occupant still has unflushed
 		// `NativeDepositOf` rows in the deletion queue. The on_idle drain will eventually
 		// clear them; until it does, instantiating here would let the new contract inherit

--- a/substrate/frame/revive/src/tests/eip7702.rs
+++ b/substrate/frame/revive/src/tests/eip7702.rs
@@ -2832,3 +2832,83 @@ fn self_delegation_traps_on_call() {
 		assert_err!(result.result, <Error<Test>>::ContractTrapped);
 	});
 }
+
+/// EIP-684: CREATE2 onto an address that holds a delegation entry must fail and leave the
+/// entry untouched, whether the delegation is active or already cleared.
+#[test]
+fn instantiate_onto_delegated_eoa_is_rejected() {
+	let (counter_code, _) = compile_module_with_type("Counter", FixtureType::Solc).unwrap();
+
+	for clear in [false, true] {
+		ExtBuilder::default().build().execute_with(|| {
+			let _ = <<Test as Config>::Currency as Mutate<_>>::set_balance(&ALICE, 100_000_000);
+			let target = builder::bare_instantiate(Code::Upload(counter_code.clone()))
+				.salt(Some([1; 32]))
+				.build_and_unwrap_contract();
+
+			// Not reachable without an address collision, so force it.
+			let salt = [2; 32];
+			let authority = crate::address::create2(&ALICE_ADDR, &counter_code, &[], &salt);
+			AccountInfo::<Test>::set_delegation(&authority, Some(target.addr), &ALICE).unwrap();
+			if clear {
+				AccountInfo::<Test>::set_delegation(&authority, None, &ALICE).unwrap();
+			}
+			let before = crate::AccountInfoOf::<Test>::get(authority);
+			assert!(matches!(
+				before,
+				Some(AccountInfo { account_type: AccountType::DelegatedEOA { .. }, .. })
+			));
+
+			let result = builder::bare_instantiate(Code::Upload(counter_code.clone()))
+				.salt(Some(salt))
+				.build()
+				.result;
+			assert_err!(result, <Error<Test>>::DuplicateContract);
+			assert_eq!(crate::AccountInfoOf::<Test>::get(authority), before);
+		});
+	}
+}
+
+/// EIP-684: an address with a nonzero nonce is taken even if it has no code.
+#[test]
+fn instantiate_onto_address_with_nonce_is_rejected() {
+	let (counter_code, _) = compile_module_with_type("Counter", FixtureType::Solc).unwrap();
+
+	ExtBuilder::default().build().execute_with(|| {
+		let _ = <<Test as Config>::Currency as Mutate<_>>::set_balance(&ALICE, 100_000_000);
+		let salt = [3; 32];
+		let addr = crate::address::create2(&ALICE_ADDR, &counter_code, &[], &salt);
+		let account_id = <Test as Config>::AddressMapper::to_account_id(&addr);
+		let _ = <<Test as Config>::Currency as Mutate<_>>::set_balance(
+			&account_id,
+			Contracts::min_balance(),
+		);
+		frame_system::Account::<Test>::mutate(&account_id, |a| a.nonce = 1);
+
+		let result = builder::bare_instantiate(Code::Upload(counter_code))
+			.salt(Some(salt))
+			.build()
+			.result;
+		assert_err!(result, <Error<Test>>::DuplicateContract);
+		assert!(!AccountInfo::<Test>::is_contract(&addr));
+	});
+}
+
+/// A funded address with nonce zero and no code is still a valid CREATE2 destination.
+#[test]
+fn instantiate_onto_funded_empty_address_works() {
+	let (counter_code, _) = compile_module_with_type("Counter", FixtureType::Solc).unwrap();
+
+	ExtBuilder::default().build().execute_with(|| {
+		let _ = <<Test as Config>::Currency as Mutate<_>>::set_balance(&ALICE, 100_000_000);
+		let salt = [4; 32];
+		let addr = crate::address::create2(&ALICE_ADDR, &counter_code, &[], &salt);
+		assert_ok!(Contracts::set_evm_balance(&addr, U256::from(1_000_000_000u64)));
+
+		let deployed = builder::bare_instantiate(Code::Upload(counter_code))
+			.salt(Some(salt))
+			.build_and_unwrap_contract();
+		assert_eq!(deployed.addr, addr);
+		assert!(AccountInfo::<Test>::is_contract(&addr));
+	});
+}


### PR DESCRIPTION
Fixes #13128 by making CREATE and CREATE2 reject any address with a nonzero nonce, code, or an EIP-7702 delegation entry, and by stopping `SELFDESTRUCT` from scheduling a delegated EOA for deletion while still moving its balance.