### PR TITLE
[pallet-revive] Price storage deposit diffs before netting them

### DIFF
--- a/substrate/frame/revive/src/exec/tests.rs
+++ b/substrate/frame/revive/src/exec/tests.rs
@@ -1555,9 +1555,9 @@ fn bank_after_invalidate_loads_cache_for_refund_pro_rating() {
 		));
 		meter.execute_postponed_deposits(&origin, &exec_config).unwrap();
 
-		// K1 = 35 bytes → deposit 37; 30-byte removal refunds floor(30/35 * 35) = 29 → net 8.
+		// K1 = 35 bytes → deposit 37; 30-byte removal refunds 30/35 of 35 = 30 → net 7.
 		let charged = min_balance * 1000 - get_balance(&ALICE);
-		assert_eq!(charged, 8, "banked removal refund not applied: expected net deposit 8");
+		assert_eq!(charged, 7, "banked removal refund not applied: expected net deposit 7");
 	});
 }
 

--- a/substrate/frame/revive/src/metering/storage.rs
+++ b/substrate/frame/revive/src/metering/storage.rs
@@ -29,7 +29,8 @@ use alloc::vec::Vec;
 use core::{marker::PhantomData, mem};
 use frame_support::{DebugNoBound, DefaultNoBound, traits::Get};
 use sp_runtime::{
-	DispatchError, FixedPointNumber, FixedU128,
+	DispatchError, Rounding, SaturatedConversion,
+	helpers_128bit::multiply_by_rational_with_rounding,
 	traits::{Saturating, Zero},
 };
 
@@ -121,55 +122,61 @@ impl Diff {
 	pub fn update_contract<T: Config>(&self, info: Option<&mut ContractInfo<T>>) -> DepositOf<T> {
 		let per_byte = T::DepositPerByte::get();
 		let per_item = T::DepositPerChildTrieItem::get();
-		let bytes_added = self.bytes_added.saturating_sub(self.bytes_removed);
-		let items_added = self.items_added.saturating_sub(self.items_removed);
-		let mut bytes_deposit = Deposit::Charge(per_byte.saturating_mul((bytes_added).into()));
-		let mut items_deposit = Deposit::Charge(per_item.saturating_mul((items_added).into()));
 
 		// Without any contract info we can only calculate diffs which add storage
-		let info = if let Some(info) = info {
-			info
-		} else {
-			return bytes_deposit.saturating_add(&items_deposit);
+		let Some(info) = info else {
+			let bytes_added = self.bytes_added.saturating_sub(self.bytes_removed);
+			let items_added = self.items_added.saturating_sub(self.items_removed);
+			return Deposit::Charge(
+				per_byte
+					.saturating_mul(bytes_added.into())
+					.saturating_add(per_item.saturating_mul(items_added.into())),
+			);
 		};
 
-		// Refunds are calculated pro rata based on the accumulated storage within the contract
-		let bytes_removed = self.bytes_removed.saturating_sub(self.bytes_added);
-		let items_removed = self.items_removed.saturating_sub(self.items_added);
-		let ratio = FixedU128::checked_from_rational(bytes_removed, info.storage_bytes)
-			.unwrap_or_default()
-			.min(FixedU128::from_u32(1));
-		bytes_deposit = bytes_deposit
-			.saturating_add(&Deposit::Refund(ratio.saturating_mul_int(info.storage_byte_deposit)));
-		let ratio = FixedU128::checked_from_rational(items_removed, info.storage_items)
-			.unwrap_or_default()
-			.min(FixedU128::from_u32(1));
-		items_deposit = items_deposit
-			.saturating_add(&Deposit::Refund(ratio.saturating_mul_int(info.storage_item_deposit)));
-
-		// We need to update the contract info structure with the new deposits
-		info.storage_bytes =
-			info.storage_bytes.saturating_add(bytes_added).saturating_sub(bytes_removed);
-		info.storage_items =
-			info.storage_items.saturating_add(items_added).saturating_sub(items_removed);
-		match &bytes_deposit {
-			Deposit::Charge(amount) => {
-				info.storage_byte_deposit = info.storage_byte_deposit.saturating_add(*amount)
-			},
-			Deposit::Refund(amount) => {
-				info.storage_byte_deposit = info.storage_byte_deposit.saturating_sub(*amount)
-			},
-		}
-		match &items_deposit {
-			Deposit::Charge(amount) => {
-				info.storage_item_deposit = info.storage_item_deposit.saturating_add(*amount)
-			},
-			Deposit::Refund(amount) => {
-				info.storage_item_deposit = info.storage_item_deposit.saturating_sub(*amount)
-			},
-		}
-
+		let bytes_deposit = Self::price::<T>(
+			self.bytes_added,
+			self.bytes_removed,
+			per_byte,
+			&mut info.storage_bytes,
+			&mut info.storage_byte_deposit,
+		);
+		let items_deposit = Self::price::<T>(
+			self.items_added,
+			self.items_removed,
+			per_item,
+			&mut info.storage_items,
+			&mut info.storage_item_deposit,
+		);
 		bytes_deposit.saturating_add(&items_deposit)
+	}
+
+	/// Prices one dimension of the diff before netting, so that storage added after a change of
+	/// `rate` is paid at the new rate even when it replaces storage paid at the old one.
+	fn price<T: Config>(
+		added: u32,
+		removed: u32,
+		rate: BalanceOf<T>,
+		stored: &mut u32,
+		deposit: &mut BalanceOf<T>,
+	) -> DepositOf<T> {
+		let removed_existing = removed.min(*stored);
+		let added_kept = added.saturating_sub(removed - removed_existing);
+
+		let refund: BalanceOf<T> = multiply_by_rational_with_rounding(
+			(*deposit).saturated_into(),
+			removed_existing.into(),
+			(*stored).into(),
+			Rounding::Down,
+		)
+		.unwrap_or_default()
+		.saturated_into();
+		let charge = rate.saturating_mul(added_kept.into());
+
+		*stored = stored.saturating_sub(removed_existing).saturating_add(added_kept);
+		*deposit = deposit.saturating_sub(refund).saturating_add(charge);
+
+		Deposit::Charge(charge).saturating_add(&Deposit::Refund(refund))
 	}
 }
 
@@ -284,10 +291,8 @@ where
 		// We are now at the position to calculate the actual final net charge of `absorbed` as we
 		// now have the contract information `info`. Before that we only took net charges related to
 		// the contract storage into account but ignored net refunds.
-		// However, with this complete information there is no need to recalculate `max_charged` for
-		// `absorbed` here before we absorb it because the actual final net charge will not be more
-		// than the net charge we observed before (as we only ignored net refunds but not net
-		// charges).
+		// There is no need to recalculate `max_charged` for `absorbed` here: a frame is finalized
+		// before it is absorbed, and finalizing already folds its actual charge into it.
 		self.max_charged = self
 			.max_charged
 			.max(self.consumed().saturating_add(&absorbed.max_charged()).charge_or_zero());
@@ -489,8 +494,9 @@ impl<T: Config, E: Ext<T>> RawMeter<T, E, Nested> {
 		let deposit = self.own_contribution.update_contract(info);
 		self.own_contribution = Contribution::Checked(deposit);
 
-		// no need to recalculate max_charged here as the consumed amount cannot increase
-		// when taking removed bytes/items into account
+		// The info-less estimate nets bytes at the current rate, which undershoots when storage
+		// paid at a lower historical rate was replaced.
+		self.recalulculate_max_charged();
 	}
 
 	/// Apply pending storage changes to a ContractInfo without finalizing the meter.

--- a/substrate/frame/revive/src/metering/storage/tests.rs
+++ b/substrate/frame/revive/src/metering/storage/tests.rs
@@ -475,6 +475,7 @@ fn max_deposits_work_nested() {
 	assert_eq!(nested2a.consumed(), Deposit::Charge(22));
 	assert_eq!(nested2a.max_charged(), Deposit::Charge(22));
 
+	// Items were paid at 1 each but `DepositPerItem` is now 2.
 	let mut nested2a_info = new_info(StorageInfo {
 		bytes: 100,
 		items: 100,
@@ -483,16 +484,16 @@ fn max_deposits_work_nested() {
 		immutable_data_len: 0,
 	});
 	nested1.absorb(nested2a, &BOB, Some(&mut nested2a_info));
-	assert_eq!(nested1.consumed(), Deposit::Charge(27));
-	assert_eq!(nested1.max_charged(), Deposit::Charge(32));
-
-	nested1.charge(&Diff { bytes_added: 10, ..Default::default() });
 	assert_eq!(nested1.consumed(), Deposit::Charge(37));
 	assert_eq!(nested1.max_charged(), Deposit::Charge(37));
 
+	nested1.charge(&Diff { bytes_added: 10, ..Default::default() });
+	assert_eq!(nested1.consumed(), Deposit::Charge(47));
+	assert_eq!(nested1.max_charged(), Deposit::Charge(47));
+
 	nested1.record_charge(&Deposit::Refund(10));
-	assert_eq!(nested1.consumed(), Deposit::Charge(27));
-	assert_eq!(nested1.max_charged(), Deposit::Charge(37));
+	assert_eq!(nested1.consumed(), Deposit::Charge(37));
+	assert_eq!(nested1.max_charged(), Deposit::Charge(47));
 
 	let mut nested2b = nested1.nested(None);
 	nested2b.record_charge(&Deposit::Refund(10));
@@ -515,12 +516,12 @@ fn max_deposits_work_nested() {
 		immutable_data_len: 0,
 	});
 	nested1.absorb(nested2b, &BOB, Some(&mut nested2b_info));
-	assert_eq!(nested1.consumed(), Deposit::Refund(3));
-	assert_eq!(nested1.max_charged(), Deposit::Charge(47));
+	assert_eq!(nested1.consumed(), Deposit::Charge(17));
+	assert_eq!(nested1.max_charged(), Deposit::Charge(57));
 
 	meter.absorb(nested1, &ALICE, None);
-	assert_eq!(meter.consumed(), Deposit::Refund(3));
-	assert_eq!(meter.max_charged(), Deposit::Charge(47));
+	assert_eq!(meter.consumed(), Deposit::Charge(17));
+	assert_eq!(meter.max_charged(), Deposit::Charge(57));
 }
 
 #[test]
@@ -532,4 +533,56 @@ fn max_deposits_work_for_reverts() {
 
 	meter.absorb_only_max_charged(nested1);
 	assert_eq!(meter.max_charged(), Deposit::Charge(10));
+}
+
+#[test]
+fn replacing_storage_after_rate_increase_charges_new_rate() {
+	crate::tests::DepositPerByte::set(10);
+	let mut info = new_info(StorageInfo { bytes: 100, bytes_deposit: 100, ..Default::default() });
+
+	let diff = Diff { bytes_added: 100, bytes_removed: 100, ..Default::default() };
+	assert_eq!(diff.update_contract::<Test>(Some(&mut info)), Deposit::Charge(900));
+	assert_eq!((info.storage_bytes, info.storage_byte_deposit), (100, 1000));
+}
+
+#[test]
+fn storage_added_and_removed_in_same_diff_is_free() {
+	crate::tests::DepositPerByte::set(10);
+	let mut info = new_info(StorageInfo::default());
+
+	let diff = Diff { bytes_added: 100, bytes_removed: 100, ..Default::default() };
+	assert_eq!(diff.update_contract::<Test>(Some(&mut info)), Deposit::Charge(0));
+	assert_eq!((info.storage_bytes, info.storage_byte_deposit), (0, 0));
+}
+
+#[test]
+fn netting_is_unchanged_without_rate_change() {
+	let mut info = new_info(StorageInfo {
+		bytes: 100,
+		items: 10,
+		bytes_deposit: 100,
+		items_deposit: 20,
+		..Default::default()
+	});
+
+	let diff = Diff { bytes_added: 30, bytes_removed: 50, items_added: 1, items_removed: 3 };
+	assert_eq!(diff.update_contract::<Test>(Some(&mut info)), Deposit::Refund(24));
+	assert_eq!((info.storage_bytes, info.storage_byte_deposit), (80, 80));
+	assert_eq!((info.storage_items, info.storage_item_deposit), (8, 16));
+}
+
+#[test]
+fn finalize_raises_max_charged_after_rate_increase() {
+	clear_ext();
+	crate::tests::DepositPerByte::set(10);
+	let meter = TestMeter::new(Some(1_000));
+	let mut nested = meter.nested(None);
+	let mut info = new_info(StorageInfo { bytes: 100, bytes_deposit: 100, ..Default::default() });
+
+	nested.charge(&Diff { bytes_added: 100, bytes_removed: 100, ..Default::default() });
+	assert_eq!(nested.max_charged(), Deposit::Charge(0));
+
+	nested.finalize_own_contributions(Some(&mut info));
+	assert_eq!(nested.consumed(), Deposit::Charge(900));
+	assert_eq!(nested.max_charged(), Deposit::Charge(900));
 }

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -977,9 +977,7 @@ fn cannot_self_destruct_through_storage_refund_after_price_change() {
 			<Test as Config>::Currency::total_balance(&contract.account_id),
 			get_contract(&contract.addr).total_deposit() + min_balance,
 		);
-		// + 1 because due to fixed point arithmetic we can sometimes refund
-		// one unit to little
-		assert_eq!(get_contract(&contract.addr).extra_deposit(), 16 + 32 + 2 + 1);
+		assert_eq!(get_contract(&contract.addr).extra_deposit(), 16 + 32 + 2);
 	});
 }
 
@@ -2440,8 +2438,7 @@ fn storage_deposit_works() {
 
 		// Remove more storage (but also add some)
 		assert_ok!(builder::call(addr).data((10u32, 20u32).encode()).build());
-		// -1 for numeric instability
-		let refunded0 = 90 - 10 - 1;
+		let refunded0 = 90 - 10;
 		deposit -= refunded0;
 		assert_eq!(get_contract(&addr).total_deposit(), deposit);
 


### PR DESCRIPTION
Fixes #12692 by charging storage added at the current `DepositPerByte`/`DepositPerChildTrieItem` rate and refunding storage removed at the contract's recorded rate before offsetting the two, so storage replaced after a rate increase is no longer left under-collateralized, with refunds now computed exactly instead of through `FixedU128`.